### PR TITLE
docs: fix broken references to deleted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ schemas, common development ports, and optional Cloudflare tunnel tooling.
 
 ## Package Metadata
 
-The canonical metadata source of truth is `server.json`, which defines the MCP server contract. `mcp.json` is the generated mirror used for tooling compatibility and packaging. Both files must report the same repository, package, and version data for PyPI, npm, OCI, and MCP Registry publishing.
+The canonical metadata source of truth is `server.json`, which defines the MCP server contract. It is synchronized with `pyproject.toml` and verified in CI via `pnpm run metadata:check`.

--- a/docs/adr/0002-version-single-source.md
+++ b/docs/adr/0002-version-single-source.md
@@ -10,14 +10,14 @@ The package exposes version metadata through Python imports, Python packaging me
 
 ## Decision
 
-`pyproject.toml` and `src/kicad_mcp/__init__.py` are the authoritative version sources. Generated public metadata in `mcp.json` and `server.json` is synchronized by `scripts/sync_mcp_metadata.py` and checked in CI with `pnpm run metadata:check`.
+`pyproject.toml` and `src/kicad_mcp/__init__.py` are the authoritative version sources. Generated public metadata in `server.json` is synchronized by `scripts/sync_mcp_metadata.py` and checked in CI with `pnpm run metadata:check`.
 
 ## Consequences
 
 - Release changes must update the Python package version and Python module version together.
-- `mcp.json` and `server.json` should be treated as generated metadata surfaces, not hand-edited version authorities.
+- `server.json` should be treated as a generated metadata surface, not a hand-edited version authority.
 - Pull requests must fail when metadata parity drifts.
 
 ## Verification
 
-`pnpm run metadata:check` exits with status 0, and `mcp.json`, `server.json`, `pyproject.toml`, and `src/kicad_mcp/__init__.py` report the same version.
+`pnpm run metadata:check` exits with status 0, and `server.json`, `pyproject.toml`, and `src/kicad_mcp/__init__.py` report the same version.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -87,13 +87,13 @@ docker build \
   -t kicad-mcp-pro:kicad-cli .
 ```
 
-For CI jobs that need a self-contained KiCad 10 CLI, use `Dockerfile.kicad10`.
+For CI jobs that need a self-contained KiCad 10 CLI, build with the `kicad10` variant.
 Pass an official Linux x86_64 KiCad 10 AppImage URL from the
 [KiCad Linux download page](https://www.kicad.org/download/linux/):
 
 ```bash
 docker build \
-  -f Dockerfile.kicad10 \
+  --build-arg KICAD_VERSION=kicad10 \
   --build-arg KICAD_APPIMAGE_URL="https://downloads.kicad.org/path/to/KiCad-10.x-x86_64.AppImage" \
   -t ghcr.io/oaslananka/kicad-mcp-pro:kicad10-ci .
 ```

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -89,8 +89,8 @@ of these paths:
 - mount a host-managed KiCad install and set `KICAD_MCP_KICAD_CLI`;
 - build locally with `--build-arg KICAD_CLI_APK_PACKAGE=kicad` when the Alpine
   distribution package is acceptable for the target platform;
-- use `Dockerfile.kicad10` for CI images that extract an official KiCad 10
-  AppImage at build time.
+- build with `--build-arg KICAD_VERSION=kicad10` for CI images that extract an official KiCad 10
+  AppImage at build time (see [`Dockerfile multi-stage`](../../Dockerfile)).
 
 Redistributing images that bundle KiCad CLI brings KiCad's upstream license
 terms into the image supply chain. Review the official

--- a/docs/public-listing.md
+++ b/docs/public-listing.md
@@ -1,8 +1,6 @@
 # Public Listings
 
-The canonical public listing source of truth is `PUBLIC_LISTING.md` at the repository root.
-
-Use that root file for submission status, manual action items, approval URLs, and post-approval operations. This documentation page exists so the MkDocs navigation can link to the listing status without referencing files outside the documentation directory.
+This file is the public listing source of truth for submission status, manual action items, approval URLs, and post-approval operations.
 
 Before submitting to a public directory, run:
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -72,13 +72,7 @@ reserved for a future explicitly gated workflow.
 
 ## MCP Registry
 
-`server.json` is the official MCP registry manifest because the current MCP
-registry documentation points publishers at the `server.json` schema hosted by
-Model Context Protocol. `mcp.json` is kept as a compatibility manifest for
-clients and registries that still expect the older repository-root metadata
-shape.
-
-Both files must remain synchronized with:
+`server.json` is the official MCP registry manifest. It must remain synchronized with:
 
 - `pyproject.toml` project name and version
 - Canonical repository URL

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -46,4 +46,4 @@ pnpm run metadata:sync
 pnpm run metadata:check
 ```
 
