### PR TITLE
fix: KiCad 10 bugs, version gating, DRU parser, KiCad 11 paths

### DIFF
--- a/packages/kicad-fixtures/fixtures/drc-courtyard-error/drc-courtyard-error.kicad_prl
+++ b/packages/kicad-fixtures/fixtures/drc-courtyard-error/drc-courtyard-error.kicad_prl
@@ -1,0 +1,105 @@
+{
+  "board": {
+    "active_layer": 0,
+    "active_layer_preset": "",
+    "auto_track_width": true,
+    "hidden_netclasses": [],
+    "hidden_nets": [],
+    "high_contrast_mode": 0,
+    "net_color_mode": 1,
+    "opacity": {
+      "images": 0.6,
+      "pads": 1.0,
+      "shapes": 1.0,
+      "tracks": 1.0,
+      "vias": 1.0,
+      "zones": 0.6
+    },
+    "prototype_zone_fills": false,
+    "selection_filter": {
+      "dimensions": true,
+      "footprints": true,
+      "graphics": true,
+      "keepouts": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pads": true,
+      "text": true,
+      "tracks": true,
+      "vias": true,
+      "zones": true
+    },
+    "visible_items": [
+      "vias",
+      "footprint_text",
+      "footprint_anchors",
+      "ratsnest",
+      "grid",
+      "footprints_front",
+      "footprints_back",
+      "footprint_values",
+      "footprint_references",
+      "tracks",
+      "drc_errors",
+      "drawing_sheet",
+      "bitmaps",
+      "pads",
+      "zones",
+      "drc_warnings",
+      "drc_exclusions",
+      "locked_item_shadows",
+      "conflict_shadows",
+      "shapes",
+      "board_outline_area",
+      "ly_points"
+    ],
+    "visible_layers": "ffffffff_ffffffff_ffffffff_ffffffff",
+    "zone_display_mode": 0
+  },
+  "git": {
+    "integration_disabled": false,
+    "repo_type": "",
+    "repo_username": "",
+    "ssh_key": ""
+  },
+  "meta": {
+    "filename": "drc-courtyard-error.kicad_prl",
+    "version": 5
+  },
+  "net_inspector_panel": {
+    "col_hidden": [],
+    "col_order": [],
+    "col_widths": [],
+    "custom_group_rules": [],
+    "expanded_rows": [],
+    "filter_by_net_name": true,
+    "filter_by_netclass": true,
+    "filter_text": "",
+    "group_by_constraint": false,
+    "group_by_netclass": false,
+    "show_time_domain_details": false,
+    "show_unconnected_nets": false,
+    "show_zero_pad_nets": false,
+    "sort_ascending": true,
+    "sorting_column": -1
+  },
+  "open_jobsets": [],
+  "project": {
+    "files": []
+  },
+  "schematic": {
+    "hierarchy_collapsed": [],
+    "selection_filter": {
+      "graphics": true,
+      "images": true,
+      "labels": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pins": true,
+      "ruleAreas": true,
+      "symbols": true,
+      "text": true,
+      "wires": true
+    }
+  }
+}

--- a/src/kicad_mcp/discovery.py
+++ b/src/kicad_mcp/discovery.py
@@ -58,12 +58,16 @@ class CliCapabilities:
     supports_pads_import: bool = False
     supports_geda_import: bool = False
     supports_cli_variant: bool = False
+    supports_drc_severity_all: bool = False
+    supports_drc_exit_code_violations: bool = False
 
 
 def _candidate_cli_paths() -> list[Path]:
     system = platform.system()
     if system == "Windows":
         return [
+            Path(r"C:\Program Files\KiCad\11.0\bin\kicad-cli.exe"),
+            Path(r"C:\Program Files\KiCad\11.0\bin\kicad-cli"),
             Path(r"C:\Program Files\KiCad\10.0\bin\kicad-cli.exe"),
             Path(r"C:\Program Files\KiCad\10.0\bin\kicad-cli"),
             Path(r"C:\Program Files\KiCad\9.0\bin\kicad-cli.exe"),
@@ -164,6 +168,7 @@ def get_cli_capabilities(cli_path: Path) -> CliCapabilities:
         [str(cli_path), "pcb", "import", "--help"],
         [str(cli_path), "sch", "export", "--help"],
         [str(cli_path), "pcb", "--help"],
+        [str(cli_path), "pcb", "drc", "--help"],
     )
     for command in commands:
         try:
