### PR TITLE
Fix release publishing recovery paths

### DIFF
--- a/.github/workflows/publish-mcp-container.yml
+++ b/.github/workflows/publish-mcp-container.yml
@@ -50,6 +50,33 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve image version
+        id: version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            case "$RELEASE_TAG" in
+              mcp-server-v*) version="${RELEASE_TAG#mcp-server-v}" ;;
+              *)
+                echo "Unexpected MCP server release tag: $RELEASE_TAG" >&2
+                exit 1
+                ;;
+            esac
+          else
+            version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          fi
+          case "$version" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "Invalid image version: $version" >&2
+              exit 1
+              ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           image: tonistiigi/binfmt:qemu-v10.0.4@sha256:8f58e6214f4cc9dc83ce8f5acad1ece508eb6b20e696a8c1e9f274481982c541
@@ -63,8 +90,8 @@ jobs:
         with:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
-            type=match,pattern=mcp-server-v(.*),group=1
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'mcp-server-v') }}
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'mcp-server-v')) || (github.event_name == 'workflow_dispatch' && inputs.publish == true) }}
 
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.publish != true)
@@ -74,6 +101,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           outputs: type=cacheonly
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            KICAD_MCP_VERSION=${{ steps.version.outputs.version }}
+            VCS_REF=${{ github.sha }}
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
@@ -92,6 +122,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            KICAD_MCP_VERSION=${{ steps.version.outputs.version }}
+            VCS_REF=${{ github.sha }}
           sbom: true
           provenance: mode=max
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,7 +82,19 @@ jobs:
           gh release upload "$RELEASE_TAG" "$upload_dir"/* --clobber
       - name: Verify npm checksums before publish
         run: (cd ../../release-assets/mcp-npm && sha256sum --check SHA256SUMS.txt)
+      - name: Check if version already published
+        id: check-published
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          if npm view "kicad-mcp-pro@${version}" version --json >/dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: npm publish "${{ steps.npm-evidence.outputs.tarball }}" --access public --provenance
+        if: steps.check-published.outputs.already_published != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Verify npm published tarball digest

--- a/.github/workflows/publish-protocol-schemas.yml
+++ b/.github/workflows/publish-protocol-schemas.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'release' &&
-       startsWith(github.event.release.tag_name, 'proto-v'))
+       startsWith(github.event.release.tag_name, 'protocol-schemas-v'))
     runs-on: ubuntu-24.04
     environment: npm
     permissions:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -111,7 +111,19 @@ jobs:
         run: |
           uv run --frozen python scripts/generate_release_evidence.py verify-local --checksums release-evidence/SHA256SUMS.txt --artifacts dist
           (cd dist && sha256sum --check ../release-evidence/SHA256SUMS.txt)
+      - name: Check if version already published
+        id: check-published
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(uv run --frozen python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          if curl -fsS "https://test.pypi.org/pypi/kicad-mcp-pro/${version}/json" >/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.check-published.outputs.already_published != 'true'
         with:
           packages-dir: dist
           repository-url: https://test.pypi.org/legacy/
@@ -157,7 +169,19 @@ jobs:
         run: |
           uv run --frozen python scripts/generate_release_evidence.py verify-local --checksums release-evidence/SHA256SUMS.txt --artifacts dist
           (cd dist && sha256sum --check ../release-evidence/SHA256SUMS.txt)
+      - name: Check if version already published
+        id: check-published
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(uv run --frozen python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          if curl -fsS "https://pypi.org/pypi/kicad-mcp-pro/${version}/json" >/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.check-published.outputs.already_published != 'true'
         with:
           packages-dir: dist
           attestations: true

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   ".": "3.9.1",
   "packages/mcp-npm": "3.9.1",
+  "packages/protocol-schemas": "1.1.1",
   "src-tauri": "3.9.1"
 }

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -143,8 +143,10 @@ executes:
 uvx kicad-mcp-pro
 ```
 
-No npm publish workflow is enabled yet. npm trusted publishing is available, but
-the package must be configured in npm before a guarded workflow is added.
+`.github/workflows/publish-npm.yml` publishes the wrapper for `mcp-npm-v*`
+GitHub Releases and verifies the published tarball digest. Re-running the
+workflow for an existing version skips the immutable npm publish operation and
+still verifies the existing artifact.
 
 ## Required Configuration
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,6 +7,7 @@ Current product versions are represented in:
 - `src/kicad_mcp/__init__.py`
 - `src/kicad_mcp/server.json`
 - `packages/mcp-npm/package.json`
+- `packages/protocol-schemas/package.json`
 
 `.release-please-manifest.json` tracks product package paths only. The private repository root is not released.
 
@@ -28,6 +29,8 @@ The publish workflows keep release evidence product-scoped:
 - `publish-mcp-container.yml` validates the Docker image on pull requests and
   publishes signed multi-arch GHCR images with BuildKit SBOM/provenance for
   `mcp-server-v*` GitHub Releases.
+- `publish-protocol-schemas.yml` publishes `@oaslananka/kicad-protocol-schemas`
+  for `protocol-schemas-v*` GitHub Releases.
 
 Release dry-runs also validate `compatibility.yaml` through the MCP server release preflight. Update [docs/status/runtime-matrix.md](status/runtime-matrix.md) and release notes whenever KiCad, VS Code, MCP, Node, pnpm, Python, or tool-schema support changes.
 

--- a/docs/tools-reference.generated.md
+++ b/docs/tools-reference.generated.md
@@ -101,8 +101,8 @@ Total public tools: 311.
 | `lib_remove_3d_model` | agent_full, builder, full, schematic, schematic_only, simulation | no | no | no | yes | no | Remove 3D model reference(s) from a footprint. |
 | `lib_search_3d_models` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search for available 3D model files in the footprint library directory. |
 | `lib_search_components` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search live component sources for purchasable parts. This KiCad MCP Pro tool supports production EDA automation workf... |
-| `lib_search_footprints` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search footprint libraries by footprint name. This KiCad MCP Pro tool supports production EDA automation workflows fo... |
-| `lib_search_symbols` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search symbol libraries by name, description, or keywords. This KiCad MCP Pro tool supports production EDA automation... |
+| `lib_search_footprints` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search footprint libraries by footprint name. |
+| `lib_search_symbols` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search symbol libraries by name, description, or keywords. |
 | `lib_set_3d_model_path` | agent_full, builder, full, schematic, schematic_only, simulation | no | yes | no | yes | no | Set or replace the 3D model path on a footprint. |
 | `manufacturing_quality_gate` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | yes | no | no | yes | no | Evaluate manufacturing readiness against the active or requested DFM profile. |
 | `mfg_check_import_support` | agent_full, full, manufacturing | yes | no | yes | yes | no | Report whether the detected KiCad CLI advertises a given board-import format. |

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -232,8 +232,8 @@ Total public tools: 311.
 | `lib_remove_3d_model` | agent_full, builder, full, schematic, schematic_only, simulation | no | no | no | yes | no | Remove 3D model reference(s) from a footprint. |
 | `lib_search_3d_models` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search for available 3D model files in the footprint library directory. |
 | `lib_search_components` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search live component sources for purchasable parts. This KiCad MCP Pro tool supports production EDA automation workf... |
-| `lib_search_footprints` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search footprint libraries by footprint name. This KiCad MCP Pro tool supports production EDA automation workflows fo... |
-| `lib_search_symbols` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search symbol libraries by name, description, or keywords. This KiCad MCP Pro tool supports production EDA automation... |
+| `lib_search_footprints` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search footprint libraries by footprint name. |
+| `lib_search_symbols` | agent_full, builder, full, schematic, schematic_only, simulation | yes | no | no | yes | no | Search symbol libraries by name, description, or keywords. |
 | `lib_set_3d_model_path` | agent_full, builder, full, schematic, schematic_only, simulation | no | yes | no | yes | no | Set or replace the 3D model path on a footprint. |
 | `manufacturing_quality_gate` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | yes | no | no | yes | no | Evaluate manufacturing readiness against the active or requested DFM profile. |
 | `mfg_check_import_support` | agent_full, full, manufacturing | yes | no | yes | yes | no | Report whether the detected KiCad CLI advertises a given board-import format. |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,7 +58,7 @@
     },
     "packages/protocol-schemas": {
       "package-name": "@oaslananka/kicad-protocol-schemas",
-      "tag-prefix": "proto-v",
+      "tag-prefix": "protocol-schemas-v",
       "release-type": "node",
       "component": "protocol-schemas",
       "changelog-path": "CHANGELOG.md"

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -79,6 +79,30 @@ def _check_versions() -> list[str]:
     return errors
 
 
+def _check_protocol_schema_version() -> list[str]:
+    manifest = _read_repo_json(".release-please-manifest.json")
+    package = _read_repo_json("packages/protocol-schemas/package.json")
+    manifest_version = str(manifest.get("packages/protocol-schemas", ""))
+    package_version = str(package.get("version", ""))
+    errors: list[str] = []
+    if not VERSION_RE.match(manifest_version):
+        errors.append(
+            ".release-please-manifest.json packages/protocol-schemas has invalid semantic "
+            f"version: {manifest_version!r}"
+        )
+    if not VERSION_RE.match(package_version):
+        errors.append(
+            "packages/protocol-schemas/package.json has invalid semantic version: "
+            f"{package_version!r}"
+        )
+    if manifest_version != package_version:
+        errors.append(
+            "protocol schema release metadata version drift detected: "
+            f"manifest={manifest_version}, package={package_version}"
+        )
+    return errors
+
+
 def _changelog_section(changelog: str, version: str) -> str:
     matches = list(CHANGELOG_VERSION_RE.finditer(changelog))
     for index, match in enumerate(matches):
@@ -129,6 +153,7 @@ def main() -> int:
     version = _project_version()
     errors = [
         *_check_versions(),
+        *_check_protocol_schema_version(),
         *_check_changelog(version),
         *validate_compatibility_matrix(),
     ]

--- a/scripts/generate_release_evidence.py
+++ b/scripts/generate_release_evidence.py
@@ -18,7 +18,7 @@ PYPI_ENDPOINTS = {
     "pypi": "https://pypi.org/pypi/{name}/{version}/json",
     "testpypi": "https://test.pypi.org/pypi/{name}/{version}/json",
 }
-DEFAULT_PYPI_RETRIES = 6
+DEFAULT_PYPI_RETRIES = 18
 DEFAULT_PYPI_RETRY_DELAY = 10.0
 
 

--- a/tests/unit/test_benchmark_latency.py
+++ b/tests/unit/test_benchmark_latency.py
@@ -62,9 +62,14 @@ def test_tools_list_reuses_runtime_capability_probe(
 @pytest.mark.benchmark
 @pytest.mark.anyio
 async def test_tools_list_latency_against_shared_budget(
+    monkeypatch: pytest.MonkeyPatch,
     sample_project: Path,
 ) -> None:
     _ = sample_project
+    monkeypatch.setattr(
+        "kicad_mcp.server.get_ipc_capability_state",
+        _unavailable_ipc_state,
+    )
     baseline = json.loads(PERFORMANCE_CATALOG_PATH.read_text(encoding="utf-8"))["metrics"][
         TOOLS_LIST_METRIC
     ]

--- a/tests/unit/test_release_evidence.py
+++ b/tests/unit/test_release_evidence.py
@@ -117,3 +117,27 @@ def test_verify_pypi_rejects_digest_mismatch(tmp_path: Path, monkeypatch) -> Non
         assert "Published PyPI digest verification failed" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("verify_pypi should reject mismatched checksums")
+
+
+def test_verify_pypi_default_retries_cover_registry_propagation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_script()
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{'a' * 64}  artifact.whl\n", encoding="utf-8")
+    payload = b'{"urls":[{"filename":"artifact.whl","digests":{"sha256":"' + b"a" * 64 + b'"}}]}'
+    attempts = 0
+
+    def delayed_metadata(*_args: object, **_kwargs: object) -> _PypiResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 6:
+            raise module.urllib.error.HTTPError("https://pypi.example", 404, "missing", {}, None)
+        return _PypiResponse(payload)
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", delayed_metadata)
+    monkeypatch.setattr(module.time, "sleep", lambda _delay: None)
+
+    module.verify_pypi("pypi", "kicad-mcp-pro", "1.0.0", checksums)
+
+    assert attempts == 7

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _read_json(path: str) -> dict[str, object]:
+    return json.loads(_read(path))
+
+
+def test_protocol_schema_release_contract_matches_existing_release_history() -> None:
+    package = _read_json("packages/protocol-schemas/package.json")
+    manifest = _read_json(".release-please-manifest.json")
+    config = _read_json("release-please-config.json")
+    workflow = _read(".github/workflows/publish-protocol-schemas.yml")
+
+    protocol_config = config["packages"]["packages/protocol-schemas"]
+    assert manifest["packages/protocol-schemas"] == package["version"]
+    assert protocol_config["component"] == "protocol-schemas"
+    assert protocol_config["tag-prefix"] == "protocol-schemas-v"
+    assert "startsWith(github.event.release.tag_name, 'protocol-schemas-v')" in workflow
+
+
+def test_publish_workflows_are_idempotent_for_existing_versions() -> None:
+    python_workflow = _read(".github/workflows/publish-python.yml")
+    npm_workflow = _read(".github/workflows/publish-npm.yml")
+
+    assert python_workflow.count("Check if version already published") == 2
+    assert python_workflow.count("steps.check-published.outputs.already_published != 'true'") == 2
+    assert "Check if version already published" in npm_workflow
+    assert "steps.check-published.outputs.already_published != 'true'" in npm_workflow
+
+
+def test_container_publish_resolves_version_for_release_and_manual_runs() -> None:
+    workflow = _read(".github/workflows/publish-mcp-container.yml")
+
+    assert "Resolve image version" in workflow
+    assert "RELEASE_TAG: ${{ github.event.release.tag_name }}" in workflow
+    assert "type=raw,value=${{ steps.version.outputs.version }}" in workflow
+    assert "type=match,pattern=mcp-server-v(.*),group=1" not in workflow
+    assert "github.event_name == 'workflow_dispatch' && inputs.publish == true" in workflow
+    assert "KICAD_MCP_VERSION=${{ steps.version.outputs.version }}" in workflow
+    assert "VCS_REF=${{ github.sha }}" in workflow


### PR DESCRIPTION
## Summary
- repair release-please protocol schema tag/version contract
- make Python and npm recovery publishes idempotent and extend PyPI propagation verification
- fix manual/release GHCR versioning, OCI labels, and latest-tag recovery
- isolate tools/list performance benchmark from external KiCad IPC latency
- update release documentation and generated tool reference

## Verification
- `corepack pnpm run check`
- `corepack pnpm run check:workflows`
- `corepack pnpm run check:release`
- targeted release and benchmark regression tests