-`pyproject.toml` is the source of truth for `mcp.json` and `server.json`.
+`pyproject.toml` is the source of truth for `server.json`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,6 @@ Current product versions are represented in:
 - `apps/vscode-extension/package.json`
 - `packages/mcp-server/pyproject.toml`
 - `packages/mcp-server/src/kicad_mcp/__init__.py`
-- `packages/mcp-server/mcp.json`
 - `packages/mcp-server/server.json`
 - `packages/mcp-npm/package.json`
 

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -1,7 +1,7 @@
 # Submission Readiness Checklist
 
 This page is the working index for public listing submissions.
-It links platform-specific instructions to the root listing source of truth: [`PUBLIC_LISTING.md`](../public-listing.md).
+It links platform-specific instructions to the listing source of truth: [`docs/public-listing.md`](../public-listing.md).
 Use this checklist before entering any external review form.
 
 ## Platform Documents
@@ -11,7 +11,7 @@ Use this checklist before entering any external review form.
 - [ ] Open [`openai-mcp-registry.md`](openai-mcp-registry.md) before publishing to the OpenAI/MCP registry.
 - [ ] Open [`reviewer-test-prompts.md`](reviewer-test-prompts.md) before sending reviewer instructions.
 - [ ] Open [`safety-and-permissions.md`](safety-and-permissions.md) before answering security questions.
-- [ ] Open [`PUBLIC_LISTING.md`](../public-listing.md) before recording submission status.
+- [ ] Open [`docs/public-listing.md`](../public-listing.md) before recording submission status.
 
 ## Identity Fields
 
@@ -30,11 +30,11 @@ Use this checklist before entering any external review form.
 
 ## Repository Evidence
 
-- [ ] Confirm `pyproject.toml` version matches `server.json`, `mcp.json`, and `src/kicad_mcp/__init__.py`.
+- [ ] Confirm `pyproject.toml` version matches `server.json` and `src/kicad_mcp/__init__.py`.
 - [ ] Confirm `server.json` declares `name` as `io.github.oaslananka/kicad-mcp-pro`.
-- [ ] Confirm `mcp.json` declares repository URL as `https://github.com/oaslananka/kicad-mcp`.
+- [ ] Confirm `server.json` declares repository URL as `https://github.com/oaslananka/kicad-mcp`.
 - [ ] Confirm README references the demo media slot `docs/assets/demo.gif`.
-- [ ] Confirm README links to `PUBLIC_LISTING.md`.
+- [ ] Confirm README links to the public listing page.
 - [ ] Confirm README links to the privacy policy.
 - [ ] Confirm `docs/privacy.md` states telemetry is disabled by default and optional OpenTelemetry export is explicit.
 - [ ] Confirm `docs/assets/icon.svg` exists and is the canonical vector icon.
@@ -108,7 +108,7 @@ Use this checklist before entering any external review form.
 
 ## Manual Submission Log
 
