### PR TITLE
feat(dashboard): surface AI agent setup + prompt links in the sidebar

### DIFF
--- a/src/kicad_mcp/web/dashboard.py
+++ b/src/kicad_mcp/web/dashboard.py
@@ -67,6 +67,12 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
     background: var(--surface-2); color: var(--accent);
     border-left-color: var(--accent); font-weight: 500;
   }
+  a.nav-item { display: block; text-decoration: none; }
+  .nav-sep { height: 1px; background: var(--surface-2); margin: 8px 14px; }
+  .nav-label {
+    padding: 6px 16px 2px; font-size: 10px; letter-spacing: 0.06em;
+    text-transform: uppercase; color: var(--text-muted); opacity: 0.7;
+  }
 
   /* Main content */
   .main { flex: 1; padding: 24px; overflow-y: auto; max-height: 100vh; }
@@ -273,6 +279,10 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
   <div class="nav-item" data-view="tools-catalog">&#9881; Tools</div>
   <div class="nav-item" data-view="settings">&#9878; Settings</div>
   <div class="nav-item" data-view="setup-wizard">&#9889; Setup</div>
+  <div class="nav-sep"></div>
+  <div class="nav-label">AI Agents</div>
+  <a class="nav-item" href="https://oaslananka.github.io/kicad-mcp/agents/" target="_blank" rel="noopener noreferrer">&#129302; Agent Setup &#8599;</a>
+  <a class="nav-item" href="https://oaslananka.github.io/kicad-mcp/agents/prompts/" target="_blank" rel="noopener noreferrer">&#128172; Prompt Library &#8599;</a>
 </nav>
 
 <!-- Main content -->


### PR DESCRIPTION
Adds an **AI Agents** section to the dashboard sidebar with links to the published docs, so users can find how to connect their agent and which prompts to use without leaving the GUI:

- **Agent Setup** → `/agents/` (per-client connection guides — Claude, Cursor, Codex, Cline, Windsurf, Continue, Zed, …)
- **Prompt Library** → `/agents/prompts/`

Plain external `<a>` links styled like nav items; they carry no `data-view`, so the existing hash-router click handler ignores them. Both URLs verified **200** on the published site; the dashboard renders the section with the correct version. `dashboard.py` compiles.