### PR TITLE
fix: discover libraries via sym-/fp-lib-table (#78)

### DIFF
--- a/src/kicad_mcp/tools/library.py
+++ b/src/kicad_mcp/tools/library.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import threading
 from pathlib import Path
@@ -42,10 +43,99 @@ def _footprint_library_dir() -> Path:
     return cfg.footprint_library_dir
 
 
+def _resolve_kicad_env(uri: str, project_dir: Path | None) -> str:
+    """Substitute KiCad library-table variables (``${KIPRJMOD}``, ``${ENV}``) in a URI."""
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name == "KIPRJMOD" and project_dir is not None:
+            return str(project_dir)
+        return os.environ.get(name, match.group(0))
+
+    return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", _sub, uri)
+
+
+def _parse_lib_table(path: Path, project_dir: Path | None) -> dict[str, Path]:
+    """Parse a KiCad sym-/fp-lib-table, returning ``{nickname: resolved_path}``.
+
+    Only ``KiCad``-type entries are returned (legacy/other plugin types are skipped),
+    with ``${KIPRJMOD}`` and environment-variable references resolved.
+    """
+    libs: dict[str, Path] = {}
+    try:
+        content = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return libs
+    # Split into one chunk per (lib ...) entry; nested parens make a single regex for the
+    # whole entry unreliable, so parse name/type/uri within each chunk.
+    for chunk in re.split(r"\(lib\b", content)[1:]:
+        name = re.search(r'\(name\s+"?([^")\s]+)"?\)', chunk)
+        type_ = re.search(r'\(type\s+"?([^")\s]+)"?\)', chunk)
+        uri = re.search(r'\(uri\s+"([^"]+)"\)', chunk)
+        if not (name and uri):
+            continue
+        if type_ and type_.group(1).lower() != "kicad":
+            continue
+        resolved = Path(_resolve_kicad_env(uri.group(1), project_dir))
+        if resolved.exists():
+            libs[name.group(1)] = resolved
+    return libs
+
+
+def _lib_table_paths(table_name: str, project_dir: Path | None) -> list[Path]:
+    """Locate the project-level then global KiCad library tables of ``table_name``."""
+    paths: list[Path] = []
+    if project_dir is not None:
+        candidate = project_dir / table_name
+        if candidate.exists():
+            paths.append(candidate)
+    config_roots = [
+        os.environ.get("APPDATA"),
+        os.path.expanduser("~/.config"),
+        os.path.expanduser("~/Library/Preferences"),
+    ]
+    for root in config_roots:
+        if not root:
+            continue
+        kicad_root = Path(root) / "kicad"
+        if not kicad_root.is_dir():
+            continue
+        for version_dir in sorted(kicad_root.glob("*")):
+            candidate = version_dir / table_name
+            if candidate.exists():
+                paths.append(candidate)
+    return paths
+
+
+def _project_dir() -> Path | None:
+    cfg = get_config()
+    if cfg.project_file is not None:
+        return cfg.project_file.parent
+    return None
+
+
+def _symbol_library_files() -> dict[str, Path]:
+    """Map every discoverable symbol-library nickname to its ``.kicad_sym`` file.
+
+    Combines the configured single directory with the project and global
+    ``sym-lib-table`` entries (work order / issue #78), so libraries registered through
+    KiCad's library tables are discovered, not just one flat directory.
+    """
+    files: dict[str, Path] = {}
+    cfg = get_config()
+    if cfg.symbol_library_dir is not None and cfg.symbol_library_dir.exists():
+        for sym_file in sorted(cfg.symbol_library_dir.glob("*.kicad_sym")):
+            files.setdefault(sym_file.stem, sym_file)
+    project_dir = _project_dir()
+    for table in _lib_table_paths("sym-lib-table", project_dir):
+        for nickname, sym_path in _parse_lib_table(table, project_dir).items():
+            files.setdefault(nickname, sym_path)
+    return files
+
+
 def _build_symbol_index() -> dict[str, dict[str, str]]:
     index: dict[str, dict[str, str]] = {}
-    for sym_file in _symbol_library_dir().glob("*.kicad_sym"):
-        library = sym_file.stem
+    for library, sym_file in _symbol_library_files().items():
         try:
             content = sym_file.read_text(encoding="utf-8", errors="ignore")
         except OSError:
@@ -84,14 +174,35 @@ def _get_symbol_index() -> dict[str, dict[str, str]]:
 
 
 def _read_symbol_file(library: str) -> str | None:
-    path = _symbol_library_dir() / f"{library}.kicad_sym"
-    if not path.exists():
+    path = _symbol_library_files().get(library)
+    if path is None or not path.exists():
         return None
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
+def _footprint_library_dirs() -> dict[str, Path]:
+    """Map every discoverable footprint-library nickname to its ``.pretty`` directory.
+
+    Combines the configured directory with project and global ``fp-lib-table`` entries
+    (issue #78), so footprint libraries registered through KiCad's library tables resolve.
+    """
+    dirs: dict[str, Path] = {}
+    cfg = get_config()
+    if cfg.footprint_library_dir is not None and cfg.footprint_library_dir.exists():
+        for pretty in sorted(cfg.footprint_library_dir.glob("*.pretty")):
+            dirs.setdefault(pretty.stem, pretty)
+    project_dir = _project_dir()
+    for table in _lib_table_paths("fp-lib-table", project_dir):
+        for nickname, pretty_path in _parse_lib_table(table, project_dir).items():
+            dirs.setdefault(nickname, pretty_path)
+    return dirs
+
+
 def _footprint_file(library: str, footprint: str) -> Path:
-    return _footprint_library_dir() / f"{library}.pretty" / f"{footprint}.kicad_mod"
+    pretty_dir = _footprint_library_dirs().get(library)
+    if pretty_dir is None:
+        pretty_dir = _footprint_library_dir() / f"{library}.pretty"
+    return pretty_dir / f"{footprint}.kicad_mod"
 
 
 def _component_search_client(source: str) -> ComponentSearchClient:

--- a/tests/unit/test_library_discovery.py
+++ b/tests/unit/test_library_discovery.py
@@ -1,0 +1,50 @@
+"""KiCad library-table (sym-lib-table / fp-lib-table) discovery (issue #78)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.tools.library import _parse_lib_table, _resolve_kicad_env
+
+
+def test_resolve_kicad_env_substitutes_kiprjmod_and_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_dir = tmp_path / "proj"
+    assert _resolve_kicad_env("${KIPRJMOD}/libs/X.kicad_sym", project_dir) == (
+        f"{project_dir}/libs/X.kicad_sym"
+    )
+    monkeypatch.setenv("MY_LIB_DIR", "/opt/libs")
+    assert _resolve_kicad_env("${MY_LIB_DIR}/X.kicad_sym", None) == "/opt/libs/X.kicad_sym"
+    # An unknown variable is left untouched rather than expanded to empty.
+    assert _resolve_kicad_env("${UNKNOWN_VAR_XYZ}/x", None) == "${UNKNOWN_VAR_XYZ}/x"
+
+
+def test_parse_lib_table_resolves_kiprjmod_and_skips_non_kicad(tmp_path: Path) -> None:
+    lib_dir = tmp_path / "libs"
+    lib_dir.mkdir()
+    sym = lib_dir / "ProjLib.kicad_sym"
+    sym.write_text('(kicad_symbol_lib (symbol "R"))', encoding="utf-8")
+
+    table = tmp_path / "sym-lib-table"
+    table.write_text(
+        "(sym_lib_table\n"
+        '  (lib (name "ProjLib")(type "KiCad")'
+        '(uri "${KIPRJMOD}/libs/ProjLib.kicad_sym")(options "")(descr ""))\n'
+        '  (lib (name "Legacy")(type "Legacy")'
+        '(uri "${KIPRJMOD}/libs/old.lib")(options "")(descr ""))\n'
+        '  (lib (name "Missing")(type "KiCad")'
+        '(uri "${KIPRJMOD}/libs/nope.kicad_sym")(options "")(descr ""))\n'
+        ")",
+        encoding="utf-8",
+    )
+
+    libs = _parse_lib_table(table, tmp_path)
+    # KIPRJMOD-resolved KiCad lib is found; the Legacy type and the missing file are skipped.
+    assert libs == {"ProjLib": sym}
+
+
+def test_parse_lib_table_handles_unreadable_table(tmp_path: Path) -> None:
+    assert _parse_lib_table(tmp_path / "does-not-exist", tmp_path) == {}


### PR DESCRIPTION
Closes #78. Library discovery was single-directory; it now also parses the project and global `sym-lib-table` / `fp-lib-table`, resolving `${KIPRJMOD}` and environment variables, and folds those libraries into symbol-index/symbol-read/footprint resolution. Additive (configured dir keeps precedence), non-KiCad entries skipped. Unit tests cover env resolution and table parsing; 77 existing library tests still pass.