### PR TITLE
fix: load CLI on Typer versions without vendored _click (pip install crash)

### DIFF
--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -23,7 +23,17 @@ from typing import Any, TextIO, cast
 import anyio
 import structlog
 import typer
-from typer._click.globals import get_current_context as _get_click_context
+
+# Typer >= 0.26 vendors Click as ``typer._click`` and drives its commands through
+# it, so the active command context lives in that vendored Click's globals. Older
+# Typer (< 0.26) has no ``typer._click`` and uses the top-level ``click`` package
+# instead. Import from whichever the installed Typer actually uses so the CLI
+# loads on any supported Typer version (regression: a pip install that resolved
+# Typer 0.25 crashed with ModuleNotFoundError: No module named 'typer._click').
+try:
+    from typer._click.globals import get_current_context as _get_click_context
+except ModuleNotFoundError:  # Typer < 0.26 uses the top-level Click package
+    from click import get_current_context as _get_click_context
 
 try:
     import watchfiles


### PR DESCRIPTION
## Bug: `pip install kicad-mcp-pro` crashes on startup

A user's pip install resolved **Typer 0.25** and the CLI crashed immediately:
```
File ".../kicad_mcp/server.py", line 26, in <module>
    from typer._click.globals import get_current_context as _get_click_context
ModuleNotFoundError: No module named 'typer._click'
```

`typer._click` only exists in **Typer >= 0.26** (where Typer vendors Click and runs commands through it). Older Typer drives commands via the **top-level `click`** package, so the active context lives there. The hard import broke on any Typer < 0.26 that pip happened to resolve (our `uv.lock` pins 0.26.7, which is why it didn't surface in dev/CI).

## Fix
Import `get_current_context` from `typer._click` when present, else fall back to the top-level `click` package — so the CLI loads on **any** supported Typer version, without forcing a Typer upgrade that could conflict with other tools.

Verified: import OK on Typer 0.26.7 (uses `typer._click.globals`); the `click` fallback import is available; ruff clean.