### PR TITLE
docs: unpin version from README install/transport examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ KiCad MCP Pro supports `stdio` and Streamable HTTP. Streamable HTTP is served at
 `/mcp` by default and can be moved with `KICAD_MCP_MOUNT_PATH`.
 
 ```bash
-uvx kicad-mcp-pro@3.9.2 --transport streamable-http --host 127.0.0.1 --port 3334
+uvx kicad-mcp-pro --transport streamable-http --host 127.0.0.1 --port 3334
 ```
 
 Streamable HTTP clients must send:
@@ -127,8 +127,8 @@ The deprecated HTTP+SSE fallback routes are disabled by default. Set
 
 ```bash
 corepack pnpm run dev:doctor -- --ci
-uvx kicad-mcp-pro@3.9.2 --help
-npx kicad-mcp-pro@3.9.2 --help
+uvx kicad-mcp-pro --help
+npx kicad-mcp-pro --help
 ```
 
 For source checkouts, `corepack pnpm run dev:doctor` validates Node, pnpm,


### PR DESCRIPTION
Final delivery polish: the uvx/npx install/transport examples pinned `@3.9.2` and went stale (latest is 3.11.0). Unpinning makes them self-maintaining (always latest); the concrete version remains in the Project identity table (release-please-managed). Docs-only; _readme_check passes.