### PR TITLE
fix: ignore explicit no-connect pins in connectivity gate

### DIFF
--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -3110,8 +3110,23 @@ def _split_lib_id(lib_id: str) -> tuple[str, str]:
     return library, symbol_name
 
 
+def _extract_no_connects(content: str) -> set[tuple[float, float]]:
+    """Return schematic points carrying an explicit no-connect marker."""
+    points: set[tuple[float, float]] = set()
+    for match in re.finditer(
+        r"\(no_connect\s+\(at\s+([-\d.]+)\s+([-\d.]+)",
+        content,
+    ):
+        points.add(_point_key(float(match.group(1)), float(match.group(2))))
+    return points
+
+
 def _build_connectivity_groups(sch_file: Path) -> list[dict[str, Any]]:
     data = parse_schematic_file(sch_file)
+    try:
+        no_connect_points = _extract_no_connects(sch_file.read_text(encoding="utf-8"))
+    except OSError:
+        no_connect_points = set()
     parent: dict[tuple[float, float], tuple[float, float]] = {}
 
     def find(point: tuple[float, float]) -> tuple[float, float]:
@@ -3153,6 +3168,7 @@ def _build_connectivity_groups(sch_file: Path) -> list[dict[str, Any]]:
                 "labels": set(),
                 "power": set(),
                 "pins": [],
+                "no_connect": False,
             },
         )
 
@@ -3160,6 +3176,11 @@ def _build_connectivity_groups(sch_file: Path) -> list[dict[str, Any]]:
         group = ensure_group(_point_key(wire["x1"], wire["y1"]))
         group["points"].add(_point_key(wire["x1"], wire["y1"]))
         group["points"].add(_point_key(wire["x2"], wire["y2"]))
+
+    for point in no_connect_points:
+        group = ensure_group(point)
+        group["points"].add(point)
+        group["no_connect"] = True
 
     for label in data["labels"]:
         group = ensure_group((float(label["x"]), float(label["y"])))
@@ -3210,23 +3231,29 @@ def _build_connectivity_groups(sch_file: Path) -> list[dict[str, Any]]:
                 "labels": set(),
                 "power": set(),
                 "pins": [],
+                "no_connect": False,
             },
         )
         merged["points"].update(group["points"])
         merged["labels"].update(group["labels"])
         merged["power"].update(group["power"])
         merged["pins"].extend(group["pins"])
+        merged["no_connect"] = bool(merged["no_connect"] or group.get("no_connect"))
 
     normalized_groups: list[dict[str, Any]] = []
     for group in collapsed_groups.values():
         names = sorted({*group["labels"], *group["power"]})
+        points = sorted(group["points"])
         normalized_groups.append(
             {
                 "names": names,
-                "points": sorted(group["points"]),
+                "points": points,
                 "pins": sorted(
                     group["pins"],
                     key=lambda item: (item["reference"], item["pin"]),
+                ),
+                "no_connect": bool(
+                    group.get("no_connect") or any(point in no_connect_points for point in points)
                 ),
             }
         )
@@ -5356,7 +5383,12 @@ def register(mcp: FastMCP) -> None:
 
         lines = [f"Connectivity groups ({len(groups)} total):"]
         for index, group in enumerate(groups, start=1):
-            names = ", ".join(group["names"]) if group["names"] else "~unnamed"
+            if group["names"]:
+                names = ", ".join(group["names"])
+            elif group.get("no_connect"):
+                names = "~no-connect"
+            else:
+                names = "~unnamed"
             pins = (
                 ", ".join(f"{item['reference']}:{item['pin']}" for item in group["pins"]) or "none"
             )

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -971,7 +971,9 @@ def _evaluate_schematic_connectivity_gate() -> GateOutcome:
             )
 
         unnamed_groups = [
-            group for group in groups if not group["names"] and len(group["pins"]) == 1
+            group
+            for group in groups
+            if not group["names"] and len(group["pins"]) == 1 and not group.get("no_connect")
         ]
         unnamed_single_pin_groups += len(unnamed_groups)
         for group in unnamed_groups[:8]:

--- a/tests/integration/test_schematic_connectivity_gate.py
+++ b/tests/integration/test_schematic_connectivity_gate.py
@@ -118,6 +118,43 @@ async def test_schematic_connectivity_gate_passes_for_connected_flat_net(
 
 
 @pytest.mark.anyio
+async def test_schematic_connectivity_gate_ignores_explicit_no_connect_pins(
+    sample_project: Path,
+    mock_kicad,
+) -> None:
+    _ = mock_kicad
+    server = build_server("schematic")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    await call_tool_text(
+        server,
+        "sch_build_circuit",
+        {
+            "symbols": [
+                {
+                    "library": "Device",
+                    "symbol_name": "R",
+                    "x_mm": 10.16,
+                    "y_mm": 10.16,
+                    "reference": "R1",
+                    "value": "10k",
+                },
+            ],
+        },
+    )
+    await call_tool_text(server, "sch_add_no_connect", {"x_mm": 7.62, "y_mm": 10.16})
+    await call_tool_text(server, "sch_add_no_connect", {"x_mm": 12.7, "y_mm": 10.16})
+
+    text = await call_tool_text(server, "schematic_connectivity_gate", {})
+
+    assert "Schematic connectivity quality gate: PASS" in text
+    assert "Unnamed single-pin groups: 0" in text
+    graph = await call_tool_text(server, "sch_get_connectivity_graph", {})
+    assert "~no-connect" in graph
+    assert "~unnamed" not in graph
+
+
+@pytest.mark.anyio
 async def test_schematic_connectivity_gate_fails_for_label_only_page(
     sample_project: Path,
     mock_kicad,


### PR DESCRIPTION
Fixes #121.

## Summary
- Parse explicit schematic no-connect markers into connectivity groups.
- Exclude no-connected single-pin groups from schematic connectivity gate false-fails.
- Show those groups as ~no-connect in sch_get_connectivity_graph.

## Validation
- .venv/bin/python -m pytest tests/integration/test_schematic_connectivity_gate.py tests/integration/test_schematic_extended.py::test_schematic_add_no_connect -q
- .venv/bin/ruff check src/kicad_mcp/tools/schematic.py src/kicad_mcp/tools/validation.py tests/integration/test_schematic_connectivity_gate.py