-- [ ] Record every submission in `PUBLIC_LISTING.md` after the external form is sent.
+- [ ] Record every submission in [`docs/public-listing.md`](../public-listing.md) after the external form is sent.
 - [ ] Record target name exactly as `Anthropic Connector Directory`, `ChatGPT Apps`, or `OpenAI/MCP Registry`.
 - [ ] Record submitted timestamp in UTC.
 - [ ] Record approved timestamp in UTC when approval arrives.
@@ -126,13 +126,10 @@ Use this checklist before entering any external review form.
 - [ ] Do not submit with any secret value in logs or screenshots.
 - [ ] Do not submit with old organization namespace strings.
 - [ ] Confirm CI and trusted publishing workflows use GitHub-hosted runners.
-- [ ] Do not submit before `PUBLIC_LISTING_READY.md` says `READY FOR SUBMISSION`.
-
 ## Final Evidence Controls
 
 - [ ] Confirm every platform-specific document has been reviewed in the same branch as the submission.
-- [ ] Confirm `PUBLIC_LISTING.md` is the only place where external submission status is recorded.
-- [ ] Confirm `PUBLIC_LISTING_READY.md` reflects the latest local gate result before merge.
+- [ ] Confirm [`docs/public-listing.md`](../public-listing.md) is the only place where external submission status is recorded.
 - [ ] Confirm the README public listing section links to the root status file.
 - [ ] Confirm the README documentation section does not duplicate the same public listing link.
 - [ ] Confirm the demo GIF exists locally and is committed.

--- a/docs/submission/anthropic-directory.md
+++ b/docs/submission/anthropic-directory.md
@@ -5,7 +5,7 @@ Use this document when submitting KiCad MCP Pro to the Anthropic Connector Direc
 ## Submission URL
 
 - Submit at `https://clau.de/mcp-directory-submission`.
-- Keep a copy of the submitted field values in `PUBLIC_LISTING.md`.
+- Keep a copy of the submitted field values in [`docs/public-listing.md`](../public-listing.md).
 - Use UTC timestamps for submitted and approved dates.
 - Do not paste secret values into the submission form.
 
@@ -78,7 +78,7 @@ Use this document when submitting KiCad MCP Pro to the Anthropic Connector Direc
 - [ ] Do not promise a fixed Anthropic approval date.
 - [ ] Check email and GitHub issues daily during the review period.
 - [ ] If rejected, copy only actionable technical requirements into a public issue.
-- [ ] If approved, update `PUBLIC_LISTING.md` with the public listing URL.
+- [ ] If approved, update [`docs/public-listing.md`](../public-listing.md) with the public listing URL.
 
 ## Rejection-Prevention Checklist
 
@@ -140,7 +140,7 @@ Use this document when submitting KiCad MCP Pro to the Anthropic Connector Direc
 - [ ] Confirm `pnpm run docs:tools:check` passes after tool metadata changes.
 - [ ] Confirm `uv run --all-extras properdocs build -f mkdocs.yml --strict` passes after docs edits.
 - [ ] Confirm `lychee --verbose --no-progress README.md docs/**/*.md` passes after link edits.
-- [ ] Confirm `server.json` and `mcp.json` versions match the package version.
+- [ ] Confirm `server.json` version matches the package version.
 - [ ] Confirm the PyPI package name remains `kicad-mcp-pro`.
 - [ ] Confirm the OCI image namespace remains `ghcr.io/oaslananka/kicad-mcp-pro`.
 - [ ] Confirm no retired owner namespace appears in copied form text.
@@ -149,7 +149,7 @@ Use this document when submitting KiCad MCP Pro to the Anthropic Connector Direc
 - [ ] Confirm optional Nexar or Freerouting notes do not imply default network egress.
 - [ ] Confirm the expected review timeline is recorded as an estimate, not a promise.
 - [ ] Confirm any rejection response is tracked in a GitHub issue before resubmission.
