### PR TITLE
fix(gui): pin working backend version + fix startup timeout/blocking

### DIFF
--- a/src-tauri/frontend/index.html
+++ b/src-tauri/frontend/index.html
@@ -117,11 +117,11 @@
         <p style="margin-top:16px;font-size:13px;">
           Try running this command manually in a terminal to see the error:
         </p>
-        <code>uvx kicad-mcp-pro dashboard --host 127.0.0.1 --port 3334</code>
+        <code>uvx kicad-mcp-pro@latest dashboard --host 127.0.0.1 --port 3334</code>
         <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap;">
           <a class="btn secondary" href="http://127.0.0.1:3334/ui" target="_blank">Try opening dashboard</a>
           <button class="btn secondary" onclick="handleRestartServer()">Restart Server</button>
-          <button class="btn" onclick="location.reload()">Retry</button>
+          <button class="btn" onclick="handleRestartServer()">Retry</button>
         </div>
       </div>
     </div>
@@ -130,7 +130,10 @@
       const DASHBOARD_URL = 'http://127.0.0.1:3334/ui';
       const HEALTH_URL = 'http://127.0.0.1:3334/api/health';
 
-      const MAX_RETRIES = 30;
+      // Must be at least as long as the Rust backend's health-wait window
+      // (120s). The first launch downloads the backend via uvx, which can take
+      // over a minute on a cold cache, so give it room before showing an error.
+      const MAX_RETRIES = 120;
       const RETRY_INTERVAL_MS = 1000;
       let retries = 0;
       let healthOk = false;
@@ -163,13 +166,8 @@
 
       /** Restart the Python server (stop + start). */
       async function handleRestartServer() {
-        const result = await tauriInvoke('restart_server', { port: 3334 });
-        if (result === null) {
-          // IPC not available — fall back to page reload
-          location.reload();
-          return;
-        }
-        // Reset UI state and start polling again
+        // Show feedback immediately so the button never looks dead — the
+        // restart can take a while on a cold first-run download.
         retries = 0;
         healthOk = false;
         spinnerEl.style.display = 'block';
@@ -177,7 +175,16 @@
         statusEl.className = 'status';
         detailsEl.classList.remove('visible');
         if (errorDetailEl) errorDetailEl.style.display = 'none';
-        setTimeout(checkServer, 1000);
+
+        const result = await tauriInvoke('restart_server', { port: 3334 });
+        if (result === null) {
+          // IPC not available (e.g. opened in a plain browser) — just re-poll.
+          setTimeout(checkServer, 1000);
+          return;
+        }
+        // restart_server returned (ready or failed); let the poller redirect
+        // on success or surface the backend error.
+        setTimeout(checkServer, 500);
       }
 
       function setStep(name, state) {
@@ -267,7 +274,10 @@
           return;
         }
 
-        statusEl.textContent = `Starting server… (${retries}/${MAX_RETRIES})`;
+        statusEl.textContent =
+          retries < 8
+            ? 'Starting server…'
+            : `Starting server… first run downloads the backend, this can take a minute (${retries}s)`;
         setTimeout(checkServer, RETRY_INTERVAL_MS);
       }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,20 @@ use std::os::windows::process::CommandExt;
 
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 
+/// Minimum kicad-mcp-pro version the GUI will launch via `uvx --from`.
+/// Bump this when the GUI requires a newer backend. The floor must stay at or
+/// above the first release whose `dashboard` command binds the HTTP transport
+/// (3.11.0); earlier cached builds started the stdio transport instead.
+const MIN_BACKEND_SPEC: &str = "kicad-mcp-pro>=3.11.0";
+
+/// How long to wait for the backend to bind and answer /api/health before
+/// giving up. First runs download the package and its dependencies via uvx,
+/// which can take well over a minute on a cold cache or slow network, so this
+/// must be generous — and must not be shorter than the frontend's own poll
+/// window, or a still-installing child would be killed prematurely.
+const HEALTH_WAIT: Duration = Duration::from_secs(120);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
 #[derive(Clone, serde::Serialize)]
 pub struct ServerStatus {
     pub running: bool,
@@ -151,9 +165,17 @@ fn start_server_inner(process: &ServerProcess, port: u16) -> Result<String, Stri
     let log_file = std::fs::File::create(&log_path)
         .map_err(|e| format!("Failed to create server log {log_path:?}: {e}"))?;
 
+    // Pin a minimum backend version with `--from` so uvx cannot serve a stale
+    // cached build. Older cached versions (e.g. 3.9.0) shipped a `dashboard`
+    // command that fell back to the stdio transport and never bound the HTTP
+    // port, which surfaced in the GUI as "Server failed to start". `>=` lets
+    // uvx reuse a satisfying cached environment (fast, works offline) while
+    // refusing anything below the known-good floor.
     let mut cmd = Command::new(&uvx);
     cmd.current_dir(&cwd)
         .args([
+            "--from",
+            MIN_BACKEND_SPEC,
             "kicad-mcp-pro",
             "dashboard",
             "--host",
@@ -179,8 +201,12 @@ fn start_server_inner(process: &ServerProcess, port: u16) -> Result<String, Stri
     *guard = Some(child);
     drop(guard);
 
-    // Wait up to 60s for server to become healthy (500ms intervals)
-    for _ in 0..120 {
+    // Wait for the server to become healthy. The first launch downloads the
+    // package via uvx, so allow a generous window (HEALTH_WAIT) before giving
+    // up — killing the child early would abort an install that is still in
+    // progress.
+    let deadline = std::time::Instant::now() + HEALTH_WAIT;
+    while std::time::Instant::now() < deadline {
         if check_health(port) {
             return Ok("started".to_string());
         }
@@ -192,21 +218,22 @@ fn start_server_inner(process: &ServerProcess, port: u16) -> Result<String, Stri
                     drop(guard);
                     return Err(format!(
                         "Python server process exited unexpectedly (code: {}) before binding to port {}.\n\
-                         Run manually to debug: uvx kicad-mcp-pro dashboard --host 127.0.0.1 --port {port}",
+                         Run manually to debug: uvx kicad-mcp-pro@latest dashboard --host 127.0.0.1 --port {port}",
                         status.code().map(|c| c.to_string()).unwrap_or_else(|| "signal".to_string()),
                         port,
                     ));
                 }
             }
         }
-        thread::sleep(Duration::from_millis(500));
+        thread::sleep(HEALTH_POLL_INTERVAL);
     }
 
     let _ = stop_server_inner(process);
     Err(format!(
-        "Python server at http://{}/api/health did not respond within 60 seconds.\n\
-         This may mean kicad-mcp-pro is not installed. Run: uvx kicad-mcp-pro dashboard --host 127.0.0.1 --port {port}",
-        server_addr(port)
+        "Python server at http://{}/api/health did not respond within {} seconds.\n\
+         First runs download the backend and can be slow. Run manually to debug: uvx kicad-mcp-pro@latest dashboard --host 127.0.0.1 --port {port}",
+        server_addr(port),
+        HEALTH_WAIT.as_secs(),
     ))
 }
 
