### PR TITLE
chore: land in-flight work-order docs + test-point/ci fixes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,8 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - if: ${{ steps.release.outputs.pr }}
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: false
       - if: ${{ steps.release.outputs.pr }}
         name: Sync version-derived MCP metadata onto the release PR
         run: |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ automated sign-off authority. ERC/DRC and the export pipeline drive KiCad's own
 engines. The signal-integrity, power-integrity, EMC, and thermal tools are
 **first-order, closed-form estimates** (typically ~5–10% accuracy) — fast first-pass
 review, **not** a substitute for a 2D/3D field solver, EM/FEA simulation, or formal
-sign-off. Live component sourcing uses the JLCPCB public catalog by default; Nexar and
-DigiKey are available only when their API credentials are configured. What fraction of
-KiCad's programmatic surface the server drives is tracked openly in the
+sign-off. Live component sourcing uses the JLCPCB public catalog by default; Nexar,
+DigiKey, and Mouser are available only when their API credentials are configured. What
+fraction of KiCad's programmatic surface the server drives is tracked openly in the
 [capability-parity matrix](docs/compatibility/capability-parity.generated.md).
 
 ## Project identity
@@ -90,9 +90,10 @@ The documentation is organized from setup to operation:
 7. [Security and privacy](docs/security/threat-model.md)
 8. [KiCad capability parity](docs/compatibility/capability-parity.generated.md) — how much of KiCad's programmatic surface this server drives
 9. [Error code catalog](docs/errors.md) — stable error codes, retry classes, and recovery
+10. [Work-order audit](docs/status/work-order-audit-2026-06-17.md) — current status of the hardening work order
 
 The `kicad_capability_parity()` tool reports, per workflow domain, what fraction of
-KiCad's programmatically reachable surface this server can drive (currently **77%**),
+KiCad's programmatically reachable surface this server can drive (currently **75.0%**),
 keeping genuine `gap`s distinct from `gui-only-no-api` items that KiCad exposes no
 headless API for.
 

--- a/docs/compatibility/capability-parity-matrix.yaml
+++ b/docs/compatibility/capability-parity-matrix.yaml
@@ -27,12 +27,12 @@
 # Coverage % per domain (and overall) = covered / (total - gui_only_no_api).
 
 schemaVersion: 1
-updated: "2026-06-16"
+updated: "2026-06-17"
 kicad_baseline: "10.0.x"
 
 status_vocabulary:
   covered: "A registered MCP tool fully drives this capability."
-  partial: "Some MCP support exists but with a tracked limitation (heuristic estimate, stubbed dependency, hidden/orphaned tool, or a manual KiCad step)."
+  partial: "Some MCP support exists but with a tracked limitation (heuristic estimate, optional/auth-gated dependency, hidden/orphaned tool, or a manual KiCad step)."
   gap: "KiCad exposes this programmatically (cli/ipc/file) but no MCP tool drives it yet."
   gui-only-no-api: "KiCad only offers this interactively; no cli/ipc/file path exists. Excluded from the coverage denominator (a KiCad API limit, not ours)."
 
@@ -199,7 +199,7 @@ domains:
         mcp_tool: pcb_auto_place_by_schematic
         status: partial
         kicad_version_introduced: "10.0.x"
-        notes: "Force-directed placement (pcb_auto_place_force_directed) is non-deterministic under a wall-clock cap (work order K7); deterministic placement is Phase 4 (P4-T2)."
+        notes: "Force-directed placement now stops by deterministic convergence and disables the wall-clock safety valve by default (K7); remaining P4-T2 work is deeper electrical/thermal/return-path scoring beyond net-weighted placement."
       - capability: "Run DRC and inspect violations"
         kicad_channel: cli
         mcp_tool: run_drc
@@ -263,13 +263,13 @@ domains:
         mcp_tool: route_autoroute_freerouting
         status: partial
         kicad_version_introduced: "10.0.x"
-        notes: "Routes headlessly (Docker/JAR); applying the routed SES is a manual KiCad GUI step (no headless SES import) surfaced via human_gate_required (P1-T7). Full headless flow is Phase 4 (P4-T1)."
+        notes: "Routes headlessly (Docker/JAR); the routed SES is now applied headlessly by route_apply_ses (utils/router_core writes segments/vias into the .kicad_pcb), closing the former GUI step (P4-T1). Status stays partial: FreeRouting's own determinism is bounded and the SES coordinate transform assumes KiCad's standard Specctra export convention (verified end-to-end only in the KiCad CI job)."
       - capability: "Export Specctra DSN / import routed SES"
         kicad_channel: cli
         mcp_tool: route_export_dsn
         status: partial
         kicad_version_introduced: "10.0.x"
