### PR TITLE
ci: fix release-please grouped title pattern and docs strict link

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -16,7 +16,8 @@ This page is the authoritative catalog of those codes. It is kept in sync with
 - **retry_after_ms** — suggested backoff before retrying a transient error.
 
 See the `error_recovery` workflow prompt for the agent retry rule, and
-[`ARCHITECTURE.md`](../ARCHITECTURE.md) for where errors are defined.
+[`ARCHITECTURE.md`](https://github.com/oaslananka/kicad-mcp/blob/main/ARCHITECTURE.md)
+for where errors are defined.
 
 ## Codes
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": true,
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore(${scope}): release ${version}",
+  "group-pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "plugins": [
     {
       "type": "linked-versions",


### PR DESCRIPTION
Unblocks the release pipeline. release-please's group-pull-request-title-pattern was missing `${component}`, so it rejected the title and never cut a release PR (version stuck at 3.9.2 despite merged feat: commits). Restores the documented default pattern. Also fixes the docs/errors.md → ARCHITECTURE.md link that broke `mkdocs build --strict` (root file outside docs_dir). Both verified locally.