### PR TITLE
chore: add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@ repos:
       - id: ruff-format
       - id: ruff
         args: [--fix]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: [--config=.gitleaks.toml]


### PR DESCRIPTION
## Problem
Local pre-commit hooks did not run the repository's secret-scanning policy even though `.gitleaks.toml` and `security:local` already enforce Gitleaks elsewhere.

## Solution
Add the official `gitleaks/gitleaks` pre-commit hook at current stable `v8.30.1`, passing the checked-in `.gitleaks.toml` config.

Closes #26.

## Verification
- `uvx pre-commit run --all-files`
- `corepack pnpm run security:local`

## Notes
This PR is stacked on #27 because #27 contains required pre-commit cleanup that makes `pre-commit run --all-files` pass. Retarget to `main` after #27 merges.