### PR TITLE
docs: add centered hero tagline + quick links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://oaslananka.github.io/kicad-mcp/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/oaslananka/kicad-mcp)
 
+<br/>
+
+**Drive KiCad schematic, PCB, DRC/ERC, DFM, and manufacturing review from any MCP-capable AI agent.**
+
+[Documentation](https://oaslananka.github.io/kicad-mcp/) · [Installation](docs/installation.md) · [Quick Start](#quick-start) · [Tool Reference](docs/tools-reference.generated.md) · [AI Agent Setup](https://oaslananka.github.io/kicad-mcp/agents/)
+
 </div>
 
 <!-- mcp-name: io.github.oaslananka/kicad-mcp-pro -->


### PR DESCRIPTION
Completes the centered header started by the badge work: a one-line value-prop tagline and a compact quick-links row (Documentation · Installation · Quick Start · Tool Reference · AI Agent Setup) under the badges, so newcomers can act immediately.

All inside the existing `align=center` block; the `parity-coverage-badge` auto-updater is unaffected (verified `build_parity_matrix.py --check`). All link targets verified to exist.