### PR TITLE
fix: sync tauri.conf.json version to 3.12.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "KiCad MCP Pro",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "identifier": "dev.oaslananka.kicad-mcp-pro",
   "build": {
     "frontendDist": "frontend",


### PR DESCRIPTION
`Cargo.toml` and `.release-please-manifest.json` are at **3.12.0** (released as `kicad-mcp-gui-v3.12.0`), but `tauri.conf.json` was still **3.11.0** — so the v3.12.0 installers were built with a 3.11.0 product-version label (e.g. `windows_KiCad-MCP-Pro_3.11.0_x64-setup.exe`).

**The startup fix shipped correctly in those builds** — this only corrects the drifted version field.

**Why it drifted:** the `extra-files` updater that auto-bumps `tauri.conf.json` was added *after* release-please had already prepared the 3.12.0 GUI release, so it didn't apply that cycle. The config is now in place, so future GUI releases bump this field automatically; this closes the one-time gap so all version surfaces read 3.12.0. The next GUI release will produce correctly-labeled installers.