-        notes: "route_export_dsn attempts headless kicad-cli specctra export, else returns a clear human-gated manual-step result; route_import_ses stages and surfaces the GUI import step (P1-T7, K1)."
+        notes: "route_export_dsn attempts headless kicad-cli specctra export, else a clear human-gated manual step; the routed SES is applied fully headlessly by route_apply_ses (deterministic, idempotent, round-trip-safe via utils/router_core, P4-T1) -- no GUI import. Export side stays partial when kicad-cli lacks headless specctra export."
       - capability: "Set per-net-class routing rules"
         kicad_channel: file
         mcp_tool: route_set_net_class_rules
@@ -321,7 +321,7 @@ domains:
         mcp_tool: lib_search_components
         status: partial
         kicad_version_introduced: "10.0.x"
-        notes: "Distributor clients (Nexar/DigiKey) are stubs requiring authenticated deployment (work order K10); real APIs land in Phase 4 (P4-T3)."
+        notes: "Live JLCPCB, Nexar, DigiKey, and Mouser sourcing clients are implemented; Nexar/DigiKey/Mouser are opt-in and auth-gated. Remaining P4-T3 work is full AVL/lifecycle policy enforcement and datasheet-grounded footprint/3D hard gates."
       - capability: "Recommend / bind a part to a symbol"
         kicad_channel: file
         mcp_tool: lib_recommend_part

--- a/docs/compatibility/capability-parity.generated.md
+++ b/docs/compatibility/capability-parity.generated.md
@@ -2,7 +2,7 @@
 
 Machine-generated from `docs/compatibility/capability-parity-matrix.yaml`. Refresh with `uv run python scripts/build_parity_matrix.py`.
 
-KiCad baseline: `10.0.x` · Updated: 2026-06-16
+KiCad baseline: `10.0.x` · Updated: 2026-06-17
 
 **Overall: 57 / 76 programmatically-reachable capabilities driven = 75.0%** (17 partial, 2 gap; 4 GUI-only with no KiCad API, excluded from the denominator).
 
@@ -37,10 +37,10 @@ KiCad baseline: `10.0.x` · Updated: 2026-06-16
 | `analysis` | Thermal via / copper-pour sizing | `partial` | `file` | `thermal_calculate_via_count` | thermal_check_copper_pour; first-order theta_JA / via-count rule of thumb labeled honestly via the solver seam (utils/solver_seams.thermal_method); for distributed spreading use thermal_simulate_plane_spreading. |
 | `library` | Generate an IPC-7351 footprint | `partial` | `file` | `lib_generate_footprint_ipc7351` | Footprint family coverage is limited (work order K10: SOT-23 implemented, SOT-223/SOT-89 not yet); datasheet/IPC validation hard-gate is Phase 4 (P4-T3). |
 | `library` | Recommend / bind a part to a symbol | `partial` | `file` | `lib_recommend_part` | lib_bind_part_to_symbol; depends on the same sourcing backends as above. |
