### PR TITLE
fix(workflows): update docs actions for Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           fetch-depth: 0  # needed for git-revision-date-localized plugin
@@ -44,7 +44,7 @@ jobs:
         run: uv run python -m mkdocs build --strict
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: site
 


### PR DESCRIPTION
## Summary
- update Docs checkout action from Node 20-era v4.2.2 to the repository-standard Node 24 checkout pin
- update upload-pages-artifact to v5 so Pages deploys no longer rely on the deprecated Node 20 artifact action

## Verification
- `corepack pnpm run check:workflows`