### PR TITLE
docs: add MCP client guides for Cline, Windsurf, Continue, and Zed

### DIFF
--- a/docs/agents/cline.md
+++ b/docs/agents/cline.md
@@ -1,0 +1,60 @@
+# Cline Integration
+
+[Cline](https://cline.bot) is an autonomous coding agent for VS Code (and a CLI).
+It speaks MCP over stdio and HTTP.
+
+## Quick Start
+
+Cline reads MCP servers from `mcpServers` in its settings JSON:
+
+- **IDE:** open the Cline panel → **MCP Servers** → **Configure** (this edits
+  `cline_mcp_settings.json` in the extension's storage), or add a project-scoped
+  config under `.cline/`.
+- **CLI:** edit `~/.cline/mcp.json`, or run `cline config mcp`.
+
+```json
+{
+  "mcpServers": {
+    "kicad": {
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+Ready-to-copy: [`docs/examples/clients/cline.mcp.json`](../examples/clients/cline.mcp.json).
+
+Keep `autoApprove` empty so Cline asks before each tool call; add specific
+read-only tool names there once you trust the workflow. Leave
+`KICAD_MCP_OPERATING_MODE=readonly` until you intend to let the agent modify
+files.
+
+## Verification
+
+```bash
+cline mcp list
+kicad-mcp-pro doctor
+```
+
+In the Cline panel the `kicad` server should show a green status with its tools
+listed.
+
+## Skills and rules
+
+Cline supports project rules and skills under `.cline/`. The shared KiCad review
+rule in `integrations/common/` and the PCB-review skill shipped for Claude
+Code / Cursor can be reused verbatim — drop the rule into `.cline/rules/` and the
+skill folder into `.cline/skills/`.
+
+## Example Prompt
+
+> Use the kicad MCP server. Inspect this KiCad project, run DRC and ERC, and
+> summarize the results. Do not modify any files.

--- a/docs/agents/continue.md
+++ b/docs/agents/continue.md
@@ -1,0 +1,47 @@
+# Continue Integration
+
+[Continue](https://continue.dev) is an open-source assistant for VS Code and
+JetBrains. Recent versions configure MCP servers as a `mcpServers` **list** in
+YAML (`config.yaml`), replacing the old
+`experimental.modelContextProtocolServers` JSON block.
+
+## Quick Start
+
+Add the server to your assistant config — global `~/.continue/config.yaml`, or a
+project block under `.continue/`:
+
+```yaml
+name: KiCad MCP
+version: 1.0.0
+schema: v1
+mcpServers:
+  - name: kicad
+    type: stdio
+    command: uvx
+    args:
+      - kicad-mcp-pro
+    env:
+      KICAD_MCP_PROJECT_DIR: /absolute/path/to/your/kicad-project
+      KICAD_MCP_PROFILE: pcb_only
+      KICAD_MCP_OPERATING_MODE: readonly
+```
+
+Ready-to-copy: [`docs/examples/clients/continue.config.yaml`](../examples/clients/continue.config.yaml).
+
+MCP tools are available in Continue's **agent** mode. Each entry takes
+`name`, `command`, `args`, optional `env`, and optional `cwd`; `type: stdio` is
+the default and may be omitted.
+
+## Verification
+
+```bash
+kicad-mcp-pro doctor
+```
+
+Open Continue in **Agent** mode and confirm the `kicad` tools appear in the tool
+list, then ask it to inspect the project.
+
+## Example Prompt
+
+> Use the kicad MCP server. Inspect this KiCad project, run DRC and ERC, and
+> summarize the results. Do not modify any files.

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -16,6 +16,10 @@ kiCad-mcp-pro is an MCP server that exposes KiCad PCB design capabilities as too
 | [Claude.ai Web](claude-ai.md) | ❌ No | ✅ Supported | — | Limited |
 | [ChatGPT Web](chatgpt-app.md) | ❌ No | ✅ Supported | — | ✅ Apps SDK |
 | [Antigravity](antigravity.md) | ⚠️ Verify | ✅ Supported | — | — |
+| [Cline](cline.md) | ✅ Supported | ✅ Supported | ✅ Reusable | — |
+| [Windsurf](windsurf.md) | ✅ Supported | ✅ Supported | — | — |
+| [Continue](continue.md) | ✅ Supported | ✅ Supported | — | — |
+| [Zed](zed.md) | ✅ Supported | ✅ Supported | — | — |
 
 ## Quick Start
 

--- a/docs/agents/windsurf.md
+++ b/docs/agents/windsurf.md
@@ -1,0 +1,51 @@
+# Windsurf Integration
+
+[Windsurf](https://windsurf.com) (the Codeium agentic IDE) connects to MCP
+servers from its Cascade panel.
+
+## Quick Start
+
+Add the server to `~/.codeium/windsurf/mcp_config.json` (the file Cascade reads),
+or use **Cascade → Plugins / MCP → Add custom server → View raw config**:
+
+```json
+{
+  "mcpServers": {
+    "kicad": {
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      }
+    }
+  }
+}
+```
+
+Ready-to-copy: [`docs/examples/clients/windsurf.mcp.json`](../examples/clients/windsurf.mcp.json).
+
+After editing the file, press **Refresh** in the Cascade MCP panel. The config
+supports `${ENV_VAR}` interpolation for `command`, `args`, `env`, `serverUrl`,
+and `headers`.
+
+A remote (HTTP) server uses `serverUrl` instead of `command`:
+
+```json
+{ "mcpServers": { "kicad": { "serverUrl": "http://127.0.0.1:8765/mcp" } } }
+```
+
+## Verification
+
+```bash
+kicad-mcp-pro doctor
+```
+
+In the Cascade **MCP** panel the `kicad` server shows a green dot and its tool
+count once it has started.
+
+## Example Prompt
+
+> Use the kicad MCP server. Inspect this KiCad project, run DRC and ERC, and
+> summarize the results. Do not modify any files.

--- a/docs/agents/zed.md
+++ b/docs/agents/zed.md
@@ -1,0 +1,47 @@
+# Zed Integration
+
+[Zed](https://zed.dev) connects to MCP servers as **context servers**. A custom
+(non-extension) server is declared in the `context_servers` block of Zed's
+`settings.json`.
+
+## Quick Start
+
+Open **`zed: open settings`** (or edit `~/.config/zed/settings.json`) and add:
+
+```json
+{
+  "context_servers": {
+    "kicad": {
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      }
+    }
+  }
+}
+```
+
+Ready-to-copy: [`docs/examples/clients/zed.settings.json`](../examples/clients/zed.settings.json).
+
+A remote (HTTP) server uses `url` (and optional `headers`) instead of `command`:
+
+```json
+{ "context_servers": { "kicad": { "url": "http://127.0.0.1:8765/mcp" } } }
+```
+
+## Verification
+
+```bash
+kicad-mcp-pro doctor
+```
+
+In the **Agent Panel → Settings** the `kicad` context server shows a green
+indicator when it is running, and its tools become available to the agent.
+
+## Example Prompt
+
+> Use the kicad MCP server. Inspect this KiCad project, run DRC and ERC, and
+> summarize the results. Do not modify any files.

--- a/docs/examples/clients/cline.mcp.json
+++ b/docs/examples/clients/cline.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "kicad": {
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}

--- a/docs/examples/clients/continue.config.yaml
+++ b/docs/examples/clients/continue.config.yaml
@@ -1,0 +1,13 @@
+name: KiCad MCP
+version: 1.0.0
+schema: v1
+mcpServers:
+  - name: kicad
+    type: stdio
+    command: uvx
+    args:
+      - kicad-mcp-pro
+    env:
+      KICAD_MCP_PROJECT_DIR: /absolute/path/to/your/kicad-project
+      KICAD_MCP_PROFILE: pcb_only
+      KICAD_MCP_OPERATING_MODE: readonly

--- a/docs/examples/clients/windsurf.mcp.json
+++ b/docs/examples/clients/windsurf.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "kicad": {
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      }
+    }
+  }
+}

--- a/docs/examples/clients/zed.settings.json
+++ b/docs/examples/clients/zed.settings.json
@@ -1,0 +1,13 @@
+{
+  "context_servers": {
+    "kicad": {
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## New MCP client guides: Cline, Windsurf, Continue, Zed

These four popular MCP clients previously only had the generic fallback config. This adds dedicated per-agent guides + ready-to-copy examples, with every format **verified against each tool's current documentation** (via Context7) rather than from memory:

| Client | Format | Location | Source verified |
|--------|--------|----------|-----------------|
| **Cline** | `mcpServers` JSON (+ `disabled`/`autoApprove`) | `~/.cline/mcp.json` or project `.cline/` | cline.bot docs |
| **Windsurf** | `mcpServers` JSON | `~/.codeium/windsurf/mcp_config.json` | windsurf.com/cascade/mcp |
| **Continue** | `mcpServers` **list** in `config.yaml` | `~/.continue/config.yaml` or `.continue/` | docs.continue.dev (current YAML format that replaced `experimental.modelContextProtocolServers`) |
| **Zed** | `context_servers` block | `settings.json` | zed.dev/docs/ai/mcp |

### Contents
- `docs/agents/{cline,windsurf,continue,zed}.md` — house-style guides (read-only defaults, verification, example prompt, HTTP variants where supported).
- `docs/examples/clients/{cline.mcp.json, windsurf.mcp.json, continue.config.yaml, zed.settings.json}` — valid, ready to copy.
- `docs/agents/index.md` — all four added to the Supported Agents table.

### Skills/plugins
Cline supports project rules and skills under `.cline/`; the guide notes the **existing** KiCad review rule (`integrations/common/`) and the Claude Code / Cursor PCB-review skill can be reused verbatim — no new plugin needed. Windsurf/Continue/Zed use rules/system-prompts rather than a skill concept.

All example JSON/YAML validated; all relative doc links resolve. opencode.ai was already covered and remains current.