@@ -389,20 +416,24 @@ pub fn run() {
             }
             let _ = tray.build(app)?;
 
-            let state = app.state::<ServerProcess>();
-            match start_server_inner(state.inner(), 3334) {
-                Ok(status) => {
-                    eprintln!("[kicad-mcp-pro] Server started: {status}");
-                    if let Some(window) = app.get_webview_window("main") {
-                        let _ = window.set_focus();
+            // Launch the backend on a background thread so the first-run
+            // download (which can take up to HEALTH_WAIT) never blocks the UI
+            // or the tray. The frontend polls /api/health and server_status
+            // independently and redirects as soon as the server is ready.
+            let handle = app.handle().clone();
+            std::thread::spawn(move || {
+                let state = handle.state::<ServerProcess>();
+                match start_server_inner(state.inner(), 3334) {
+                    Ok(status) => {
+                        eprintln!("[kicad-mcp-pro] Server started: {status}");
+                        let _ = state.error.lock().map(|mut e| *e = None);
                     }
-                    let _ = state.error.lock().map(|mut e| *e = None);
+                    Err(error) => {
+                        eprintln!("[kicad-mcp-pro] ERROR: {error}");
+                        let _ = state.error.lock().map(|mut e| *e = Some(error));
+                    }
                 }
-                Err(error) => {
-                    eprintln!("[kicad-mcp-pro] ERROR: {error}");
-                    let _ = state.error.lock().map(|mut e| *e = Some(error.clone()));
-                }
-            }
+            });
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Fix: desktop GUI "Server failed to start" (while manual run works)

Reported: the app shows **Server failed to start** after ~30s and the buttons appear dead, yet `uvx kicad-mcp-pro dashboard --host 127.0.0.1 --port 3334` works in a terminal.

### Root cause (three compounding issues)

1. **Stale backend version.** The GUI spawned plain `uvx kicad-mcp-pro` (no pin), so `uvx` served the user's **cached 3.9.0** — whose `dashboard` command fell back to the **stdio** transport and never bound port 3334 (visible as `transport=stdio` in the user's terminal). PyPI latest is **3.11.0**, whose dashboard correctly uses `streamable-http` (verified: `Uvicorn running`, `/api/health → 200` in 3ms).
2. **Premature timeout.** Frontend gave up at **30s**; backend waited **60s** then **killed the child** — aborting a cold first-run `uvx` download mid-install.
3. **Blocking startup.** `start_server_inner` ran synchronously in Tauri `setup`, so a longer wait would freeze the window/tray.

### Fix
- **Pin a working floor:** spawn `uvx --from "kicad-mcp-pro>=3.11.0" kicad-mcp-pro dashboard …` (const `MIN_BACKEND_SPEC`). `>=` lets uvx reuse a satisfying cached env (fast, offline-friendly) but refuses the broken 3.9.x cache.
- **Align timeouts to 120s** and stop killing a still-installing child; frontend shows a "first run downloads the backend, this can take a minute" message.
- **Background-thread the startup spawn** so the UI/tray never freeze (frontend polls `/api/health` + `server_status` independently).
- **Buttons:** "Retry" now re-spawns the server (previously only reloaded the page, which never restarted a dead backend); Restart/Retry give immediate feedback; debug hints use `kicad-mcp-pro@latest`.

`cargo check` passes. (Note for reviewers: `tauri.conf.json` version `3.9.2` vs `Cargo.toml` `3.11.0` are out of sync — flagged separately, not changed here.)
