### PR TITLE
fix: ignore informational gate metrics in findings

### DIFF
--- a/src/kicad_mcp/tools/project.py
+++ b/src/kicad_mcp/tools/project.py
@@ -678,30 +678,14 @@ def _render_project_spec_resolution(resolution: ProjectSpecResolution) -> str:
 
 
 def _queue_reason_from_details(details: list[str], summary: str) -> str:
-    ignored_prefixes = (
-        "Footprints analysed:",
-        "Board frame:",
-        "Density:",
-        "Connector checks:",
-        "Decoupling pair checks:",
-        "RF keepout checks:",
-        "Power-tree refs checked:",
-        "Analog refs checked:",
-        "Digital refs checked:",
-        "Sensor-cluster refs checked:",
-        "Placement score:",
-    )
     for detail in details:
         cleaned = detail.strip()
-        if not cleaned or cleaned.startswith(ignored_prefixes):
-            continue
         if cleaned.startswith("FAIL: "):
             return cleaned[6:]
         if cleaned.startswith("WARN: "):
             return cleaned[6:]
         if cleaned.startswith("BLOCKED: "):
             return cleaned[9:]
-        return cleaned
     return summary
 
 

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -292,13 +292,19 @@ def _finding_for_gate_detail(outcome: GateOutcome, detail: str) -> Finding:
 
 
 def _gate_findings(outcome: GateOutcome) -> list[Finding]:
-    actionable = [
+    # Detail lines are often informational metrics (counts, score, zero-count
+    # summaries). Only explicit FAIL/WARN/BLOCKED lines should become actionable
+    # findings. When a non-passing gate has no tagged detail, fall back to a
+    # single summary finding rather than promoting every metric line to errors.
+    tagged = [
         detail
         for detail in outcome.details
-        if outcome.status != "PASS" or detail.strip().startswith(("FAIL: ", "WARN: ", "BLOCKED: "))
+        if detail.strip().startswith(("FAIL: ", "WARN: ", "BLOCKED: "))
     ]
-    if outcome.status != "PASS" and not actionable:
-        actionable = [outcome.summary]
+    if outcome.status == "PASS":
+        actionable = tagged
+    else:
+        actionable = tagged or [outcome.summary]
     return [_finding_for_gate_detail(outcome, detail) for detail in actionable]
 
 

--- a/tests/integration/test_verdict_reports.py
+++ b/tests/integration/test_verdict_reports.py
@@ -96,6 +96,87 @@ async def test_project_next_action_includes_verdict_and_finding(
 
 
 @pytest.mark.anyio
+async def test_gate_findings_ignore_informational_metric_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "kicad_mcp.tools.validation._evaluate_schematic_gate",
+        lambda: GateOutcome(
+            name="Schematic",
+            status="FAIL",
+            summary="Schematic still has blocking issues.",
+            details=[
+                "Pages analysed: 4",
+                "Dangling label groups: 0",
+                "Zero-wire pages: 0",
+                "FAIL: U1 pin 3 is not connected.",
+            ],
+        ),
+    )
+    server = build_server("full")
+
+    payload = await call_tool_payload(server, "schematic_quality_gate", {})
+
+    assert isinstance(payload, dict)
+    assert payload["verdict"] == "FAIL"
+    descriptions = [finding["description"] for finding in payload["findings"]]
+    assert descriptions == ["U1 pin 3 is not connected."]
+
+
+@pytest.mark.anyio
+async def test_project_next_action_ignores_metric_details_for_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "kicad_mcp.tools.validation._evaluate_project_gate",
+        lambda: [
+            GateOutcome(
+                name="Schematic connectivity",
+                status="FAIL",
+                summary="Connectivity smells suggest the schematic is not ready.",
+                details=[
+                    "Pages analysed: 3",
+                    "Dangling label groups: 0",
+                    "Zero-wire pages: 0",
+                    "FAIL: Sheet 'Power' is required by design intent.",
+                ],
+            )
+        ],
+    )
+    server = build_server("full")
+
+    payload = await call_tool_payload(server, "project_get_next_action", {})
+
+    assert isinstance(payload, dict)
+    assert payload["status"] == "FAIL"
+    assert payload["reason"] == "Sheet 'Power' is required by design intent."
+
+
+@pytest.mark.anyio
+async def test_non_passing_gate_without_tagged_details_uses_summary_finding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "kicad_mcp.tools.validation._evaluate_schematic_gate",
+        lambda: GateOutcome(
+            name="Schematic",
+            status="FAIL",
+            summary="ERC reported blocking issues.",
+            details=[
+                "Pages analysed: 1",
+                "Violations: 0",
+            ],
+        ),
+    )
+    server = build_server("full")
+
+    payload = await call_tool_payload(server, "schematic_quality_gate", {})
+
+    assert isinstance(payload, dict)
+    assert payload["findings"][0]["description"] == "ERC reported blocking issues."
+
+
+@pytest.mark.anyio
 async def test_pcb_board_summary_returns_verdict_report(mock_board: object) -> None:
     server = build_server("pcb")
 


### PR DESCRIPTION
Fixes #120.

## Summary
- Only explicit FAIL/WARN/BLOCKED gate detail lines become actionable findings.
- Project next-action reasons ignore informational metric lines and fall back to summaries when needed.
- Adds regression coverage for zero-count and metric-only details.

## Validation
- .venv/bin/python -m pytest tests/integration/test_verdict_reports.py -q
- .venv/bin/ruff check src/kicad_mcp/tools/validation.py src/kicad_mcp/tools/project.py tests/integration/test_verdict_reports.py