### PR TITLE
fix: avoid generic regulator contract false matches

### DIFF
--- a/src/kicad_mcp/models/component_contracts.py
+++ b/src/kicad_mcp/models/component_contracts.py
@@ -66,7 +66,6 @@ COMPONENT_CONTRACTS: tuple[ComponentContract, ...] = (
         key="ap2112k_3v3",
         category="regulator",
         lib_ids=("Regulator_Linear:AP2112K-3.3",),
-        footprint_patterns=("Package_TO_SOT_SMD:SOT-23-5*",),
         required_net_groups=(
             ("GND",),
             ("+5V", "VBUS"),

--- a/tests/unit/test_component_contracts.py
+++ b/tests/unit/test_component_contracts.py
@@ -17,6 +17,22 @@ def test_find_component_contract_matches_footprint_pattern() -> None:
     assert contract.key == "usb_c_power_entry"
 
 
+def test_find_component_contract_matches_ap2112k_exact_lib_id() -> None:
+    contract = find_component_contract(lib_id="Regulator_Linear:AP2112K-3.3")
+
+    assert contract is not None
+    assert contract.key == "ap2112k_3v3"
+
+
+def test_find_component_contract_does_not_match_generic_regulator_footprint() -> None:
+    contract = find_component_contract(
+        lib_id="Regulator_Linear:TPS7A20xxxDBV",
+        footprint="Package_TO_SOT_SMD:SOT-23-5",
+    )
+
+    assert contract is None
+
+
 def test_find_component_contract_returns_none_for_unknown_component() -> None:
     assert find_component_contract(lib_id="Device:R", footprint="Resistor_SMD:R_0805") is None
 


### PR DESCRIPTION
Fixes #122.

## Summary
- Restrict AP2112K connectivity contract matching to its exact KiCad lib_id.
- Prevent generic SOT-23-5 regulators from being treated as AP2112K and producing spurious missing-net failures.
- Add regression tests for exact match and generic regulator non-match.

## Validation
- .venv/bin/python -m pytest tests/unit/test_component_contracts.py -q
- .venv/bin/ruff check src/kicad_mcp/models/component_contracts.py tests/unit/test_component_contracts.py