-| `library` | Source live component data (price/stock/lifecycle) | `partial` | `file` | `lib_search_components` | Distributor clients (Nexar/DigiKey) are stubs requiring authenticated deployment (work order K10); real APIs land in Phase 4 (P4-T3). |
-| `pcb_edit` | Auto-place footprints from schematic | `partial` | `ipc` | `pcb_auto_place_by_schematic` | Force-directed placement (pcb_auto_place_force_directed) is non-deterministic under a wall-clock cap (work order K7); deterministic placement is Phase 4 (P4-T2). |
-| `routing` | Export Specctra DSN / import routed SES | `partial` | `cli` | `route_export_dsn` | route_export_dsn attempts headless kicad-cli specctra export, else returns a clear human-gated manual-step result; route_import_ses stages and surfaces the GUI import step (P1-T7, K1). |
-| `routing` | Full autoroute (FreeRouting orchestration) | `partial` | `cli` | `route_autoroute_freerouting` | Routes headlessly (Docker/JAR); applying the routed SES is a manual KiCad GUI step (no headless SES import) surfaced via human_gate_required (P1-T7). Full headless flow is Phase 4 (P4-T1). |
+| `library` | Source live component data (price/stock/lifecycle) | `partial` | `file` | `lib_search_components` | Live JLCPCB, Nexar, DigiKey, and Mouser sourcing clients are implemented; Nexar/DigiKey/Mouser are opt-in and auth-gated. Remaining P4-T3 work is full AVL/lifecycle policy enforcement and datasheet-grounded footprint/3D hard gates. |
+| `pcb_edit` | Auto-place footprints from schematic | `partial` | `ipc` | `pcb_auto_place_by_schematic` | Force-directed placement now stops by deterministic convergence and disables the wall-clock safety valve by default (K7); remaining P4-T2 work is deeper electrical/thermal/return-path scoring beyond net-weighted placement. |
+| `routing` | Export Specctra DSN / import routed SES | `partial` | `cli` | `route_export_dsn` | route_export_dsn attempts headless kicad-cli specctra export, else a clear human-gated manual step; the routed SES is applied fully headlessly by route_apply_ses (deterministic, idempotent, round-trip-safe via utils/router_core, P4-T1) -- no GUI import. Export side stays partial when kicad-cli lacks headless specctra export. |
+| `routing` | Full autoroute (FreeRouting orchestration) | `partial` | `cli` | `route_autoroute_freerouting` | Routes headlessly (Docker/JAR); the routed SES is now applied headlessly by route_apply_ses (utils/router_core writes segments/vias into the .kicad_pcb), closing the former GUI step (P4-T1). Status stays partial: FreeRouting's own determinism is bounded and the SES coordinate transform assumes KiCad's standard Specctra export convention (verified end-to-end only in the KiCad CI job). |
 | `schematic_edit` | Modify a symbol property by reference | `partial` | `ipc` | `sch_modify_property` | Round-trip-safe edit primitive (utils/schematic_roundtrip) with a corruption guard exists (P2-T1); testing showed kicad-sch-api 0.5.x drops global_label on save, so writes refuse+restore rather than silently corrupt (K5). Migrating each regex write path through the guarded primitive is incremental. |
 | `schematic_edit` | Swap pins / gates | `partial` | `file` | `sch_swap_pins` | Experimental; sch_swap_gates is also experimental and profile-gated. |
 
@@ -83,7 +83,7 @@ Footprint place/move, track/via/zone/stackup/rules/groups/teardrops/fanout on .k
 | Add teardrops | `ipc` | `pcb_add_teardrops` | `covered` | 10.0.x |  |
 | BGA / fine-pitch fanout | `ipc` | `pcb_bga_fanout` | `covered` | 10.0.x |  |
 | Set the board outline | `ipc` | `pcb_set_board_outline` | `covered` | 10.0.x |  |
-| Auto-place footprints from schematic | `ipc` | `pcb_auto_place_by_schematic` | `partial` | 10.0.x | Force-directed placement (pcb_auto_place_force_directed) is non-deterministic under a wall-clock cap (work order K7); deterministic placement is Phase 4 (P4-T2). |
+| Auto-place footprints from schematic | `ipc` | `pcb_auto_place_by_schematic` | `partial` | 10.0.x | Force-directed placement now stops by deterministic convergence and disables the wall-clock safety valve by default (K7); remaining P4-T2 work is deeper electrical/thermal/return-path scoring beyond net-weighted placement. |
 | Run DRC and inspect violations | `cli` | `run_drc` | `covered` | 10.0.x | drc_add_exclusion / drc_validate_exclusions manage waivers. |
 | Manage design blocks / reusable groups | `file` | `pcb_block_create_from_selection` | `covered` | 10.0.x | pcb_block_list, pcb_block_place. |
 | Read / set board groups | `ipc` | `pcb_get_groups` | `covered` | 10.0.x | pcb_get_groups for inspection; pcb_group_by_function and pcb_block_* for grouping. |
@@ -100,8 +100,8 @@ Autoroute, length/skew tuning, diff-pair, and interactive routing.
 | Route a single track / pad-to-pad | `ipc` | `route_single_track` | `covered` | 10.0.x | route_from_pad_to_pad. |
 | Route a differential pair | `ipc` | `route_differential_pair` | `covered` | 10.0.x |  |
 | Tune track / diff-pair length | `file` | `route_tune_length` | `covered` | 10.0.x | tune_diff_pair_length, route_tune_time_domain, tuning-profile tools. |
