### PR TITLE
fix: silence mypy no-redef on the typer/click fallback import

### DIFF
--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -33,7 +33,7 @@ import typer
 try:
     from typer._click.globals import get_current_context as _get_click_context
 except ModuleNotFoundError:  # Typer < 0.26 uses the top-level Click package
-    from click import get_current_context as _get_click_context
+    from click import get_current_context as _get_click_context  # type: ignore[no-redef]
 
 try:
     import watchfiles


### PR DESCRIPTION
Follow-up to the Typer compatibility fix. The conditional import defines `_get_click_context` in both branches, which mypy flags as `[no-redef]` — failing the `typecheck` gate on `main`. Adds a targeted `# type: ignore[no-redef]` on the fallback import (standard for conditional imports). Runtime unchanged; `uv run mypy src/kicad_mcp/` is clean (125 files).