### PR TITLE
fix: restore release readiness baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @oaslananka

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/packages/mcp-npm"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,76 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "mcp-server (ubuntu-24.04)"
+          },
+          {
+            "context": "mcp-server (windows-2025-vs2026)"
+          },
+          {
+            "context": "mcp-server (macos-15)"
+          },
+          {
+            "context": "mcp-npm (ubuntu-24.04)"
+          },
+          {
+            "context": "mcp-npm (windows-2025-vs2026)"
+          },
+          {
+            "context": "mcp-npm (macos-15)"
+          },
+          {
+            "context": "protocol-schemas"
+          },
+          {
+            "context": "scan"
+          },
+          {
+            "context": "analyze (python)"
+          },
+          {
+            "context": "analyze (javascript-typescript)"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "37 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@21eb7f7842f33eafc83782b56fff2a2c43e9696f
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - uses: github/codeql-action/analyze@21eb7f7842f33eafc83782b56fff2a2c43e9696f

--- a/.github/workflows/publish-mcp-container.yml
+++ b/.github/workflows/publish-mcp-container.yml
@@ -1,0 +1,113 @@
+name: Publish MCP Container
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - Dockerfile.kicad10
+      - docker-entrypoint.sh
+      - pyproject.toml
+      - uv.lock
+      - src/**
+      - scripts/check_docker_metadata.py
+      - .github/workflows/publish-mcp-container.yml
+      - docs/deployment/docker.md
+      - docs/install/docker.md
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the image to GHCR.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-mcp-container-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GHCR_IMAGE: ghcr.io/oaslananka/kicad-mcp-pro
+  STABLE_LATEST_IMAGE: ghcr.io/oaslananka/kicad-mcp-pro:latest
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        with:
+          image: tonistiigi/binfmt:qemu-v10.0.4@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+        with:
+          driver-opts: image=moby/buildkit:v0.26.2@sha256:de10faf919fc71ba4eb1dd7bd6449566d012b0c9436b1c61bfee21d621b009aa
+
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        id: meta
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=match,pattern=mcp-server-v(.*),group=1
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'mcp-server-v') }}
+
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.publish != true)
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          outputs: type=cacheonly
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        id: build-push
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+          provenance: mode=max
+
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        with:
+          image-ref: ${{ env.GHCR_IMAGE }}@${{ steps.build-push.outputs.digest }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: table
+          exit-code: "1"
+          version: v0.70.0
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        with:
+          cosign-release: v3.0.6
+
+      - name: Sign image digest
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign --yes "${GHCR_IMAGE}@${{ steps.build-push.outputs.digest }}"

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,95 @@
+name: Publish MCP Registry
+
+on:
+  pull_request:
+    paths:
+      - server.json
+      - mcp.json
+      - pyproject.toml
+      - src/kicad_mcp/__init__.py
+      - scripts/publish_mcp_registry.py
+      - scripts/validate_mcp_manifest.py
+      - .github/workflows/publish-mcp-registry.yml
+      - docs/submission/openai-mcp-registry.md
+      - PUBLIC_LISTING.md
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Validate and print the registry payload without publishing.
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-mcp-registry-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  MCP_PUBLISHER_VERSION: v1.7.9
+
+jobs:
+  dry-run:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == true)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: uv.toml
+      - run: uv sync --all-extras --frozen
+      - run: uv run --all-extras python scripts/validate_mcp_manifest.py server.json
+      - run: uv run --all-extras python scripts/publish_mcp_registry.py --dry-run
+
+  publish:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != true)
+    runs-on: ubuntu-24.04
+    environment: mcp-registry
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: uv.toml
+      - run: uv sync --all-extras --frozen
+      - name: Install mcp-publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" -o mcp-publisher.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+          mkdir -p "$HOME/.local/bin"
+          mv mcp-publisher "$HOME/.local/bin/mcp-publisher"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: uv run --all-extras python scripts/validate_mcp_manifest.py server.json
+      - name: Verify package artifacts before registry publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+
+          for attempt in {1..30}; do
+            if python -c "import json, tomllib, urllib.request; version = tomllib.load(open('pyproject.toml', 'rb'))['project']['version']; payload = json.load(urllib.request.urlopen(f'https://pypi.org/pypi/kicad-mcp-pro/{version}/json', timeout=30)); assert payload['info']['version'] == version" \
+              && npm view "kicad-mcp-pro@${version}" version --json \
+              && docker buildx imagetools inspect "ghcr.io/oaslananka/kicad-mcp-pro:${version}"; then
+              exit 0
+            fi
+            echo "Package artifacts for ${version} are not ready yet (attempt ${attempt}/30)."
+            sleep 20
+          done
+
+          echo "Package artifacts for ${version} were not available after waiting." >&2
+          exit 1
+      - run: uv run --all-extras python scripts/publish_mcp_registry.py

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -16,8 +16,9 @@ gh api -X PUT /repos/oaslananka/kicad-mcp/rulesets/<id> --input .github/rulesets
 ```
 
 The current policy requires pull requests, one review, code owner review,
-signed commits, non-fast-forward protection, and the current monorepo workflow
-check-run contexts listed in `docs/architecture/branch-protection.md`.
+signed commits, linear history, non-fast-forward protection, and the required
+CI, Gitleaks, and CodeQL check-run contexts listed in
+`.github/rulesets/main.json`.
 
 When a required workflow job name changes, update the root branch-protection
 document and `.github/rulesets/main.json` together before applying the ruleset.

--- a/docs/maintenance-policy.md
+++ b/docs/maintenance-policy.md
@@ -22,13 +22,12 @@ skipping the scan.
 
 ## Dependency Updates
 
-Renovate remains responsible for security updates and alerts. Renovate handles
-regular version update PRs using `renovate.json`.
+Dependabot remains responsible for security updates and regular dependency
+version PRs using `.github/dependabot.yml`.
 
 Patch and minor updates for development tooling and GitHub Actions may automerge
 only after protected checks pass. Runtime dependencies, major updates, and core
-KiCad/MCP/Pydantic/Typer ecosystem updates require Dependency Dashboard approval
-and maintainer review.
+KiCad/MCP/Pydantic/Typer ecosystem updates require maintainer review.
 
 ## Security Scans
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -20,7 +20,7 @@ KiCad MCP Pro runs local automation against KiCad projects. The main risks are f
 
 - Project path resolution keeps normal writes inside the active project.
 - Optional bearer-token auth protects HTTP transport.
-- Renovate, CodeQL, Gitleaks, Scorecard, Trivy, Hadolint, Bandit, and pip-audit cover the main automated scan layers.
+- Dependabot, CodeQL, Gitleaks, Trivy, Hadolint, Bandit, and pip-audit cover the main automated scan layers.
 - SBOM, Sigstore signing, checksums, and GitHub artifact attestations accompany release artifacts.
 
 ## Reporting

--- a/examples/mcp-docker/docker-compose.yml
+++ b/examples/mcp-docker/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  kicad-mcp-pro:
+    image: ghcr.io/oaslananka/kicad-mcp-pro:latest
+    read_only: true
+    ports:
+      - "127.0.0.1:3334:3334"
+    environment:
+      KICAD_MCP_TRANSPORT: streamable-http
+      KICAD_MCP_HOST: 0.0.0.0
+      KICAD_MCP_AUTH_TOKEN: ${KICAD_MCP_AUTH_TOKEN:?Set KICAD_MCP_AUTH_TOKEN}
+      KICAD_MCP_PROJECT_DIR: /projects
+      KICAD_MCP_OUTPUT_DIR: /tmp/kicad-mcp-output
+    volumes:
+      - ${KICAD_PROJECT_DIR:-.}:/projects:ro
+      - kicad-mcp-output:/tmp/kicad-mcp-output
+    tmpfs:
+      - /tmp
+
+volumes:
+  kicad-mcp-output:

--- a/src/kicad_mcp/resources/gate_history.py
+++ b/src/kicad_mcp/resources/gate_history.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -46,54 +47,56 @@ class GateHistory:
         return history
 
     def _init(self) -> None:
-        with sqlite3.connect(self.db_path) as db:
-            version = int(db.execute("PRAGMA user_version").fetchone()[0])
-            if version > SCHEMA_VERSION:
-                raise RuntimeError(
-                    f"Gate history schema version {version} is newer than this server supports."
+        with closing(sqlite3.connect(self.db_path)) as db:
+            with db:
+                version = int(db.execute("PRAGMA user_version").fetchone()[0])
+                if version > SCHEMA_VERSION:
+                    raise RuntimeError(
+                        f"Gate history schema version {version} is newer than this server supports."
+                    )
+                db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS gate_history (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp TEXT NOT NULL,
+                        gate_name TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        issue_count INTEGER NOT NULL,
+                        auto_fixed INTEGER NOT NULL,
+                        payload TEXT NOT NULL
+                    )
+                    """
                 )
-            db.execute(
-                """
-                CREATE TABLE IF NOT EXISTS gate_history (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT NOT NULL,
-                    gate_name TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    issue_count INTEGER NOT NULL,
-                    auto_fixed INTEGER NOT NULL,
-                    payload TEXT NOT NULL
-                )
-                """
-            )
-            db.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+                db.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
     def record(self, outcome: GateOutcome, auto_fixed: int = 0) -> None:
         issue_count = 0 if outcome.status == "PASS" else max(1, len(outcome.details))
-        with sqlite3.connect(self.db_path) as db:
-            db.execute(
-                """
-                INSERT INTO gate_history
-                    (timestamp, gate_name, status, issue_count, auto_fixed, payload)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    datetime.now(UTC).isoformat(),
-                    outcome.name,
-                    outcome.status,
-                    issue_count,
-                    auto_fixed,
-                    json.dumps(
-                        {
-                            "summary": outcome.summary,
-                            "details": outcome.details,
-                        },
-                        sort_keys=True,
+        with closing(sqlite3.connect(self.db_path)) as db:
+            with db:
+                db.execute(
+                    """
+                    INSERT INTO gate_history
+                        (timestamp, gate_name, status, issue_count, auto_fixed, payload)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        datetime.now(UTC).isoformat(),
+                        outcome.name,
+                        outcome.status,
+                        issue_count,
+                        auto_fixed,
+                        json.dumps(
+                            {
+                                "summary": outcome.summary,
+                                "details": outcome.details,
+                            },
+                            sort_keys=True,
+                        ),
                     ),
-                ),
-            )
+                )
 
     def trend(self, gate_name: str, last_n: int = 10) -> list[GateHistoryRecord]:
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             rows = db.execute(
                 """
                 SELECT timestamp, gate_name, status, issue_count, auto_fixed
@@ -116,7 +119,7 @@ class GateHistory:
         ]
 
     def latest(self, last_n: int = 10) -> list[GateHistoryRecord]:
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             rows = db.execute(
                 """
                 SELECT timestamp, gate_name, status, issue_count, auto_fixed
@@ -139,7 +142,7 @@ class GateHistory:
 
     def regression_check(self) -> list[str]:
         warnings: list[str] = []
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             names = [row[0] for row in db.execute("SELECT DISTINCT gate_name FROM gate_history")]
             for name in names:
                 rows = db.execute(

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -230,6 +230,7 @@ _TOOL_LIMITERS_LOCK = threading.Lock()
 _METRICS_LOCK = threading.Lock()
 _TOOL_CALL_COUNTS: dict[tuple[str, str], int] = {}
 _TOOL_LATENCIES_MS: dict[str, deque[float]] = {}
+IPC_CAPABILITY_CACHE_TTL_SEC = 1.0
 
 
 def _tool_limiter(tool_name: str) -> anyio.CapacityLimiter | None:
@@ -511,8 +512,11 @@ def _ipc_runtime_allows_tool(tool_name: str, state: KiCadIpcCapabilityState) -> 
     return state.reachable
 
 
-def _filter_ipc_runtime_tools(tools: list[mcp_types.Tool]) -> list[mcp_types.Tool]:
-    state = get_ipc_capability_state()
+def _filter_ipc_runtime_tools(
+    tools: list[mcp_types.Tool],
+    state: KiCadIpcCapabilityState | None = None,
+) -> list[mcp_types.Tool]:
+    state = state or get_ipc_capability_state()
     return [tool for tool in tools if _ipc_runtime_allows_tool(tool.name, state)]
 
 
@@ -530,6 +534,8 @@ class KiCadFastMCP(FastMCP):
     _lazy_registration_thread: threading.Thread | None = None
     _telemetry_catalog_hash: str | None = None
     _telemetry_kicad_version: str | None = None
+    _ipc_capability_state: KiCadIpcCapabilityState | None = None
+    _ipc_capability_checked_at: float = 0.0
 
     def set_lazy_registration(self, register: Callable[[], None]) -> None:
         """Defer heavy tool/resource registration until after stdio initialize can bind."""
@@ -622,7 +628,7 @@ class KiCadFastMCP(FastMCP):
         mode = getattr(self, "operating_mode", active_operating_mode())
         tools = filter_tools_for_mode(tools, mode)
         if getattr(self, "filter_runtime_tools", True):
-            tools = _filter_ipc_runtime_tools(tools)
+            tools = _filter_ipc_runtime_tools(tools, self._runtime_ipc_capability_state())
         if mode is OperatingMode.EXPERIMENTAL:
             return tools
         if (
@@ -633,6 +639,17 @@ class KiCadFastMCP(FastMCP):
         return [
             tool for tool in tools if getattr(tool, "name", None) not in EXPERIMENTAL_TOOL_NAMES
         ]
+
+    def _runtime_ipc_capability_state(self) -> KiCadIpcCapabilityState:
+        """Return a short-lived KiCad IPC capability snapshot for discovery filtering."""
+        now = time.monotonic()
+        cached = getattr(self, "_ipc_capability_state", None)
+        checked_at = getattr(self, "_ipc_capability_checked_at", 0.0)
+        if cached is None or now - checked_at > IPC_CAPABILITY_CACHE_TTL_SEC:
+            cached = get_ipc_capability_state()
+            self._ipc_capability_state = cached
+            self._ipc_capability_checked_at = now
+        return cached
 
     def list_tools_sync(self) -> list[mcp_types.Tool]:
         """List filtered tools without needing to drive an asyncio event loop."""

--- a/tests/unit/test_benchmark_latency.py
+++ b/tests/unit/test_benchmark_latency.py
@@ -7,11 +7,55 @@ from pathlib import Path
 
 import pytest
 
+from kicad_mcp.ipc.capabilities import KiCadIpcCapabilityState
+from kicad_mcp.ipc.discovery import KiCadIpcEndpoint
 from kicad_mcp.server import build_server
 
 PERFORMANCE_CATALOG_PATH = Path(__file__).resolve().parents[2] / "performance" / "baselines.json"
 MEASUREMENT_OUTPUT_ENV = "KICAD_PERFORMANCE_MEASUREMENTS_JSON"
 TOOLS_LIST_METRIC = "mcp.tools_list.response_ms"
+
+
+def _unavailable_ipc_state() -> KiCadIpcCapabilityState:
+    """Return a deterministic unavailable IPC state for discovery tests."""
+    return KiCadIpcCapabilityState(
+        endpoint=KiCadIpcEndpoint(
+            socket_path=None,
+            source="default",
+            token_configured=False,
+            timeout_ms=10_000,
+        ),
+        reachable=False,
+        version=None,
+        api_version=None,
+        major_version=None,
+        live_pcb_context=False,
+        live_schematic_context=False,
+        operations={},
+        diagnostics=(),
+    )
+
+
+def test_tools_list_reuses_runtime_capability_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_project: Path,
+) -> None:
+    """Avoid repeated cold KiCad IPC probes during one tools/list burst."""
+    _ = sample_project
+    calls = 0
+
+    def fake_ipc_state() -> KiCadIpcCapabilityState:
+        nonlocal calls
+        calls += 1
+        return _unavailable_ipc_state()
+
+    monkeypatch.setattr("kicad_mcp.server.get_ipc_capability_state", fake_ipc_state)
+    server = build_server("full")
+
+    server.list_tools_sync()
+    server.list_tools_sync()
+
+    assert calls == 1
 
 
 @pytest.mark.benchmark

--- a/tests/unit/test_gate_history.py
+++ b/tests/unit/test_gate_history.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from kicad_mcp.resources.gate_history import GateHistory
@@ -23,26 +24,27 @@ def test_gate_history_records_trends_and_regressions(tmp_path: Path) -> None:
 
 def test_gate_history_schema_migration_sets_user_version(tmp_path: Path) -> None:
     db_path = tmp_path / "gate_history.db"
-    with sqlite3.connect(db_path) as db:
-        db.execute(
-            """
-            CREATE TABLE gate_history (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp TEXT NOT NULL,
-                gate_name TEXT NOT NULL,
-                status TEXT NOT NULL,
-                issue_count INTEGER NOT NULL,
-                auto_fixed INTEGER NOT NULL,
-                payload TEXT NOT NULL
+    with closing(sqlite3.connect(db_path)) as db:
+        with db:
+            db.execute(
+                """
+                CREATE TABLE gate_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    gate_name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    issue_count INTEGER NOT NULL,
+                    auto_fixed INTEGER NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
             )
-            """
-        )
-        db.execute("PRAGMA user_version = 0")
+            db.execute("PRAGMA user_version = 0")
 
     history = GateHistory(db_path)
     history._init()
 
-    with sqlite3.connect(db_path) as db:
+    with closing(sqlite3.connect(db_path)) as db:
         user_version = db.execute("PRAGMA user_version").fetchone()[0]
 
     assert user_version == 1

--- a/tests/unit/test_refactor_helper_modules.py
+++ b/tests/unit/test_refactor_helper_modules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 import subprocess
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 
@@ -142,8 +143,9 @@ def test_gate_history_records_trends_and_regressions(tmp_path: Path) -> None:
 
 def test_gate_history_rejects_newer_schema(tmp_path: Path) -> None:
     db_path = tmp_path / "future_gate_history.db"
-    with sqlite3.connect(db_path) as db:
-        db.execute("PRAGMA user_version = 999")
+    with closing(sqlite3.connect(db_path)) as db:
+        with db:
+            db.execute("PRAGMA user_version = 999")
 
     with pytest.raises(RuntimeError, match="newer than this server supports"):
         GateHistory(db_path)._init()

--- a/uv.lock
+++ b/uv.lock
@@ -2217,11 +2217,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Problem

Repository audit found release-readiness and security-baseline gaps that were breaking or weakening local gates:

- MCP container/registry publishing files expected by metadata checks were missing.
- `tools/list` could repeatedly pay the cold KiCad IPC capability probe cost and fail the latency budget.
- The dependency audit flagged PyJWT advisories fixed by PyJWT 2.13.0.
- Docs referenced branch rulesets, CodeQL, CODEOWNERS, and dependency maintenance controls that were not present in repo files.
- Full tests emitted sqlite `ResourceWarning`s from unclosed gate-history database handles.

## Solution

- Add pinned MCP container and registry publishing workflows plus a Docker compose example.
- Cache runtime IPC capability discovery per server instance for a short TTL and cover it with a regression test.
- Update `uv.lock` to PyJWT 2.13.0.
- Add Dependabot, CodeQL, CODEOWNERS, and ruleset-as-code; align security/maintenance docs.
- Close sqlite connections explicitly in gate history and related tests.

Closes #6

## Verification

- `corepack pnpm run check`
- `uv run --all-extras pytest tests/unit/test_gate_history.py tests/unit/test_refactor_helper_modules.py tests/unit/test_cli_diagnostics.py tests/unit/test_i18n.py tests/unit/test_release_hardening.py tests/integration/test_project_library_surface.py tests/integration/test_prompt_workflows.py -q -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning`
- `gitleaks detect --source . --redact --verbose`
- `corepack pnpm run hooks:pre-commit`
- `act -l` blocked by local act schema support for the existing `artifact-metadata` permission in pre-existing publish workflows; repository workflow lint/security passed.

## Freshness / Deprecation

- CodeQL Action pinned to `v4.36.1` commit `21eb7f7842f33eafc83782b56fff2a2c43e9696f`; action metadata declares `node24`.
- New Docker/GHCR publishing actions and tool images are pinned to verified action commits and image digests.
- PyJWT 2.13.0 selected because it resolves the pip-audit advisory set reported against the locked version.
- Final local check output has no deprecation warnings.