-| Full autoroute (FreeRouting orchestration) | `cli` | `route_autoroute_freerouting` | `partial` | 10.0.x | Routes headlessly (Docker/JAR); applying the routed SES is a manual KiCad GUI step (no headless SES import) surfaced via human_gate_required (P1-T7). Full headless flow is Phase 4 (P4-T1). |
-| Export Specctra DSN / import routed SES | `cli` | `route_export_dsn` | `partial` | 10.0.x | route_export_dsn attempts headless kicad-cli specctra export, else returns a clear human-gated manual-step result; route_import_ses stages and surfaces the GUI import step (P1-T7, K1). |
+| Full autoroute (FreeRouting orchestration) | `cli` | `route_autoroute_freerouting` | `partial` | 10.0.x | Routes headlessly (Docker/JAR); the routed SES is now applied headlessly by route_apply_ses (utils/router_core writes segments/vias into the .kicad_pcb), closing the former GUI step (P4-T1). Status stays partial: FreeRouting's own determinism is bounded and the SES coordinate transform assumes KiCad's standard Specctra export convention (verified end-to-end only in the KiCad CI job). |
+| Export Specctra DSN / import routed SES | `cli` | `route_export_dsn` | `partial` | 10.0.x | route_export_dsn attempts headless kicad-cli specctra export, else a clear human-gated manual step; the routed SES is applied fully headlessly by route_apply_ses (deterministic, idempotent, round-trip-safe via utils/router_core, P4-T1) -- no GUI import. Export side stays partial when kicad-cli lacks headless specctra export. |
 | Set per-net-class routing rules | `file` | `route_set_net_class_rules` | `covered` | 10.0.x |  |
 | Interactive length tuning / meander drawing | `gui-only` | — | `gui-only-no-api` | 10.0.x | Interactive trace tuning UX is GUI-only; programmatic tuning is modeled by route_tune_length. |
 
@@ -116,7 +116,7 @@ Symbol/footprint/3D generation + assignment + part sourcing.
 | Create a custom symbol | `file` | `lib_create_custom_symbol` | `covered` | 10.0.x | lib_generate_symbol_from_pintable for pin-table-driven generation. |
 | Generate an IPC-7351 footprint | `file` | `lib_generate_footprint_ipc7351` | `partial` | 10.0.x | Footprint family coverage is limited (work order K10: SOT-23 implemented, SOT-223/SOT-89 not yet); datasheet/IPC validation hard-gate is Phase 4 (P4-T3). |
 | Assign / manage 3D models | `file` | `lib_set_3d_model_path` | `covered` | 10.0.x | lib_bulk_assign_3d_models, lib_search_3d_models, lib_remove_3d_model. |
-| Source live component data (price/stock/lifecycle) | `file` | `lib_search_components` | `partial` | 10.0.x | Distributor clients (Nexar/DigiKey) are stubs requiring authenticated deployment (work order K10); real APIs land in Phase 4 (P4-T3). |
+| Source live component data (price/stock/lifecycle) | `file` | `lib_search_components` | `partial` | 10.0.x | Live JLCPCB, Nexar, DigiKey, and Mouser sourcing clients are implemented; Nexar/DigiKey/Mouser are opt-in and auth-gated. Remaining P4-T3 work is full AVL/lifecycle policy enforcement and datasheet-grounded footprint/3D hard gates. |
 | Recommend / bind a part to a symbol | `file` | `lib_recommend_part` | `partial` | 10.0.x | lib_bind_part_to_symbol; depends on the same sourcing backends as above. |
 
 ### `analysis`

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ The docs are ordered from first setup to operations and maintenance.
 - [Maintenance Policy](maintenance-policy.md)
 - [Capability Verification Levels](status/capability-levels.md)
 - [Runtime Matrix](status/runtime-matrix.md)
+- [Work-Order Audit](status/work-order-audit-2026-06-17.md)
 
 ### Install, packaging, and distribution
 