-- [ ] Confirm `PUBLIC_LISTING.md` is updated only after the form is actually sent.
+- [ ] Confirm [`docs/public-listing.md`](../public-listing.md) is updated only after the form is actually sent.
 - [ ] Confirm approval status is recorded only after the public listing URL is visible.
 - [ ] Confirm the maintainer identity is Osman Aslan with handle `oaslananka`.
 - [ ] Confirm the final submission packet contains this document, reviewer prompts, and safety statement.

--- a/docs/submission/chatgpt-apps.md
+++ b/docs/submission/chatgpt-apps.md
@@ -7,7 +7,7 @@ Use this document for the ChatGPT Apps submission path.
 - Dashboard URL: `https://platform.openai.com/apps`.
 - Use the OpenAI Developer Platform account controlled by Osman Aslan.
 - Track review status in the platform dashboard after submission.
-- Keep public status mirrored in `PUBLIC_LISTING.md`.
+- Keep public status mirrored in [`docs/public-listing.md`](../public-listing.md).
 
 ## Domain Verification
 
@@ -18,7 +18,7 @@ Use this document for the ChatGPT Apps submission path.
 - [ ] Keep the TXT record until the dashboard reports verified.
 - [ ] Do not put the TXT token into repository files.
 - [ ] If verification fails, check registrar DNS, Cloudflare proxy state, and record name.
-- [ ] Record verification completion in `PUBLIC_LISTING.md` notes.
+- [ ] Record verification completion in [`docs/public-listing.md`](../public-listing.md) notes.
 
 ## App Metadata
 
@@ -84,7 +84,7 @@ Use this document for the ChatGPT Apps submission path.
 - [ ] Attach only screenshots that avoid private paths and hostnames.
 - [ ] Use fixture project evidence for all reviewer tests.
 - [ ] Do not upload secrets, logs with tokens, or private KiCad designs.
-- [ ] Update `PUBLIC_LISTING.md` after submission.
+- [ ] Update [`docs/public-listing.md`](../public-listing.md) after submission.
 
 ## Final ChatGPT Apps Dashboard Controls
 
@@ -142,7 +142,7 @@ Use this document for the ChatGPT Apps submission path.
 - [ ] Confirm PyPI, GHCR, and documentation links match the current version being reviewed.
 - [ ] Confirm reviewer-facing copy remains in English at launch.
 - [ ] Confirm Turkish localization is described only as future work.
-- [ ] Confirm approval and rejection status are recorded in `PUBLIC_LISTING.md` after dashboard updates.
+- [ ] Confirm approval and rejection status are recorded in [`docs/public-listing.md`](../public-listing.md) after dashboard updates.
 - [ ] Confirm no private dashboard screenshots are committed.
 - [ ] Confirm no API keys, OAuth secrets, or auth cookies appear in evidence.
 - [ ] Confirm no customer board files are attached to the submission.

--- a/docs/submission/openai-mcp-registry.md
+++ b/docs/submission/openai-mcp-registry.md
@@ -141,8 +141,8 @@ cosign verify ghcr.io/oaslananka/kicad-mcp-pro:${VERSION} \
 - [ ] Confirm `server.json` remains the registry payload source of truth.
 - [ ] Confirm `server.json` schema validation passes before dry run.
 - [ ] Confirm `server.json` stays synchronized with `pyproject.toml`.
-- [ ] Confirm `pyproject.toml` version matches both manifest files.
-- [ ] Confirm `src/kicad_mcp/__init__.py` version matches the manifests.
+- [ ] Confirm `pyproject.toml` version matches `server.json`.
+- [ ] Confirm `src/kicad_mcp/__init__.py` version matches `server.json`.
 - [ ] Confirm PyPI package `kicad-mcp-pro` is reachable for the current version.
 - [ ] Confirm registry package transport is `stdio`.
 - [ ] Confirm registry package runtime hint is `uvx` for PyPI.

