### PR TITLE
fix: preserve unsnapped power symbol coordinates

### DIFF
--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -4256,7 +4256,8 @@ def register(mcp: FastMCP) -> None:
         sheet_file: str | None = None,
     ) -> str:
         """Add a power symbol, snapping its anchor to the 2.54 mm grid by default."""
-        return str(
+        placed_x, placed_y = _snap_point(x_mm, y_mm, snap_to_grid)
+        result = str(
             sch_add_symbol(
                 library="power",
                 symbol_name=name,
@@ -4271,6 +4272,9 @@ def register(mcp: FastMCP) -> None:
                 sheet_file=sheet_file,
             )
         )
+        if "was not found" in result:
+            return result
+        return f"{result}\nPower symbol {name} placed at ({_fmt_mm(placed_x)}, {_fmt_mm(placed_y)})"
 
     @mcp.tool()
     def sch_add_bus(

--- a/tests/integration/test_schematic_extended.py
+++ b/tests/integration/test_schematic_extended.py
@@ -783,6 +783,30 @@ async def test_schematic_add_power_symbol_rotated(sample_project, mock_kicad) ->
 
 
 @pytest.mark.anyio
+async def test_schematic_add_power_symbol_preserves_unsnapped_coordinate(
+    sample_project, mock_kicad
+) -> None:
+    """snap_to_grid=False should preserve the exact requested power-symbol origin."""
+    server = build_server("schematic")
+    result = await call_tool_text(
+        server,
+        "sch_add_power_symbol",
+        {
+            "name": "GND",
+            "x_mm": 340.13,
+            "y_mm": 70.37,
+            "snap_to_grid": False,
+        },
+    )
+
+    schematic = (sample_project / "demo.kicad_sch").read_text(encoding="utf-8")
+    assert "Power symbol GND placed at (340.13, 70.37)" in result
+    assert '(lib_id "power:GND")' in schematic
+    assert "\t\t(at 340.13 70.37 0)" in schematic
+    assert "233.68" not in schematic
+
+
+@pytest.mark.anyio
 async def test_schematic_add_symbol_with_unit(sample_project, mock_kicad) -> None:
     """sch_add_symbol should support unit parameter for multi-unit symbols."""
     server = build_server("schematic")


### PR DESCRIPTION
Fixes #110.

## Summary
- sch_add_power_symbol now reports the final placed coordinate for follow-up label/wire operations.
- snap_to_grid=False preserves the requested power-symbol origin exactly.
- Keeps existing snapped placement and rotation behavior covered by existing tests.

## Validation
- .venv/bin/python -m pytest tests/integration/test_schematic_extended.py::test_schematic_add_power_symbol_preserves_unsnapped_coordinate tests/integration/test_schematic_extended.py::test_schematic_add_power_symbol_rotated tests/integration/test_schematic_tools.py::test_power_symbol_reference_is_hidden_and_value_offset tests/integration/test_schematic_tools.py::test_schematic_misc_file_tools_cover_buses_labels_jumper_and_project_flags -q
- .venv/bin/ruff check src/kicad_mcp/tools/schematic.py tests/integration/test_schematic_extended.py