--- a/docs/status/work-order-audit-2026-06-17.md
+++ b/docs/status/work-order-audit-2026-06-17.md
@@ -1,0 +1,54 @@
+# KICAD-MCP-PROMT Work-Order Audit
+
+Date: 2026-06-17
+
+This audit maps the external work order to the current repository state. It is a
+status snapshot, not a replacement for the machine-readable parity matrix.
+
+## Completed Or Gated
+
+| Work order | Evidence |
+|---|---|
+| P0-T1 architecture overview | Root `ARCHITECTURE.md` and linked development architecture docs. |
+| P0-T2 registry/profile consistency | `tests/unit/test_tool_registry_consistency.py`. |
+| P0-T3 tool-surface snapshot | `tests/integration/test_tool_surface_snapshot.py` and committed snapshot data. |
+| P0-T4 capability parity matrix | `docs/compatibility/capability-parity-matrix.yaml`, generator, tool, tests, regression baseline. |
+| P1-T2 profile source of truth | `scripts/build_toolsets.py` generates `integrations/common/toolsets.json`; parity tests enforce drift-free output. |
+| P1-T3 fail-capable SI gates | `src/kicad_mcp/verdicts.py` and `tests/unit/test_si_gate_verdicts.py`. |
+| P1-T5 error/idempotency contract | `ErrorPayload` transient fields, idempotency annotations, and contract tests. |
+| P1-T7 FreeRouting honesty | DSN/SES flow surfaces human-gated KiCad limitations instead of silently claiming full headless import. |
+| P1-T8 error/doc consolidation | Error catalog and docs sync tests are present. |
+| P2-T2 round-trip safety tests | `tests/integration/test_roundtrip_fidelity.py` guards non-trivial schematic round trips. |
+| P2-T5 reproducible manufacturing exports | Manufacturing export tests assert stable content hashes and provenance. |
+| P5-T1 governance | Maintainer, governance, and contributing docs are present. |
+| P5-T2 security threat model | Threat model plus path/rate-limit/security-control tests are present. |
+| P5-T6 parity regression maintenance | `parity:check:regression` enforces the committed coverage baseline. |
+
+## Partial, With Honest Limits
+
+| Work order | Current state | Remaining work |
+|---|---|---|
+| P1-T1 export consolidation | Central alias registrar exists; `export_3d_step` is a deprecated alias of `export_step`. | Keep enforcing one public tool per identical output; ADR documents why STEPZ and helper functions are not treated as duplicate agent-facing tools. |
+| P1-T4 structured verdict outputs | Shared verdict models and several high-traffic gates are structured. | Continue converting remaining high-traffic read/quality tools to stable structured payloads. |
+| P1-T6 doc-code honesty | README/docs now label first-order physics and auth-gated sourcing honestly. | Keep parity notes synchronized as solver/API capabilities mature. |
+| P2-T1 AST-safe schematic writing | Guarded `roundtrip_edit` exists and refuses unsafe serializer loss. | Migrate every remaining regex/string schematic writer through the guarded AST path or explicit unsafe fallback. |
+| P2-T3 live KiCad E2E | KiCad-marked E2E tests exist and skip when KiCad is unavailable. | Run/expand in a KiCad-equipped CI lane. |
+| P2-T4 unresolved-net surfacing | Schematic connectivity tests cover warnings for unresolved nets. | Keep expanding structured warnings into all mutating schematic/routing paths. |
+| P3-T1 impedance field solver | Closed-form estimates are labeled; field-solver seam exists. | Integrate a real 2D/2.5D solver or return solver-unavailable for solver mode. |
+| P3-T2 PDN | Lumped and mesh-style PDN checks exist with method labels. | Add full copper-plane field solve/current-density model. |
+| P3-T3 high-speed channel | Lossy-line/optional ngspice seam exists. | Add full S-parameter/IBIS-AMI class channel analysis. |
+| P3-T4 thermal | 2D finite-difference spreading exists. | Add full 3D FEA/airflow/stack conduction model. |
+| P3-T5 EMC | Layout heuristic checks exist and are labeled partial. | Tie checks to real EM/standard-named numeric margins. |
+| P4-T1 routing | FreeRouting orchestration is honest about SES import requiring KiCad GUI. | Build full deterministic headless DSN/SES application or an alternative constraint router. |
+| P4-T2 placement | Deterministic convergence replaces default wall-clock stopping. | Add deeper electrical, thermal, return-path, and incremental placement scoring. |
+| P4-T3 sourcing/footprints | JLCPCB, Nexar, DigiKey, and Mouser clients exist; SOT-23 generation and footprint validation exist. | Expand package generators and enforce datasheet/IPC/AVL hard gates. |
+| P4-T4 edit/ingest mode | Edit-impact tools and selective revalidation tests exist. | Expand semantic diff coverage and gate-preservation proofs for larger real projects. |
+| P5-T3 sign-off report | Sign-off report builder and tests exist. | Fully hard-gate every manufacturing handoff on evidence-linked requirements. |
+| P5-T4 release hardening | Ruleset and release tests exist. | Continue validating post-publish SBOM/provenance in release dry-runs. |
+| P5-T5 runtime hardening | IPC lifecycle, task timeout/cancel, bridge rate limit tests exist. | Keep replacing brittle substring error handling with structured errors across adapters. |
+
+## Current Verification
+
+- `task verify` passes locally.
+- `uv run --all-extras python scripts/build_parity_matrix.py --check-regression` passes with
+  75.0% programmatic coverage at the committed baseline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Maintenance Policy: maintenance-policy.md
       - Capability Verification Levels: status/capability-levels.md
       - Runtime Matrix: status/runtime-matrix.md
