### PR TITLE
fix: preserve schematic paper size on build

### DIFF
--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -1043,6 +1043,18 @@ def _read_sheet_paper(sch_file: Path) -> str:
     return "A4"
 
 
+def _read_sheet_paper_declaration(sch_file: Path) -> str:
+    """Read the full paper declaration from a schematic, including User dimensions."""
+    try:
+        text = sch_file.read_text(encoding="utf-8", errors="replace")
+        match = re.search(r'\(paper\s+"[^"]+"(?:\s+[\d.]+\s+[\d.]+)?\)', text)
+        if match:
+            return match.group(0)
+    except Exception as exc:
+        logger.debug("sheet_paper_declaration_parse_failed", error=str(exc))
+    return '(paper "A4")'
+
+
 def _symbol_bbox_bounds(symbol: dict[str, Any]) -> tuple[float, float, float, float]:
     """Estimate a symbol bounding box and widen it to include routed pin tips."""
     x = float(symbol.get("x", symbol.get("x_mm", 0.0)) or 0.0)
@@ -4922,6 +4934,8 @@ def register(mcp: FastMCP) -> None:
                 f"Alias matches: {resolution_stats['pin_alias_resolutions']}."
             )
 
+        sch_file = _get_schematic_file()
+        paper_declaration = _read_sheet_paper_declaration(sch_file)
         root_uuid = new_uuid()
         cfg = get_config()
         project_name = cfg.project_file.stem if cfg.project_file is not None else "KiCadMCP"
@@ -5026,7 +5040,7 @@ def register(mcp: FastMCP) -> None:
             "\t(version 20250316)\n"
             '\t(generator "kicad-mcp-pro")\n'
             f'\t(uuid "{root_uuid}")\n'
-            '\t(paper "A4")\n'
+            f"\t{paper_declaration}\n"
             f"{lib_section}\n"
             + "\n".join(elements)
             + (
@@ -5041,7 +5055,7 @@ def register(mcp: FastMCP) -> None:
         )
         content = _normalize_schematic_wire_connectivity(content)
         _validate_schematic_text(content)
-        _get_schematic_file().write_text(content, encoding="utf-8")
+        sch_file.write_text(content, encoding="utf-8")
         result = _reload_schematic()
         if auto_layout and raw_nets:
             summary = (

--- a/tests/integration/test_schematic_tools.py
+++ b/tests/integration/test_schematic_tools.py
@@ -1817,6 +1817,57 @@ async def test_schematic_auto_place_functional_applies_design_intent_spacing(
 
 
 @pytest.mark.anyio
+async def test_build_circuit_preserves_existing_sheet_paper(sample_project, mock_kicad) -> None:
+    """sch_build_circuit should not reset an enlarged sheet back to A4."""
+    server = build_server("schematic")
+    await call_tool_text(server, "sch_set_sheet_size", {"paper": "A3"})
+
+    await call_tool_text(
+        server,
+        "sch_build_circuit",
+        {
+            "symbols": [
+                {
+                    "library": "Device",
+                    "symbol_name": "R",
+                    "x_mm": 10.16,
+                    "y_mm": 10.16,
+                    "reference": "R1",
+                    "value": "10k",
+                }
+            ]
+        },
+    )
+
+    schematic = (sample_project / "demo.kicad_sch").read_text(encoding="utf-8")
+    assert '(paper "A3")' in schematic
+    assert '(paper "A4")' not in schematic
+
+
+@pytest.mark.anyio
+async def test_build_circuit_preserves_user_sheet_paper_dimensions(
+    sample_project, mock_kicad
+) -> None:
+    """sch_build_circuit should preserve custom User paper dimensions."""
+    sch_file = sample_project / "demo.kicad_sch"
+    text = sch_file.read_text(encoding="utf-8")
+    sch_file.write_text(
+        re.sub(r'\(paper\s+"[^"]+"\)', '(paper "User" 298.45 217.3224)', text, count=1),
+        encoding="utf-8",
+    )
+    server = build_server("schematic")
+
+    await call_tool_text(
+        server,
+        "sch_build_circuit",
+        {"symbols": [], "wires": [], "labels": [], "power_symbols": []},
+    )
+
+    schematic = sch_file.read_text(encoding="utf-8")
+    assert '(paper "User" 298.45 217.3224)' in schematic
+
+
+@pytest.mark.anyio
 async def test_build_circuit_empty(sample_project, mock_kicad) -> None:
     """sch_build_circuit with all empty lists must not raise."""
     server = build_server("schematic")


### PR DESCRIPTION
Fixes #138.

## Summary
- sch_build_circuit now preserves the existing schematic paper declaration instead of resetting to A4.
- Preserves custom User paper dimensions as well as standard sizes like A3.
- Adds regression tests for A3 and User paper declarations.

## Validation
- .venv/bin/python -m pytest tests/integration/test_schematic_tools.py::test_build_circuit_preserves_existing_sheet_paper tests/integration/test_schematic_tools.py::test_build_circuit_preserves_user_sheet_paper_dimensions tests/integration/test_schematic_tools.py::test_build_circuit_empty tests/integration/test_schematic_extended.py::test_schematic_set_sheet_size_valid -q
- .venv/bin/ruff check src/kicad_mcp/tools/schematic.py tests/integration/test_schematic_tools.py