### PR TITLE
fix: handle scoped tarball name mismatch in verify-npm-release, make publish idempotent

### DIFF
--- a/.github/workflows/publish-protocol-schemas.yml
+++ b/.github/workflows/publish-protocol-schemas.yml
@@ -72,7 +72,23 @@ jobs:
           gh release upload "$RELEASE_TAG" "$upload_dir"/* --clobber
       - name: Verify checksums before publish
         run: (cd ../../release-assets/protocol-schemas && sha256sum --check SHA256SUMS.txt)
-      - run: npm publish "${{ steps.pack-evidence.outputs.tarball }}" --access public --provenance --ignore-scripts
+      - name: Check if version already published
+        id: check-published
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          pkg="@oaslananka/kicad-protocol-schemas"
+          if npm view "${pkg}@${version}" version --json 2>/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "found=true"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "not found"
+          fi
+      - name: Publish to npm
+        if: steps.check-published.outputs.already_published != 'true'
+        run: npm publish "${{ steps.pack-evidence.outputs.tarball }}" --access public --provenance --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Verify published tarball

--- a/scripts/verify-npm-release.mjs
+++ b/scripts/verify-npm-release.mjs
@@ -94,7 +94,30 @@ export async function verifyPublishedNpmDigest({
 
   const tarball = await fetchBytes(tarballUrl);
   const tarballName = basename(new URL(tarballUrl).pathname);
-  const expected = checksums.get(tarballName);
+  let expected = checksums.get(tarballName);
+  if (expected === undefined) {
+    // Local pack may produce a different basename than the registry
+    // (e.g. scoped packages: pack -> oaslananka-kicad-...tgz, registry -> kicad-...tgz).
+    // If there is exactly one .tgz entry in checksums, use it as the fallback.
+    const tarballEntries = [...checksums.entries()].filter(([name]) =>
+      name.endsWith(".tgz"),
+    );
+    if (tarballEntries.length === 0) {
+      throw new Error(`No .tgz entry found in checksums file ${checksumsPath}`);
+    }
+    if (tarballEntries.length > 1) {
+      throw new Error(
+        `${tarballName} not found in checksums and multiple .tgz entries exist (` +
+          `${tarballEntries.map(([n]) => n).join(", ")}). ` +
+          `Cannot unambiguously match. Add an explicit entry for ${tarballName}.`,
+      );
+    }
+    const [entryName, entryDigest] = tarballEntries[0];
+    console.log(
+      `[warn] tarball basename differs: local="${entryName}" registry="${tarballName}" — matching by digest`,
+    );
+    expected = entryDigest;
+  }
   const actual = sha256(tarball);
   if (expected !== actual) {
     throw new Error(


### PR DESCRIPTION
## Problem

The publish workflow for \@oaslananka/kicad-protocol-schemas\ had two issues:

1. **Verification step fails for scoped packages**: \pnpm pack\ produces \oaslananka-kicad-protocol-schemas-1.1.0.tgz\ (org-prefixed) but npm registry serves it as \kicad-protocol-schemas-1.1.0.tgz\. The verifier did filename-based SHA lookup which failed because the names don't match.

2. **Not idempotent**: Re-running the workflow on an already-published version would attempt publish again and fail instead of just verifying.

## Changes

### \scripts/verify-npm-release.mjs\
When the registry tarball basename isn't found in SHA256SUMS.txt, fall back to matching against the single \.tgz\ entry. Logs a warning about the filename difference. Fails clearly if multiple or zero \.tgz\ entries exist.

### \.github/workflows/publish-protocol-schemas.yml\
Added \Check if version already published\ step before publish. If the version already exists on npm, the publish step is skipped and verification proceeds directly.

## Verification

- \pnpm run format\ ✅ \pnpm run lint\ ✅ \pnpm run typecheck\ ✅ \pnpm run build\ ✅
- Fallback match logic tested locally against published 1.1.0