+      - Work-Order Audit: status/work-order-audit-2026-06-17.md
   - Install, Packaging, and Distribution:
       - Docker Install: install/docker.md
       - Client Config Generator: install/client-config-generator.md

--- a/src/kicad_mcp/parity_matrix_data.py
+++ b/src/kicad_mcp/parity_matrix_data.py
@@ -13,11 +13,11 @@ from typing import Any
 _RAW = r"""
 {
   "schemaVersion": 1,
-  "updated": "2026-06-16",
+  "updated": "2026-06-17",
   "kicad_baseline": "10.0.x",
   "status_vocabulary": {
     "covered": "A registered MCP tool fully drives this capability.",
-    "partial": "Some MCP support exists but with a tracked limitation (heuristic estimate, stubbed dependency, hidden/orphaned tool, or a manual KiCad step).",
+    "partial": "Some MCP support exists but with a tracked limitation (heuristic estimate, optional/auth-gated dependency, hidden/orphaned tool, or a manual KiCad step).",
     "gap": "KiCad exposes this programmatically (cli/ipc/file) but no MCP tool drives it yet.",
     "gui-only-no-api": "KiCad only offers this interactively; no cli/ipc/file path exists. Excluded from the coverage denominator (a KiCad API limit, not ours)."
   },
@@ -234,7 +234,7 @@ _RAW = r"""
           "mcp_tool": "pcb_auto_place_by_schematic",
           "status": "partial",
           "kicad_version_introduced": "10.0.x",
