### PR TITLE
fix: correct Specctra SES coordinate scale (router_core)

### DIFF
--- a/src/kicad_mcp/utils/router_core.py
+++ b/src/kicad_mcp/utils/router_core.py
@@ -67,9 +67,17 @@ class SesRoute:
 
 
 def _units_per_mm(unit: str, factor: float) -> float:
-    """Convert a Specctra ``(resolution unit factor)`` to resolution units per millimetre."""
+    """Resolution units per millimetre for a Specctra ``(resolution unit factor)``.
+
+    KiCad's Specctra export writes coordinates in the base ``unit`` itself (verified: with
+    ``(resolution um 10)`` a part at 2.5 mm exports as ``2500`` -> micrometres, 1 mm = 1000
+    units). The ``factor`` is KiCad's resolution-grid declaration, not a coordinate
+    multiplier, so it is not applied to the magnitude. FreeRouting echoes the same
+    convention in the .ses it returns.
+    """
+    _ = factor
     per_unit = {"um": 1000.0, "mm": 1.0, "inch": 1.0 / 25.4, "mil": 1000.0 / 25.4}
-    return factor * per_unit.get(unit.lower(), 1000.0)
+    return per_unit.get(unit.lower(), 1000.0)
 
 
 def _to_mm(value: float, units_per_mm: float, *, flip: bool = False) -> float:

--- a/tests/integration/test_routing_tools.py
+++ b/tests/integration/test_routing_tools.py
@@ -198,8 +198,8 @@ async def test_route_apply_ses_applies_routing_headlessly(sample_project: Path) 
     ses.parent.mkdir(parents=True, exist_ok=True)
     ses.write_text(
         "(session t.dsn (routes (resolution um 10) (network_out "
-        '(net "GND" (wire (path F.Cu 250 100000 50000 110000 50000)) '
-        '(via "Via[0-1]_600:300_um" 110000 50000)))))',
+        '(net "GND" (wire (path F.Cu 250 2500 -5000 11000 -5000)) '
+        '(via "Via[0-1]_600:300_um" 11000 -5000)))))',
         encoding="utf-8",
     )
     server = build_server("pcb")
@@ -217,7 +217,7 @@ async def test_route_apply_ses_applies_routing_headlessly(sample_project: Path) 
     # The routed segment + via are now in the board, mapped to net 1 (GND).
     text = pcb.read_text(encoding="utf-8")
     assert '(layer "F.Cu") (net 1)' in text
-    assert "(via (at 11 -5)" in text
+    assert "(via (at 11 5)" in text
     # The original net table is preserved (round-trip safe).
     assert '(net 1 "GND")' in text and "(version 20250216)" in text
 

--- a/tests/unit/test_router_core.py
+++ b/tests/unit/test_router_core.py
@@ -9,17 +9,19 @@ from kicad_mcp.utils.router_core import (
     render_pcb_items,
 )
 
+# KiCad's Specctra convention: 1 mm = 1000 units (um), board Y is negated in the session
+# (board y=5 mm -> -5000). The applier scales by 1000 and un-flips Y back to board mm.
 _SES = """(session test.dsn
   (routes
     (resolution um 10)
     (network_out
       (net "GND"
-        (wire (path F.Cu 250 100000 50000 110000 50000) (type protect))
-        (wire (path B.Cu 250 110000 50000 110000 60000))
-        (via "Via[0-1]_600:300_um" 110000 50000)
+        (wire (path F.Cu 250 2500 -5000 11000 -5000) (type protect))
+        (wire (path B.Cu 250 11000 -5000 11000 -6000))
+        (via "Via[0-1]_600:300_um" 11000 -5000)
       )
       (net "VCC"
-        (wire (path "F.Cu" 200 200000 200000 250000 200000))
+        (wire (path "F.Cu" 200 20000 -20000 25000 -20000))
       )
     )
   )
@@ -30,18 +32,18 @@ _PCB = '(kicad_pcb\n\t(version 20250216)\n\t(net 0 "")\n\t(net 1 "GND")\n\t(net 
 
 def test_parse_ses_scales_and_unflips_coordinates() -> None:
     route = parse_ses(_SES)
-    assert route.units_per_mm == 10000.0  # (resolution um 10) -> 10 * 1000
+    assert route.units_per_mm == 1000.0  # (resolution um 10) -> coords are micrometres
     assert len(route.segments) == 3
     assert len(route.vias) == 1
 
     gnd_f = next(s for s in route.segments if s.net_name == "GND" and s.layer == "F.Cu")
-    # 100000 units / 10000 = 10 mm; Specctra Y is up, KiCad Y is down -> 50000 -> -5 mm.
-    assert gnd_f.start == (10.0, -5.0)
-    assert gnd_f.end == (11.0, -5.0)
-    assert gnd_f.width_mm == 0.025  # 250 units / 10000
+    # 2500 units / 1000 = 2.5 mm; session Y is negated, so -5000 -> +5.0 mm board Y.
+    assert gnd_f.start == (2.5, 5.0)
+    assert gnd_f.end == (11.0, 5.0)
+    assert gnd_f.width_mm == 0.25  # 250 units / 1000
 
     via = route.vias[0]
-    assert via.at == (11.0, -5.0)
+    assert via.at == (11.0, 5.0)
     # Padstack Via[0-1]_600:300_um -> 0.6 mm size, 0.3 mm drill.
     assert via.size_mm == 0.6
     assert via.drill_mm == 0.3
@@ -67,7 +69,7 @@ def test_apply_ses_is_deterministic_and_round_trip_safe() -> None:
     # Net names are mapped to numbers; GND -> 1, VCC -> 2.
     assert '(layer "F.Cu") (net 1)' in out_a  # GND segment
     assert '(layer "F.Cu") (net 2)' in out_a  # VCC segment
-    assert '(via (at 11 -5) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1)' in out_a
+    assert '(via (at 11 5) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1)' in out_a
     # Three segments + one via were added.
     assert out_a.count("(segment ") == 3
     assert out_a.count("(via ") == 1


### PR DESCRIPTION
Follow-up to #91. Validating router_core's transform against a **real KiCad 10 Specctra DSN** (`pcbnew.ExportSpecctraDSN`) revealed the scale was 10x off: with `(resolution um 10)` KiCad writes coordinates in micrometres (board 2.5 mm -> 2500, Y negated, no offset), i.e. 1 mm = 1000 units. The code had multiplied by the resolution factor (10), so all track coords, widths, and via positions were 10x too small. The factor is KiCad's resolution-grid declaration, not a coordinate multiplier. Y-flip / no-offset re-confirmed by the same export. Tests updated to the real convention.