### PR TITLE
fix: remove invalid subfolder '.' from server.json

### DIFF
--- a/scripts/sync_mcp_metadata.py
+++ b/scripts/sync_mcp_metadata.py
@@ -101,7 +101,6 @@ def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
         "repository": {
             "url": REPOSITORY,
             "source": "github",
-            "subfolder": ".",
         },
         "websiteUrl": WEBSITE,
         "icons": [

--- a/server.json
+++ b/server.json
@@ -6,8 +6,7 @@
   "version": "3.7.3",
   "repository": {
     "url": "https://github.com/oaslananka/kicad-mcp",
-    "source": "github",
-    "subfolder": "."
+    "source": "github"
   },
   "websiteUrl": "https://oaslananka.github.io/kicad-mcp",
   "icons": [

--- a/tests/unit/test_mcp_manifest.py
+++ b/tests/unit/test_mcp_manifest.py
@@ -26,7 +26,7 @@ def test_checked_mcp_manifest_is_valid() -> None:
 
     assert manifest["name"] == "io.github.oaslananka/kicad-mcp-pro"
     assert manifest["repository"]["url"] == "https://github.com/oaslananka/kicad-mcp"
-    assert manifest["repository"]["subfolder"] == "."
+    assert manifest["repository"].get("subfolder") is None
     assert [package["runtimeHint"] for package in manifest["packages"]] == [
         "uvx",
         "npx",


### PR DESCRIPTION
MCP Registry publish for v3.7.3 fails with 'invalid subfolder path: .'. Removing the subfolder field since the server is at repo root.