-          "notes": "Force-directed placement (pcb_auto_place_force_directed) is non-deterministic under a wall-clock cap (work order K7); deterministic placement is Phase 4 (P4-T2)."
+          "notes": "Force-directed placement now stops by deterministic convergence and disables the wall-clock safety valve by default (K7); remaining P4-T2 work is deeper electrical/thermal/return-path scoring beyond net-weighted placement."
         },
         {
           "capability": "Run DRC and inspect violations",
@@ -319,7 +319,7 @@ _RAW = r"""
           "mcp_tool": "route_autoroute_freerouting",
           "status": "partial",
           "kicad_version_introduced": "10.0.x",
-          "notes": "Routes headlessly (Docker/JAR); applying the routed SES is a manual KiCad GUI step (no headless SES import) surfaced via human_gate_required (P1-T7). Full headless flow is Phase 4 (P4-T1)."
+          "notes": "Routes headlessly (Docker/JAR); the routed SES is now applied headlessly by route_apply_ses (utils/router_core writes segments/vias into the .kicad_pcb), closing the former GUI step (P4-T1). Status stays partial: FreeRouting's own determinism is bounded and the SES coordinate transform assumes KiCad's standard Specctra export convention (verified end-to-end only in the KiCad CI job)."
         },
         {
           "capability": "Export Specctra DSN / import routed SES",
@@ -327,7 +327,7 @@ _RAW = r"""
           "mcp_tool": "route_export_dsn",
           "status": "partial",
           "kicad_version_introduced": "10.0.x",
-          "notes": "route_export_dsn attempts headless kicad-cli specctra export, else returns a clear human-gated manual-step result; route_import_ses stages and surfaces the GUI import step (P1-T7, K1)."
+          "notes": "route_export_dsn attempts headless kicad-cli specctra export, else a clear human-gated manual step; the routed SES is applied fully headlessly by route_apply_ses (deterministic, idempotent, round-trip-safe via utils/router_core, P4-T1) -- no GUI import. Export side stays partial when kicad-cli lacks headless specctra export."
         },
         {
           "capability": "Set per-net-class routing rules",
@@ -396,7 +396,7 @@ _RAW = r"""
           "mcp_tool": "lib_search_components",
           "status": "partial",
           "kicad_version_introduced": "10.0.x",
-          "notes": "Distributor clients (Nexar/DigiKey) are stubs requiring authenticated deployment (work order K10); real APIs land in Phase 4 (P4-T3)."
+          "notes": "Live JLCPCB, Nexar, DigiKey, and Mouser sourcing clients are implemented; Nexar/DigiKey/Mouser are opt-in and auth-gated. Remaining P4-T3 work is full AVL/lifecycle policy enforcement and datasheet-grounded footprint/3D hard gates."
         },
         {
           "capability": "Recommend / bind a part to a symbol",

--- a/src/kicad_mcp/tools/test_points.py
+++ b/src/kicad_mcp/tools/test_points.py
@@ -55,16 +55,19 @@ def _save_test_points(state: dict[str, Any]) -> Path:
 
 def _collect_board_nets() -> list[dict[str, Any]]:
     """Collect net names and codes from the board (IPC or file fallback)."""
+    live_nets: list[dict[str, Any]] = []
     try:
         board = get_board()
         nets = board.get_nets()
-        return [
+        live_nets = [
             {
                 "code": getattr(n, "code", 0),
                 "name": getattr(n, "name", ""),
             }
             for n in nets
         ]
+        if any(net["name"] for net in live_nets):
+            return live_nets
     except (KiCadConnectionError, AttributeError, OSError):
         pass
 
@@ -79,9 +82,9 @@ def _collect_board_nets() -> list[dict[str, Any]]:
             if code not in seen_codes:
                 seen_codes.add(code)
                 fallback_nets.append({"code": code, "name": name})
-        return fallback_nets
+        return fallback_nets or live_nets
     except (OSError, ValueError):
-        return []
+        return live_nets
 
 
 def register(mcp: FastMCP) -> None:

--- a/src/kicad_mcp/utils/__init__.py
+++ b/src/kicad_mcp/utils/__init__.py
@@ -1,6 +1,12 @@
 """Utility helpers for KiCad MCP Pro."""
 
-from .component_search import ComponentRecord, DigiKeyClient, JLCSearchClient, NexarClient
+from .component_search import (
+    ComponentRecord,
+    DigiKeyClient,
+    JLCSearchClient,
+    MouserClient,
+    NexarClient,
+)
 from .freerouting import FreeRoutingResult, FreeRoutingRunner
 from .impedance import (
     copper_thickness_mm,
@@ -25,6 +31,7 @@ __all__ = [
     "FreeRoutingResult",
     "FreeRoutingRunner",
     "JLCSearchClient",
+    "MouserClient",
     "NgspiceRunner",
     "NexarClient",
     "SimulationResult",

--- a/tests/unit/test_component_search.py
+++ b/tests/unit/test_component_search.py
@@ -4,6 +4,7 @@ import io
 
 import pytest
 
+from kicad_mcp import utils
 from kicad_mcp.utils.component_search import (
     DEFAULT_USER_AGENT,
     ComponentRecord,
@@ -16,6 +17,13 @@ from kicad_mcp.utils.component_search import (
     _request_json,
     normalize_lcsc_code,
 )
+
+
+def test_public_utils_exports_all_live_component_clients() -> None:
+    assert utils.JLCSearchClient is JLCSearchClient
+    assert utils.NexarClient is NexarClient
+    assert utils.DigiKeyClient is DigiKeyClient
+    assert utils.MouserClient is MouserClient
 
 
 def test_normalize_lcsc_code_accepts_bare_digits() -> None:


### PR DESCRIPTION
Lands a small batch of in-flight work-order changes that had been sitting uncommitted: the work-order **audit report** (+ docs index/nav links), README/parity doc refresh (Mouser as an auth-gated sourcing backend, route_apply_ses headless-routing notes, regenerated parity artifacts), a **fix** so test-point net collection prefers named live nets over a blank IPC list (with file fallback), and a CI tweak (disable uv cache in the release metadata-sync step) plus a utils import tidy. All gates green locally (lint, mypy, meta checks, affected tests).