### PR TITLE
fix: sync GUI app version (tauri.conf.json) and auto-bump it on release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -77,7 +77,10 @@
       "tag-prefix": "kicad-mcp-gui-v",
       "release-type": "rust",
       "component": "kicad-mcp-gui",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "src-tauri/tauri.conf.json", "jsonpath": "$.version" }
+      ]
     }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "KiCad MCP Pro",
-  "version": "3.9.2",
+  "version": "3.11.0",
   "identifier": "dev.oaslananka.kicad-mcp-pro",
   "build": {
     "frontendDist": "frontend",


### PR DESCRIPTION
The GUI is released at **3.11.0** (latest `kicad-mcp-gui-v3.11.0` tag, `.release-please-manifest.json` `src-tauri: 3.11.0`, `Cargo.toml` 3.11.0), but `src-tauri/tauri.conf.json` still read **3.9.2** — so the built installer/app version drifted behind the actual release.

**Cause:** release-please's `src-tauri` component uses the `rust` release-type, which bumps `Cargo.toml` but not `tauri.conf.json`, and the latter had no `extra-files` entry.

**Fix:**
- `tauri.conf.json` version 3.9.2 → 3.11.0 (matches the source of truth).
- Added a release-please `extra-files` JSON updater (`$.version`) for the `src-tauri` component so it auto-bumps on every future GUI release and never drifts again.