@@ -203,6 +208,9 @@ def get_cli_capabilities(cli_path: Path) -> CliCapabilities:
         supports_pads_import="pads" in blob,
         supports_geda_import="geda" in blob,
         supports_cli_variant="--variant" in blob,
+        supports_drc_severity_all="--severity-all" in blob or "severity-all" in blob,
+        supports_drc_exit_code_violations="--exit-code-violations" in blob
+        or "exit-code-violations" in blob,
     )
     _CLI_CAPABILITIES_CACHE[cache_key] = capabilities
     return capabilities
@@ -241,6 +249,7 @@ def discover_library_paths(cli_path: Path) -> dict[str, Path | None]:
     if system == "Windows":
         candidates.extend(
             [
+                Path(r"C:\Program Files\KiCad\11.0\share\kicad"),
                 Path(r"C:\Program Files\KiCad\10.0\share\kicad"),
                 Path(r"C:\Program Files\KiCad\9.0\share\kicad"),
                 Path(r"C:\Program Files\KiCad\8.0\share\kicad"),
@@ -275,13 +284,18 @@ def find_recent_projects(limit: int = 10) -> list[Path]:
     system = platform.system()
     if system == "Windows":
         config_dirs = [
+            Path.home() / "AppData" / "Roaming" / "kicad" / "11.0",
             Path.home() / "AppData" / "Roaming" / "kicad" / "10.0",
             Path.home() / "AppData" / "Roaming" / "kicad" / "9.0",
         ]
     elif system == "Darwin":
-        config_dirs = [Path.home() / "Library" / "Preferences" / "kicad" / "10.0"]
+        config_dirs = [
+            Path.home() / "Library" / "Preferences" / "kicad" / "11.0",
+            Path.home() / "Library" / "Preferences" / "kicad" / "10.0",
+        ]
     else:
         config_dirs = [
+            Path.home() / ".config" / "kicad" / "11.0",
             Path.home() / ".config" / "kicad" / "10.0",
             Path.home() / ".config" / "kicad" / "9.0",
         ]

--- a/src/kicad_mcp/tools/pcb.py
+++ b/src/kicad_mcp/tools/pcb.py
@@ -2910,6 +2910,8 @@ def register(mcp: FastMCP) -> None:
         drill_mm: float = 0.4,
         net_name: str = "",
         via_type: str = "through",
+        from_layer: str = "",
+        to_layer: str = "",
     ) -> str:
         """Add a via."""
         payload = AddViaInput(
@@ -2930,6 +2932,12 @@ def register(mcp: FastMCP) -> None:
         via.diameter = mm_to_nm(payload.diameter_mm)
         via.drill_diameter = mm_to_nm(payload.drill_mm)
         via.type = type_map[payload.via_type]
+        if payload.via_type in ("blind", "micro"):
+            if not from_layer or not to_layer:
+                raise ValueError(
+                    f"from_layer and to_layer are required when via_type='{payload.via_type}'."
+                )
+            _configure_layer_via(via, from_layer=from_layer, to_layer=to_layer)
         if payload.net_name:
             via.net = _find_net(payload.net_name)
         with board_transaction() as board:
@@ -3171,19 +3179,28 @@ def register(mcp: FastMCP) -> None:
         layer: str = "F.Fab",
         barcode_type: str = "qr",
         size_mm: float = 10.0,
+        text_height_mm: float | None = None,
+        hide_text: bool = True,
     ) -> str:
-        """Add a production barcode marker to the board file."""
+        """Add a production barcode marker to the board file using KiCad's native barcode format."""
         normalized_type = barcode_type.casefold()
-        if normalized_type not in {"qr", "datamatrix", "code128"}:
-            return "barcode_type must be one of 'qr', 'datamatrix', or 'code128'."
+        if normalized_type not in {"qr", "datamatrix", "code128", "code39"}:
+            return "barcode_type must be one of 'qr', 'datamatrix', 'code128', or 'code39'."
+        text_h = text_height_mm if text_height_mm is not None else size_mm / 4
         board_block = (
-            f'(gr_text "{normalized_type.upper()}:{content}" (at {x_mm:.4f} {y_mm:.4f} 0) '
-            f'(layer "{layer}") (effects (font (size {size_mm / 4:.4f} {size_mm / 4:.4f}))))'
+            f"(barcode (at {x_mm:.4f} {y_mm:.4f} 0) "
+            f'(layer "{layer}") '
+            f"(size {size_mm:.4f} {size_mm:.4f}) "
+            f'(text "{content}") '
+            f"(text_height {text_h:.4f}) "
+            f'(type "{normalized_type}") '
+            f"(hide {'yes' if hide_text else 'no'})"
+            f")"
         )
         _transactional_board_write(lambda current: _append_board_blocks(current, [board_block]))
         return (
-            f"Barcode marker added at ({x_mm:.2f}, {y_mm:.2f}) mm on {layer}. "
-            "The KiCad 10 native barcode renderer can refine the appearance in the GUI."
+            f"Barcode added at ({x_mm:.2f}, {y_mm:.2f}) mm on {layer} "
+            f"with type '{normalized_type}'."
         )
 
     @mcp.tool()
@@ -3199,8 +3216,11 @@ def register(mcp: FastMCP) -> None:
             kiid = KIID()
             kiid.value = item_id
             kiids.append(kiid)
-        with board_transaction() as board:
-            board.remove_items_by_id(kiids)
+        try:
+            with board_transaction() as board:
+                board.remove_items_by_id(kiids)
+        except Exception as exc:
+            return f"Failed to delete items: {exc}"
         return f"Deleted {len(kiids)} item(s)."
 
     @mcp.tool()

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -1607,13 +1607,21 @@ def _remove_wire_blocks(content: str) -> str:
 
 
 def _normalize_schematic_wire_connectivity(content: str) -> str:
-    segments = _deduplicate_segments(_wire_segments_from_content(content))
-    if not segments:
+    wires = _extract_wires(content)
+    segments = _wire_segments_from_content(content)
+    deduped = _deduplicate_segments(segments)
+    if not deduped:
         return content
+    uuid_map: dict[tuple[float, float, float, float], str] = {}
+    for w in wires:
+        key = (w["x1"], w["y1"], w["x2"], w["y2"])
+        if key in segments and "uuid" in w:
+            uuid_map[key] = w["uuid"]
     updated = _remove_wire_blocks(content)
-    for segment in segments:
-        updated = _append_before_sheet_instances(updated, wire_block(*segment))
-    return _insert_junctions_for_batch(updated, _detect_t_intersections(segments))
+    for segment in deduped:
+        uid = uuid_map.get(segment)
+        updated = _append_before_sheet_instances(updated, wire_block(*segment, uuid_str=uid))
+    return _insert_junctions_for_batch(updated, _detect_t_intersections(deduped))
 
 
 def _extract_labels(content: str) -> list[dict[str, Any]]:
@@ -2799,13 +2807,16 @@ def _iter_child_sheet_paths(sch_file: Path) -> list[tuple[str, Path]]:
     return discovered
 
 
-def wire_block(x1: float, y1: float, x2: float, y2: float, kind: str = "wire") -> str:
+def wire_block(
+    x1: float, y1: float, x2: float, y2: float, kind: str = "wire", uuid_str: str | None = None
+) -> str:
     """Create a schematic wire or bus block."""
+    uid = uuid_str if uuid_str is not None else new_uuid()
     return (
         f"\t({kind}\n"
         f"\t\t(pts (xy {_fmt_mm(x1)} {_fmt_mm(y1)}) (xy {_fmt_mm(x2)} {_fmt_mm(y2)}))\n"
         "\t\t(stroke (width 0) (type solid))\n"
-        f'\t\t(uuid "{new_uuid()}")\n'
+        f'\t\t(uuid "{uid}")\n'
         "\t)"
     )
 

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -1615,7 +1615,7 @@ def _normalize_schematic_wire_connectivity(content: str) -> str:
     uuid_map: dict[tuple[float, float, float, float], str] = {}
     for w in wires:
         key = (w["x1"], w["y1"], w["x2"], w["y2"])
-        if key in segments and "uuid" in w:
+        if "uuid" in w:
             uuid_map[key] = w["uuid"]
     updated = _remove_wire_blocks(content)
     for segment in deduped:

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 
 from ..config import get_config
 from ..connection import KiCadConnectionError, get_board
+from ..discovery import get_cli_capabilities
 from ..models.component_contracts import find_component_contract
 from ..utils.dru import (
     SExprNode,
@@ -26,7 +27,6 @@ from ..utils.dru import (
     parse_dru,
     upsert_rule,
 )
-from ..discovery import get_cli_capabilities
 from .export_support import _ensure_output_dir, _get_pcb_file, _get_sch_file, _run_cli_variants
 from .gates import GateOutcome, GateStatus, _combined_status
 from .metadata import headless_compatible

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -26,6 +26,7 @@ from ..utils.dru import (
     parse_dru,
     upsert_rule,
 )
+from ..discovery import get_cli_capabilities
 from .export_support import _ensure_output_dir, _get_pcb_file, _get_sch_file, _run_cli_variants
 from .gates import GateOutcome, GateStatus, _combined_status
 from .metadata import headless_compatible
@@ -154,6 +155,15 @@ def _format_violations(title: str, entries: list[dict[str, object]]) -> str:
 def _run_drc_report(report_name: str) -> tuple[Path, dict[str, object] | None, str | None]:
     pcb_file = _get_pcb_file()
     out_file = _ensure_output_dir() / report_name
+
+    cfg = get_config()
+    capabilities = get_cli_capabilities(cfg.kicad_cli)
+    drc_flags: list[str] = []
+    if capabilities.supports_drc_severity_all:
+        drc_flags.append("--severity-all")
+    if capabilities.supports_drc_exit_code_violations:
+        drc_flags.append("--exit-code-violations")
+
     code, _, stderr = _run_cli_variants(
         [
             [
@@ -163,8 +173,7 @@ def _run_drc_report(report_name: str) -> tuple[Path, dict[str, object] | None, s
                 str(out_file),
                 "--format",
                 "json",
-                "--severity-all",
-                "--exit-code-violations",
+                *drc_flags,
                 str(pcb_file),
             ],
             [
@@ -176,8 +185,7 @@ def _run_drc_report(report_name: str) -> tuple[Path, dict[str, object] | None, s
                 str(out_file),
                 "--format",
                 "json",
-                "--severity-all",
-                "--exit-code-violations",
+                *drc_flags,
             ],
         ]
     )
@@ -1680,7 +1688,7 @@ def register(mcp: FastMCP) -> None:
             return json.dumps({"rules": built_in}, indent=2)
 
         content = _load_rules_content(_rules_file_path())
-        root = parse_dru(content)
+        root, _version = parse_dru(content)
         state = _load_drc_state()
         custom = [_rule_payload(rule, state) for rule in iter_rule_nodes(root)]
         return json.dumps({"rules": [*built_in, *custom]}, indent=2)
@@ -1711,9 +1719,9 @@ def register(mcp: FastMCP) -> None:
             ["severity", severity],
         ]
         path = _rules_file_path()
-        root = parse_dru(_load_rules_content(path))
+        root, version = parse_dru(_load_rules_content(path))
         upsert_rule(root, rule_node)
-        path.write_text(dump_dru(root), encoding="utf-8")
+        path.write_text(dump_dru(root, version=version), encoding="utf-8")
         state = _load_drc_state()
         cast(dict[str, bool], state.setdefault("enabled", {}))[name] = True
         cast(dict[str, str], state.setdefault("severity", {}))[name] = severity
@@ -1727,10 +1735,10 @@ def register(mcp: FastMCP) -> None:
         from .routing_rules import _load_rules_content, _rules_file_path
 
         path = _rules_file_path()
-        root = parse_dru(_load_rules_content(path))
+        root, version = parse_dru(_load_rules_content(path))
         if not delete_rule(root, rule_name):
             raise ValueError(f"Rule '{rule_name}' was not found.")
-        path.write_text(dump_dru(root), encoding="utf-8")
+        path.write_text(dump_dru(root, version=version), encoding="utf-8")
         state = _load_drc_state()
         cast(dict[str, bool], state.setdefault("enabled", {})).pop(rule_name, None)
         cast(dict[str, str], state.setdefault("severity", {})).pop(rule_name, None)
@@ -1744,7 +1752,7 @@ def register(mcp: FastMCP) -> None:
         from .routing_rules import _load_rules_content, _rules_file_path
 
         path = _rules_file_path()
-        root = parse_dru(_load_rules_content(path))
+        root, version = parse_dru(_load_rules_content(path))
         rule = find_rule(root, rule_name)
         if rule is None:
             return f"Custom DRC rule '{rule_name}' was not found."
@@ -1770,7 +1778,7 @@ def register(mcp: FastMCP) -> None:
             ["severity", "ignore" if not enabled else existing_severity],
         )
         upsert_rule(root, replacement)
-        path.write_text(dump_dru(root), encoding="utf-8")
+        path.write_text(dump_dru(root, version=version), encoding="utf-8")
         _save_drc_state(state)
         state_text = "enabled" if enabled else "disabled"
         return f"Custom DRC rule '{rule_name}' {state_text}."

--- a/src/kicad_mcp/utils/dru.py
+++ b/src/kicad_mcp/utils/dru.py
@@ -103,6 +103,9 @@ def parse_dru(content: str) -> tuple[SExprNode, str | None]:
         version = tokens[index + 2]
         index += 4
 
+    if index >= len(tokens):
+        return ["rules"], version
+
     node, next_index = _parse_expression(tokens, index)
     if next_index != len(tokens):
         raise ValueError("Unexpected trailing tokens in .kicad_dru content.")

--- a/src/kicad_mcp/utils/dru.py
+++ b/src/kicad_mcp/utils/dru.py
@@ -79,17 +79,36 @@ def _parse_expression(tokens: list[str], start_index: int = 0) -> tuple[SExprVal
     raise ValueError("Unbalanced parentheses in .kicad_dru content.")
 
 
-def parse_dru(content: str) -> SExprNode:
-    """Parse a KiCad ``.kicad_dru`` file into a simple S-expression tree."""
+def parse_dru(content: str) -> tuple[SExprNode, str | None]:
+    """Parse a KiCad ``.kicad_dru`` file into a simple S-expression tree.
+
+    Returns ``(rules_node, version)`` where *version* is ``None`` or a
+    version string (e.g. ``"1"``) extracted from a leading ``(version N)``
+    declaration.
+    """
     tokens = _tokenize(content)
     if not tokens:
-        return ["rules"]
-    node, next_index = _parse_expression(tokens, 0)
+        return ["rules"], None
+
+    index = 0
+    version: str | None = None
+    # Consume leading (version N) declarations
+    while (
+        index < len(tokens)
+        and tokens[index] == "("
+        and index + 3 < len(tokens)
+        and tokens[index + 1] == "version"
+        and tokens[index + 3] == ")"
+    ):
+        version = tokens[index + 2]
+        index += 4
+
+    node, next_index = _parse_expression(tokens, index)
     if next_index != len(tokens):
         raise ValueError("Unexpected trailing tokens in .kicad_dru content.")
     if not isinstance(node, list) or not node or node[0] != "rules":
         raise ValueError("A KiCad .kicad_dru file must have a root '(rules ...)' form.")
-    return node
+    return node, version
 
 
 def _format_atom(value: str) -> str:
@@ -122,9 +141,13 @@ def _dump_expression(node: SExprValue, indent: int = 0) -> str:
     return "\n".join(lines)
 
 
-def dump_dru(node: SExprNode) -> str:
-    """Serialize a parsed KiCad ``.kicad_dru`` tree."""
-    return _dump_expression(node) + "\n"
+def dump_dru(node: SExprNode, version: str | None = None) -> str:
+    """Serialize a parsed KiCad ``.kicad_dru`` tree.
+
+    If *version* is provided, a ``(version ...)`` declaration is prepended.
+    """
+    header = f"(version {version})\n" if version else ""
+    return header + _dump_expression(node) + "\n"
 
 
 def iter_rule_nodes(root: SExprNode) -> list[SExprNode]:

--- a/tests/integration/test_pcb_export_validation_surface.py
+++ b/tests/integration/test_pcb_export_validation_surface.py
@@ -120,6 +120,13 @@ def _fake_cli_run_factory(sample_project: Path):
         _ = (capture_output, text, timeout, check)
         if "--version" in cmd:
             return subprocess.CompletedProcess(cmd, 0, stdout="KiCad 10.0.1", stderr="")
+        if "--help" in cmd:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="gerber drill positions ipc2581 svg dxf step stpz xao render spice",
+                stderr="",
+            )
 
         output_path = None
         if "--output" in cmd:
@@ -203,13 +210,6 @@ def _fake_cli_run_factory(sample_project: Path):
                     {"violations": [{"severity": "error", "description": "Missing driver"}]}
                 ),
                 encoding="utf-8",
-            )
-        elif "--help" in cmd:
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                stdout="gerber drill positions ipc2581 svg dxf step stpz xao render spice",
-                stderr="",
             )
 
         return subprocess.CompletedProcess(cmd, 0, stdout=str(sample_project), stderr="")

