### PR TITLE
ci: single-source every version reference so releases bump cleanly

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,12 +18,17 @@ jobs:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
+      # A PAT (RELEASE_PLEASE_TOKEN) is used so that the release PR and the follow-up
+      # metadata-sync commit trigger CI -- commits/PRs created with the default
+      # GITHUB_TOKEN do not start new workflow runs. Falls back to GITHUB_TOKEN when the
+      # PAT is not configured (the release PR is still created, but its checks must be
+      # re-triggered manually).
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       # release-please bumps the bare version fields, but server.json / mcp.json embed
       # the version inside the OCI image identifier (ghcr.io/...:X.Y.Z), which its JSON
@@ -34,7 +39,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - if: ${{ steps.release.outputs.pr }}
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       - if: ${{ steps.release.outputs.pr }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ KiCad's programmatic surface the server drives is tracked openly in the
 | PyPI package | [`kicad-mcp-pro`](https://pypi.org/project/kicad-mcp-pro/) |
 | npm wrapper | [`kicad-mcp-pro`](https://www.npmjs.com/package/kicad-mcp-pro) |
 | MCP Registry name | `io.github.oaslananka/kicad-mcp-pro` |
-| Version | `3.9.2` |
+| Version | `3.9.2` | <!-- x-release-please-version -->
 
 ## Quick Start
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,6 +46,15 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "compatibility.yaml",
+          "jsonpath": "$.products.kicad-mcp-pro.version"
+        },
+        {
+          "type": "generic",
+          "path": "README.md"
         }
       ]
     },

--- a/src/kicad_mcp/compatibility.py
+++ b/src/kicad_mcp/compatibility.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Final
 
+from . import __version__
+
 MCP_PROTOCOL_VERSION: Final = "2025-11-25"
 MCP_TOOL_SCHEMA_VERSION: Final = "1.0"
 PRIMARY_KICAD_VERSION: Final = "10.0.x"
@@ -30,7 +32,7 @@ COMPATIBILITY_MATRIX: Final[dict[str, object]] = {
             },
         },
         "kicad-mcp-pro": {
-            "version": "3.9.2",
+            "version": __version__,
             "compatibleExtension": {
                 "required": ">=1.0.0 <2.0.0",
                 "testedAgainst": "1.0.0",

--- a/src/kicad_mcp/web/dashboard.py
+++ b/src/kicad_mcp/web/dashboard.py
@@ -8,6 +8,8 @@ Single-file single-page application with hash-routed views:
 - #setup-wizard - 4-step setup wizard
 """
 
+from .. import __version__
+
 DASHBOARD_HTML = r"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1114,5 +1116,5 @@ connectSSE();
 </body>
 </html>"""
 
-# Replace version template on import
-DASHBOARD_HTML = DASHBOARD_HTML.replace("{{version}}", "3.9.2")
+# Replace version template on import (derived from the package version, not hardcoded)
+DASHBOARD_HTML = DASHBOARD_HTML.replace("{{version}}", __version__)

--- a/tests/e2e/test_web_dashboard.py
+++ b/tests/e2e/test_web_dashboard.py
@@ -21,6 +21,7 @@ from typing import Any
 import pytest
 from playwright.sync_api import Page, Route
 
+from kicad_mcp import __version__
 from kicad_mcp.web.dashboard import DASHBOARD_HTML  # type: ignore[attr-defined]
 
 pytestmark = [
@@ -75,7 +76,7 @@ MOCK_METRICS: dict[str, Any] = {
 MOCK_HEALTH: dict[str, Any] = {
     "ok": True,
     "status": "healthy",
-    "version": "3.9.2",
+    "version": __version__,
     "uptime": 3600,
 }
 
@@ -301,7 +302,7 @@ class TestDashboardSPA:
         """The SPA loads and shows the dashboard view by default."""
         page.goto(dashboard_url)
         page.wait_for_selector("#navVersion")
-        assert page.text_content("#navVersion") == "v3.9.2"
+        assert page.text_content("#navVersion") == f"v{__version__}"
         assert page.is_visible("#view-dashboard")
         classes = page.get_attribute("#view-dashboard", "class") or ""
         assert "active" in classes

--- a/tests/unit/test_web_routes.py
+++ b/tests/unit/test_web_routes.py
@@ -16,6 +16,8 @@ SRC = Path(__file__).resolve().parents[2] / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from kicad_mcp import __version__  # noqa: E402  (after sys.path bootstrap above)
+
 if TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -114,7 +116,7 @@ class TestWebModule:
         assert "refreshStatus" in DASHBOARD_HTML
         assert "connectSSE" in DASHBOARD_HTML
         assert "setLogFilter" in DASHBOARD_HTML
-        assert "3.9.2" in DASHBOARD_HTML
+        assert __version__ in DASHBOARD_HTML
 
 
 # ---------------------------------------------------------------------------
@@ -250,7 +252,7 @@ class TestAPIEndpoints:
         response = await api_status(request)
         data = json.loads(response.body)
 
-        assert data["server"]["version"] == "3.9.2"
+        assert data["server"]["version"] == __version__
         assert data["health"]["ok"] is True
         assert data["health"]["status"] == "ok"
         assert "kicad" in data
@@ -269,7 +271,7 @@ class TestAPIEndpoints:
 
         assert data["ok"] is True
         assert data["status"] == "ok"
-        assert data["version"] == "3.9.2"
+        assert data["version"] == __version__
         assert "uptime" in data
 
     @pytest.mark.anyio
@@ -282,7 +284,7 @@ class TestAPIEndpoints:
         data = json.loads(response.body)
 
         assert data["name"] == "KiCad MCP Pro"
-        assert data["version"] == "3.9.2"
+        assert data["version"] == __version__
         assert "python" in data
         assert "platform" in data
         assert "config" in data
@@ -345,7 +347,7 @@ class TestDashboardHTML:
         from kicad_mcp.web.dashboard import DASHBOARD_HTML
 
         assert "{{version}}" not in DASHBOARD_HTML
-        assert "3.9.2" in DASHBOARD_HTML
+        assert __version__ in DASHBOARD_HTML
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +380,7 @@ class TestRouteRegistration:
         response = client.get("/api/status")
         assert response.status_code == 200
         data = response.json()
-        assert data["server"]["version"] == "3.9.2"
+        assert data["server"]["version"] == __version__
 
     def test_health_via_test_client(self) -> None:
         """Test that /api/health responds via TestClient."""


### PR DESCRIPTION
Fixes the remaining release-automation gaps that made every release PR red (web/compat/readme version-drift). Runtime code + tests now derive from `__version__`; release-please also bumps compatibility.yaml + the README version line; and release-please uses a PAT (RELEASE_PLEASE_TOKEN, GITHUB_TOKEN fallback) so its PR and the metadata-sync commit trigger CI. Verified by simulating a 3.10.0 bump and running the full backend suite (1296 passed). **Action required to finish automation:** add a repo secret `RELEASE_PLEASE_TOKEN` (a fine-grained PAT with Contents: write + Pull requests: write on this repo).