### PR TITLE
fix: handle partial document availability in kicad_get_version

### DIFF
--- a/src/kicad_mcp/tools/project.py
+++ b/src/kicad_mcp/tools/project.py
@@ -1729,10 +1729,19 @@ def register(mcp: FastMCP) -> None:
 
             kicad = get_kicad()
             lines.append(f"IPC version: {kicad.get_version()}")
-            pcb_docs = kicad.get_open_documents(DocumentType.DOCTYPE_PCB)
-            sch_docs = kicad.get_open_documents(DocumentType.DOCTYPE_SCHEMATIC)
-            lines.append(f"Open PCB documents: {len(pcb_docs)}")
-            lines.append(f"Open schematic documents: {len(sch_docs)}")
+
+            try:
+                pcb_docs = kicad.get_open_documents(DocumentType.DOCTYPE_PCB)
+                lines.append(f"Open PCB documents: {len(pcb_docs)}")
+            except Exception:
+                lines.append("Open PCB documents: unavailable")
+
+            try:
+                sch_docs = kicad.get_open_documents(DocumentType.DOCTYPE_SCHEMATIC)
+                lines.append(f"Open schematic documents: {len(sch_docs)}")
+            except Exception:
+                lines.append("Open schematic documents: unavailable")
+
         except KiCadConnectionError as exc:
             lines.append(f"IPC connection: unavailable ({exc})")
         except Exception as exc:

--- a/tests/unit/test_project_kicad_version.py
+++ b/tests/unit/test_project_kicad_version.py
@@ -6,8 +6,11 @@ from kicad_mcp.server import create_server
 from tests.conftest import call_tool_text
 from unittest.mock import patch, MagicMock
 
+
 @pytest.mark.anyio
-async def test_kicad_get_version_partial_document_availability(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_kicad_get_version_partial_document_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # We want to test the case where get_open_documents throws an error
     # for DOCTYPE_PCB but succeeds for DOCTYPE_SCHEMATIC.
     # The output should say "unavailable" for PCB and report the count for Schematic.
@@ -18,6 +21,7 @@ async def test_kicad_get_version_partial_document_availability(monkeypatch: pyte
 
         def get_open_documents(self, doc_type: int) -> list[str]:
             from kipy.proto.common.types.base_types_pb2 import DocumentType
+
             if doc_type == DocumentType.DOCTYPE_PCB:
                 raise RuntimeError("No handler for DOCTYPE_PCB")
             elif doc_type == DocumentType.DOCTYPE_SCHEMATIC:
@@ -34,8 +38,11 @@ async def test_kicad_get_version_partial_document_availability(monkeypatch: pyte
     assert "Open PCB documents: unavailable" in output
     assert "Open schematic documents: 2" in output
 
+
 @pytest.mark.anyio
-async def test_kicad_get_version_partial_document_availability_sch_error(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_kicad_get_version_partial_document_availability_sch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # Same but error on schematic
     class MockKiCadPartialSch:
         def get_version(self) -> str:
@@ -43,6 +50,7 @@ async def test_kicad_get_version_partial_document_availability_sch_error(monkeyp
 
         def get_open_documents(self, doc_type: int) -> list[str]:
             from kipy.proto.common.types.base_types_pb2 import DocumentType
+
             if doc_type == DocumentType.DOCTYPE_SCHEMATIC:
                 raise RuntimeError("No handler for DOCTYPE_SCHEMATIC")
             elif doc_type == DocumentType.DOCTYPE_PCB:

--- a/tests/unit/test_project_kicad_version.py
+++ b/tests/unit/test_project_kicad_version.py
@@ -4,7 +4,6 @@ import pytest
 
 from kicad_mcp.server import create_server
 from tests.conftest import call_tool_text
-from unittest.mock import patch, MagicMock
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_project_kicad_version.py
+++ b/tests/unit/test_project_kicad_version.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from kicad_mcp.server import create_server
+from tests.conftest import call_tool_text
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.anyio
+async def test_kicad_get_version_partial_document_availability(monkeypatch: pytest.MonkeyPatch) -> None:
+    # We want to test the case where get_open_documents throws an error
+    # for DOCTYPE_PCB but succeeds for DOCTYPE_SCHEMATIC.
+    # The output should say "unavailable" for PCB and report the count for Schematic.
+
+    class MockKiCadPartial:
+        def get_version(self) -> str:
+            return "10.0.0-mock"
+
+        def get_open_documents(self, doc_type: int) -> list[str]:
+            from kipy.proto.common.types.base_types_pb2 import DocumentType
+            if doc_type == DocumentType.DOCTYPE_PCB:
+                raise RuntimeError("No handler for DOCTYPE_PCB")
+            elif doc_type == DocumentType.DOCTYPE_SCHEMATIC:
+                return ["sch1", "sch2"]
+            return []
+
+    # Mock get_kicad
+    monkeypatch.setattr("kicad_mcp.tools.project.get_kicad", MockKiCadPartial)
+
+    server = create_server()
+    output = await call_tool_text(server, "kicad_get_version", {})
+
+    assert "IPC version: 10.0.0-mock" in output
+    assert "Open PCB documents: unavailable" in output
+    assert "Open schematic documents: 2" in output
+
+@pytest.mark.anyio
+async def test_kicad_get_version_partial_document_availability_sch_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same but error on schematic
+    class MockKiCadPartialSch:
+        def get_version(self) -> str:
+            return "10.0.0-mock"
+
+        def get_open_documents(self, doc_type: int) -> list[str]:
+            from kipy.proto.common.types.base_types_pb2 import DocumentType
+            if doc_type == DocumentType.DOCTYPE_SCHEMATIC:
+                raise RuntimeError("No handler for DOCTYPE_SCHEMATIC")
+            elif doc_type == DocumentType.DOCTYPE_PCB:
+                return ["pcb1"]
+            return []
+
+    # Mock get_kicad
+    monkeypatch.setattr("kicad_mcp.tools.project.get_kicad", MockKiCadPartialSch)
+
+    server = create_server()
+    output = await call_tool_text(server, "kicad_get_version", {})
+
+    assert "IPC version: 10.0.0-mock" in output
+    assert "Open PCB documents: 1" in output
+    assert "Open schematic documents: unavailable" in output


### PR DESCRIPTION
Modifies `kicad_get_version` to handle exceptions independently for PCB and schematic document fetching. This resolves an issue where the entire IPC connection was incorrectly reported as unavailable if only one of the two editors was open. Also added unit tests to verify the partial document availability scenarios.

---
*PR created automatically by Jules for task [3893305557892077209](https://jules.google.com/task/3893305557892077209) started by @oaslananka*