--- a/docs/submission/openai-mcp-registry.md
+++ b/docs/submission/openai-mcp-registry.md
@@ -6,7 +6,7 @@ This document covers the registry publish path driven by `server.json`.
 
 - Use `server.json` as the single source of truth for registry metadata.
 - Do not hand-edit registry payloads after generation.
-- Keep `mcp.json` synchronized with `server.json` and `pyproject.toml`.
+- Keep `server.json` synchronized with `pyproject.toml`.
 - Version must match `src/kicad_mcp/__init__.py`.
 
 ## Verified Registry Status (2026-05-31)
@@ -26,12 +26,12 @@ version, tag, or release identity was changed.
 Findings:
 
 - The server **is** listed and active in the official registry, so the historical
-  "Not submitted" entry in `PUBLIC_LISTING.md` was inaccurate and has been corrected.
+  "Not submitted" entry in the public listing was inaccurate and has been corrected.
 - The listing is **stale**: the registry shows `2.1.0` while the current product line is
   `3.6.0` (PyPI already has `3.6.0`). The record predates the monorepo migration, so its
   `repository.url` still points at the legacy standalone repository and it advertises only
   the PyPI package.
-- `server.json` and `mcp.json` both validate against the official
+- `server.json` validates against the official
   `2025-12-11` `server.schema.json`, and `metadata:check` / `submission:check` pass, so the
   current manifest is publish-ready.
 
@@ -82,8 +82,8 @@ OIDC under the `oaslananka` namespace (`id-token: write`).
 
 - [ ] Run live publish only after dry-run output is reviewed.
 - [ ] Use the maintainer account controlled by Osman Aslan.
-- [ ] Record live publish UTC timestamp in `PUBLIC_LISTING.md`.
-- [ ] Record registry response URL in `PUBLIC_LISTING.md` only after it is public.
+- [ ] Record live publish UTC timestamp in [`docs/public-listing.md`](../public-listing.md).
+- [ ] Record registry response URL in [`docs/public-listing.md`](../public-listing.md) only after it is public.
 - [ ] Do not publish from a dirty working tree.
 - [ ] Do not publish with placeholder screenshots if the registry requires production media.
 
@@ -140,7 +140,7 @@ cosign verify ghcr.io/oaslananka/kicad-mcp-pro:${VERSION} \
 
 - [ ] Confirm `server.json` remains the registry payload source of truth.
 - [ ] Confirm `server.json` schema validation passes before dry run.
-- [ ] Confirm `mcp.json` stays synchronized with `server.json`.
+- [ ] Confirm `server.json` stays synchronized with `pyproject.toml`.
 - [ ] Confirm `pyproject.toml` version matches both manifest files.
 - [ ] Confirm `src/kicad_mcp/__init__.py` version matches the manifests.
 - [ ] Confirm PyPI package `kicad-mcp-pro` is reachable for the current version.
@@ -200,7 +200,7 @@ cosign verify ghcr.io/oaslananka/kicad-mcp-pro:${VERSION} \
 - [ ] Confirm no temporary payload files are left in the repository after publish.
 - [ ] Confirm local logs are redacted before copying into public issues.
 - [ ] Confirm live publish is postponed if network reachability is unstable.
-- [ ] Confirm the final outcome is reflected in `PUBLIC_LISTING.md`.
+- [ ] Confirm the final outcome is reflected in [`docs/public-listing.md`](../public-listing.md).
 - [ ] Confirm the next release repeats this checklist rather than copying stale evidence.
 - [ ] Confirm registry docs are updated if the registry schema version changes.
 - [ ] Confirm `scripts/schemas/server.schema.json` is updated only from the official schema.


### PR DESCRIPTION
Fixes broken references across 12 documentation files:

- mcp.json → server.json (canonical only)
- PUBLIC_LISTING.md → docs/public-listing.md
- PUBLIC_LISTING_READY.md → removed
- Dockerfile.kicad10 → Dockerfile with --build-arg KICAD_VERSION=kicad10