--- a/tests/unit/test_dru_utils.py
+++ b/tests/unit/test_dru_utils.py
@@ -14,7 +14,9 @@ from kicad_mcp.utils.dru import (
 
 
 def test_parse_dru_handles_empty_content_and_invalid_root() -> None:
-    assert parse_dru("") == ["rules"]
+    tree, ver = parse_dru("")
+    assert tree == ["rules"]
+    assert ver is None
     with pytest.raises(ValueError, match="root"):
         parse_dru("(not_rules)")
 
@@ -27,7 +29,7 @@ def test_parse_dru_rejects_unterminated_and_unbalanced_content() -> None:
 
 
 def test_dump_and_mutate_dru_rules_round_trip() -> None:
-    root = parse_dru("(rules)")
+    root, _ver = parse_dru("(rules)")
     rule = [
         "rule",
         "Length Match",
@@ -38,7 +40,7 @@ def test_dump_and_mutate_dru_rules_round_trip() -> None:
 
     upsert_rule(root, rule)
     serialized = dump_dru(root)
-    reparsed = parse_dru(serialized)
+    reparsed, _ver2 = parse_dru(serialized)
     reparsed_rule = find_rule(reparsed, "Length Match")
 
     assert reparsed_rule is not None

--- a/tests/unit/test_kicad10_parity_tools.py
+++ b/tests/unit/test_kicad10_parity_tools.py
@@ -167,6 +167,8 @@ async def test_pcb_add_barcode_accepts_code128_and_inner_layer_graphics_require_
     )
 
     pcb_text = (sample_project / "demo.kicad_pcb").read_text(encoding="utf-8")
-    assert "Barcode marker added" in barcode
-    assert "CODE128:SN-001" in pcb_text
+    assert "Barcode added" in barcode
+    assert "(barcode" in pcb_text
+    assert '(text "SN-001")' in pcb_text
+    assert '(type "code128")' in pcb_text
     assert "at least four copper layers" in inner_layer

--- a/tests/unit/test_runtime_helpers.py
+++ b/tests/unit/test_runtime_helpers.py
@@ -273,7 +273,7 @@ def test_cli_capabilities_are_cached(tmp_path: Path, monkeypatch) -> None:
     second = get_cli_capabilities(cli)
 
     assert first == second
-    assert len(calls) == 5
+    assert len(calls) == 6
 
 
 def test_cli_capabilities_cache_refreshes_when_binary_changes(tmp_path: Path, monkeypatch) -> None:
@@ -303,7 +303,7 @@ def test_cli_capabilities_cache_refreshes_when_binary_changes(tmp_path: Path, mo
     os.utime(cli, ns=(now_ns, now_ns))
     _ = get_cli_capabilities(cli)
 
-    assert len(calls) == 10
+    assert len(calls) == 12
 
 
 def test_board_transaction_uses_reentrant_lock() -> None:


### PR DESCRIPTION
## Changes

### Bug fixes
- **pcb_add_via**: Added from_layer/to_layer params for blind/micro vias; calls _configure_layer_via()
- **pcb_add_barcode**: Now uses native (barcode ...) S-expression format instead of plain (gr_text ...)
- **pcb_delete_items**: Wrapped remove_items_by_id() in try/except for invalid UUIDs
- **schematic wire normalization**: UUIDs preserved on rebuild via optional uuid_str param on wire_block()

### DRU parser
- parse_dru(): Handles leading (version N) declarations; returns (node, version) tuple
- dump_dru(): Accepts optional version parameter, prepends (version ...) when set
- All callers in validation.py updated for the new tuple return

### DRC version gating
- CliCapabilities: Added supports_drc_severity_all and supports_drc_exit_code_violations fields
- get_cli_capabilities(): Probes kicad-cli pcb drc --help for flag support
- _run_drc_report(): Dynamically gates --severity-all/--exit-code-violations based on capability

### KiCad 11 readiness
- Added C:\Program Files\KiCad\11.0\bin\ paths in all 3 hardcoded locations (CLI, library, config)
- Same for macOS and Linux paths

### Test fixes
- test_dru_utils.py: Updated for parse_dru tuple return
- test_kicad10_parity_tools.py: Barcode assertions for (barcode ...) format
- test_runtime_helpers.py: CLI probing count 5->6 (cached), 10->12 (refresh)
- test_pcb_export_validation_surface.py: Fixed fake_run order -- --help handled before drc