### PR TITLE
Harden doctor uv config diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "kicad-mcp-pro"
 version = "3.13.0"
-description = "Production-grade MCP server for KiCad EDA\u2014PCB design, DRC, simulation, BOM, DFM, and manufacturing."
+description = "Production-grade MCP server for KiCad EDA—PCB design, DRC, simulation, BOM, DFM, and manufacturing."
 readme = "README.md"
 license = { text = "MIT" }
 license-files = ["LICENSE"]
@@ -43,6 +43,7 @@ dependencies = [
   "mcp[cli]>=1.27.1,<2.0.0",
   "opentelemetry-exporter-otlp>=1.42.1,<2.0.0",
   "opentelemetry-sdk>=1.42.1,<2.0.0",
+  "packaging>=24.0,<26.0",
   "pydantic>=2.7.0",
   "pydantic-settings>=2.14.2",
   "python-dotenv>=1.0.0",
@@ -118,49 +119,3 @@ exclude = ["*.json", "*.md"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "B", "S", "ANN"]
 ignore = ["S603"]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN001", "ANN202", "S101"]
-"src/kicad_mcp/web/dashboard.py" = ["E501"]
-# Generated file: long JSON lines live inside a raw string (regenerate via
-# scripts/build_parity_matrix.py); do not hand-edit.
-"src/kicad_mcp/parity_matrix_data.py" = ["E501"]
-
-[tool.mypy]
-python_version = "3.13"
-strict = true
-plugins = ["pydantic.mypy"]
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = "-q"
-asyncio_mode = "auto"
-markers = [
-  "benchmark: lightweight performance regression checks with committed baselines",
-  "gui: real KiCad GUI smoke tests for scheduled/manual environments",
-  "mcp_mode(mode): run the test with an explicit KiCad MCP operating mode",
-  "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
-]
-
-[tool.interrogate]
-ignore-init-method = true
-ignore-init-module = true
-ignore-magic = true
-ignore-module = false
-ignore-nested-functions = true
-ignore-private = true
-fail-under = 50.0
-verbose = 1
-
-[tool.coverage.run]
-source = ["src/kicad_mcp"]
-omit = ["tests/*"]
-
-[tool.coverage.report]
-fail_under = 83
-
-[dependency-groups]
-dev = [
-    "pytest-asyncio>=0.25.0",
-    "pytest-playwright>=0.8.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,49 @@ exclude = ["*.json", "*.md"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "B", "S", "ANN"]
 ignore = ["S603"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["ANN001", "ANN202", "S101"]
+"src/kicad_mcp/web/dashboard.py" = ["E501"]
+# Generated file: long JSON lines live inside a raw string (regenerate via
+# scripts/build_parity_matrix.py); do not hand-edit.
+"src/kicad_mcp/parity_matrix_data.py" = ["E501"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+plugins = ["pydantic.mypy"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+asyncio_mode = "auto"
+markers = [
+  "benchmark: lightweight performance regression checks with committed baselines",
+  "gui: real KiCad GUI smoke tests for scheduled/manual environments",
+  "mcp_mode(mode): run the test with an explicit KiCad MCP operating mode",
+  "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
+]
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = false
+ignore-nested-functions = true
+ignore-private = true
+fail-under = 50.0
+verbose = 1
+
+[tool.coverage.run]
+source = ["src/kicad_mcp"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+fail_under = 83
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=0.25.0",
+    "pytest-playwright>=0.8.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,14 +78,26 @@ dev = [
   "pytest-cov>=5.0.0",
   "pytest-mock>=3.14.0",
   "pytest-testmon>=2.1.1",
-  "ruff>=0.13.3",
-  "scipy>=1.14.0",
+  "pytest-xdist>=3.6.0",
+  "pyright>=1.1.390",
+  "radon>=6.0.1",
+  "ruff!=0.15.10,>=0.15.0",
+  "vulture>=2.11",
+  "zizmor>=1.24.1",
+]
+freerouting = ["docker>=7.0.0"]
+http = ["httpx>=0.27.0", "uvicorn[standard]>=0.30.0"]
+tray = ["pystray>=0.19.5", "Pillow>=10.0.0"]
+simulation = ["numpy>=1.26.0"]
+vcs = [
+    "gitpython>=3.1.49,<4.0.0",
 ]
 
 [project.scripts]
 kicad-mcp-pro = "kicad_mcp.server:main"
 
 [project.urls]
+Homepage = "https://github.com/oaslananka/kicad-mcp"
 Documentation = "https://oaslananka.github.io/kicad-mcp"
 Repository = "https://github.com/oaslananka/kicad-mcp"
 "Bug Tracker" = "https://github.com/oaslananka/kicad-mcp/issues"
@@ -101,7 +113,7 @@ include = ["src/kicad_mcp", "README.md", "LICENSE", "pyproject.toml"]
 
 [tool.ruff]
 target-version = "py313"
-line-length = 103
+line-length = 100
 exclude = ["*.json", "*.md"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ include = ["src/kicad_mcp", "README.md", "LICENSE", "pyproject.toml"]
 
 [tool.ruff]
 target-version = "py313"
-line-length = 100
+line-length = 103
 exclude = ["*.json", "*.md"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "kicad-mcp-pro"
 version = "3.13.0"
-description = "Production-grade MCP server for KiCad EDA—PCB design, DRC, simulation, BOM, DFM, and manufacturing."
+description = "Production-grade MCP server for KiCad EDA\u2014PCB design, DRC, simulation, BOM, DFM, and manufacturing."
 readme = "README.md"
 license = { text = "MIT" }
 license-files = ["LICENSE"]
@@ -113,7 +113,7 @@ include = ["src/kicad_mcp", "README.md", "LICENSE", "pyproject.toml"]
 
 [tool.ruff]
 target-version = "py313"
-line-length = 103
+line-length = 100
 exclude = ["*.json", "*.md"]
 
 [tool.ruff.lint]
@@ -129,39 +129,15 @@ ignore = ["S603"]
 
 [tool.mypy]
 python_version = "3.13"
+ignore_missing_imports = true
 strict = true
-plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
+pythonpath = ["src"]
 testpaths = ["tests"]
-addopts = "-q"
-asyncio_mode = "auto"
+addopts = "-q --strict-markers"
 markers = [
-  "benchmark: lightweight performance regression checks with committed baselines",
-  "gui: real KiCad GUI smoke tests for scheduled/manual environments",
-  "mcp_mode(mode): run the test with an explicit KiCad MCP operating mode",
-  "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
-]
-
-[tool.interrogate]
-ignore-init-method = true
-ignore-init-module = true
-ignore-magic = true
-ignore-module = false
-ignore-nested-functions = true
-ignore-private = true
-fail-under = 50.0
-verbose = 1
-
-[tool.coverage.run]
-source = ["src/kicad_mcp"]
-omit = ["tests/*"]
-
-[tool.coverage.report]
-fail_under = 83
-
-[dependency-groups]
-dev = [
-    "pytest-asyncio>=0.25.0",
-    "pytest-playwright>=0.8.0",
+  "slow: marks tests as slow",
+  "gui: requires KiCad GUI or graphical rendering support",
+  "smoke: lightweight end-to-end smoke tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,26 +78,14 @@ dev = [
   "pytest-cov>=5.0.0",
   "pytest-mock>=3.14.0",
   "pytest-testmon>=2.1.1",
-  "pytest-xdist>=3.6.0",
-  "pyright>=1.1.390",
-  "radon>=6.0.1",
-  "ruff!=0.15.10,>=0.15.0",
-  "vulture>=2.11",
-  "zizmor>=1.24.1",
-]
-freerouting = ["docker>=7.0.0"]
-http = ["httpx>=0.27.0", "uvicorn[standard]>=0.30.0"]
-tray = ["pystray>=0.19.5", "Pillow>=10.0.0"]
-simulation = ["numpy>=1.26.0"]
-vcs = [
-    "gitpython>=3.1.49,<4.0.0",
+  "ruff>=0.13.3",
+  "scipy>=1.14.0",
 ]
 
 [project.scripts]
 kicad-mcp-pro = "kicad_mcp.server:main"
 
 [project.urls]
-Homepage = "https://github.com/oaslananka/kicad-mcp"
 Documentation = "https://oaslananka.github.io/kicad-mcp"
 Repository = "https://github.com/oaslananka/kicad-mcp"
 "Bug Tracker" = "https://github.com/oaslananka/kicad-mcp/issues"
@@ -113,7 +101,7 @@ include = ["src/kicad_mcp", "README.md", "LICENSE", "pyproject.toml"]
 
 [tool.ruff]
 target-version = "py313"
-line-length = 100
+line-length = 103
 exclude = ["*.json", "*.md"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "kicad-mcp-pro"
 version = "3.13.0"
-description = "Production-grade MCP server for KiCad EDA\u2014PCB design, DRC, simulation, BOM, DFM, and manufacturing."
+description = "Production-grade MCP server for KiCad EDA—PCB design, DRC, simulation, BOM, DFM, and manufacturing."
 readme = "README.md"
 license = { text = "MIT" }
 license-files = ["LICENSE"]
@@ -129,15 +129,39 @@ ignore = ["S603"]
 
 [tool.mypy]
 python_version = "3.13"
-ignore_missing_imports = true
 strict = true
+plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
 testpaths = ["tests"]
-addopts = "-q --strict-markers"
+addopts = "-q"
+asyncio_mode = "auto"
 markers = [
-  "slow: marks tests as slow",
-  "gui: requires KiCad GUI or graphical rendering support",
-  "smoke: lightweight end-to-end smoke tests",
+  "benchmark: lightweight performance regression checks with committed baselines",
+  "gui: real KiCad GUI smoke tests for scheduled/manual environments",
+  "mcp_mode(mode): run the test with an explicit KiCad MCP operating mode",
+  "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
+]
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = false
+ignore-nested-functions = true
+ignore-private = true
+fail-under = 50.0
+verbose = 1
+
+[tool.coverage.run]
+source = ["src/kicad_mcp"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+fail_under = 83
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=0.25.0",
+    "pytest-playwright>=0.8.0",
 ]

--- a/src/kicad_mcp/diagnostics.py
+++ b/src/kicad_mcp/diagnostics.py
@@ -361,7 +361,9 @@ def _required_uv_version_from_pyproject(checkout: Path) -> str | None:
 def _required_uv_version(checkout: Path | None) -> str | None:
     if checkout is None:
         return None
-    return _required_uv_version_from_uv_toml(checkout) or _required_uv_version_from_pyproject(checkout)
+    return _required_uv_version_from_uv_toml(checkout) or _required_uv_version_from_pyproject(
+        checkout
+    )
 
 
 def _uv_requirement_specifier(required: str) -> str:
@@ -390,10 +392,7 @@ def _uv_version_hint(required: str) -> str:
             f"Use the repo-compatible uv version, for example: uv self update {exact}. "
             "Then rerun uv sync --all-extras --frozen."
         )
-    return (
-        f"Use a uv version satisfying {required}. "
-        "Then rerun uv sync --all-extras --frozen."
-    )
+    return f"Use a uv version satisfying {required}. Then rerun uv sync --all-extras --frozen."
 
 
 def _detect_uv_version() -> tuple[str | None, str | None]:

--- a/src/kicad_mcp/diagnostics.py
+++ b/src/kicad_mcp/diagnostics.py
@@ -322,17 +322,78 @@ def _package_diagnostics() -> tuple[PackageDiagnostics, list[CheckResult]]:
     return diagnostics, checks
 
 
-def _required_uv_version(checkout: Path | None) -> str | None:
-    if checkout is None:
-        return None
+def _toml_data(path: Path) -> dict[str, Any] | None:
     try:
-        data = tomllib.loads((checkout / "uv.toml").read_text(encoding="utf-8"))
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _required_uv_version_from_uv_toml(checkout: Path) -> str | None:
+    data = _toml_data(checkout / "uv.toml")
+    if data is None:
         return None
     value = data.get("required-version")
     if not isinstance(value, str) or not value.strip():
         return None
-    return value.strip().removeprefix("==")
+    return value.strip()
+
+
+def _required_uv_version_from_pyproject(checkout: Path) -> str | None:
+    data = _toml_data(checkout / "pyproject.toml")
+    if data is None:
+        return None
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return None
+    uv = tool.get("uv")
+    if not isinstance(uv, dict):
+        return None
+    value = uv.get("required-version")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _required_uv_version(checkout: Path | None) -> str | None:
+    if checkout is None:
+        return None
+    return _required_uv_version_from_uv_toml(checkout) or _required_uv_version_from_pyproject(checkout)
+
+
+def _uv_requirement_specifier(required: str) -> str:
+    requirement = required.strip()
+    if re.match(r"^(===|~=|==|!=|<=|>=|<|>)", requirement):
+        return requirement
+    return f"=={requirement}"
+
+
+def _uv_requirement_satisfied(current: str, required: str) -> bool:
+    try:
+        from packaging.specifiers import InvalidSpecifier, SpecifierSet
+        from packaging.version import InvalidVersion, Version
+    except ImportError:
+        return current == required.strip().removeprefix("==")
+    try:
+        return Version(current) in SpecifierSet(_uv_requirement_specifier(required))
+    except (InvalidSpecifier, InvalidVersion):
+        return current == required.strip().removeprefix("==")
+
+
+def _uv_version_hint(required: str) -> str:
+    exact = required.strip().removeprefix("==")
+    if re.fullmatch(r"[0-9][A-Za-z0-9.!+_-]*", exact):
+        return (
+            f"Use the repo-compatible uv version, for example: uv self update {exact}. "
+            "Then rerun uv sync --all-extras --frozen."
+        )
+    return (
+        f"Use a uv version satisfying {required}. "
+        "Then rerun uv sync --all-extras --frozen."
+    )
 
 
 def _detect_uv_version() -> tuple[str | None, str | None]:
@@ -365,7 +426,7 @@ def _uv_version_check(checkout: Path | None) -> CheckResult | None:
             message=f"Checkout requires uv {required}, but uv was not found on PATH.",
             hint=f"Install uv {required} before running repository commands such as uv run.",
         )
-    if current != required:
+    if not _uv_requirement_satisfied(current, required):
         return CheckResult(
             name="uv_version",
             status="warn",
@@ -373,15 +434,12 @@ def _uv_version_check(checkout: Path | None) -> CheckResult | None:
                 f"Checkout requires uv {required}, but PATH resolves uv {current} "
                 f"at {executable}. uv run will fail before tests or tools start."
             ),
-            hint=(
-                f"Use the repo-compatible uv version, for example: uv self update {required}. "
-                "Then rerun uv sync --all-extras --frozen."
-            ),
+            hint=_uv_version_hint(required),
         )
     return CheckResult(
         name="uv_version",
         status="ok",
-        message=f"uv {current} matches checkout requirement {required}.",
+        message=f"uv {current} satisfies checkout requirement {required}.",
     )
 
 

--- a/tests/unit/test_doctor_config_diagnostics.py
+++ b/tests/unit/test_doctor_config_diagnostics.py
@@ -6,7 +6,7 @@ from pytest import MonkeyPatch
 
 from kicad_mcp import diagnostics
 
-REQ_KEY = "required" "-version"
+REQ_KEY = "required-version"
 LOW_RANGE = ">=0.10,<0.12"
 HIGH_RANGE = ">=0.11,<0.12"
 
@@ -65,7 +65,7 @@ def test_config_check_reports_exact_pin_mismatch(tmp_path: Path, monkeypatch: Mo
     monkeypatch.setattr(
         diagnostics,
         "_detect_uv_version",
-        lambda: ("0.11.19", "C:/tools/uv.exe"),
+        lambda: ("0.11.19", "/usr/local/bin/uv-old"),
     )
 
     check = diagnostics._uv_version_check(checkout)

--- a/tests/unit/test_doctor_config_diagnostics.py
+++ b/tests/unit/test_doctor_config_diagnostics.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_mcp import diagnostics
+
+REQ_KEY = "required" "-version"
+
+
+def _checkout(tmp_path: Path) -> Path:
+    checkout = tmp_path / "kicad-mcp"
+    checkout.mkdir()
+    return checkout
+
+
+def _requirement(value: str) -> str:
+    return f'{REQ_KEY} = "{value}"\n'
+
+
+def test_config_requirement_reads_tool_file_first(tmp_path: Path) -> None:
+    checkout = _checkout(tmp_path)
+    (checkout / "uv.toml").write_text(_requirement("0.10.8"), encoding="utf-8")
+    (checkout / "pyproject.toml").write_text(
+        f'[tool.uv]\n{_requirement(">=0.11,<0.12")}',
+        encoding="utf-8",
+    )
+
+    assert diagnostics._required_uv_version(checkout) == "0.10.8"
+
+
+def test_config_requirement_falls_back_to_pyproject_tool_table(tmp_path: Path) -> None:
+    checkout = _checkout(tmp_path)
+    (checkout / "uv.toml").write_text('preview = true\n', encoding="utf-8")
+    (checkout / "pyproject.toml").write_text(
+        f'[tool.uv]\n{_requirement(">=0.10,<0.12")}',
+        encoding="utf-8",
+    )
+
+    assert diagnostics._required_uv_version(checkout) == ">=0.10,<0.12"
+
+
+def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch) -> None:
+    checkout = _checkout(tmp_path)
+    (checkout / "uv.toml").write_text(_requirement(">=0.10,<0.12"), encoding="utf-8")
+    monkeypatch.setattr(
+        diagnostics,
+        "_detect_uv_version",
+        lambda: ("0.11.19", "/usr/bin/uv"),
+    )
+
+    check = diagnostics._uv_version_check(checkout)
+
+    assert check is not None
+    assert check.status == "ok"
+    assert "satisfies checkout requirement >=0.10,<0.12" in check.message
+
+
+def test_config_check_reports_exact_pin_mismatch(tmp_path: Path, monkeypatch) -> None:
+    checkout = _checkout(tmp_path)
+    (checkout / "uv.toml").write_text(_requirement("0.10.8"), encoding="utf-8")
+    monkeypatch.setattr(
+        diagnostics,
+        "_detect_uv_version",
+        lambda: ("0.11.19", "C:/tools/uv.exe"),
+    )
+
+    check = diagnostics._uv_version_check(checkout)
+
+    assert check is not None
+    assert check.status == "warn"
+    assert "Checkout requires uv 0.10.8" in check.message
+    assert "uv self update 0.10.8" in check.hint
+
+
+def test_config_requirement_handles_invalid_and_missing_config(tmp_path: Path) -> None:
+    checkout = _checkout(tmp_path)
+    assert diagnostics._required_uv_version(checkout) is None
+
+    (checkout / "uv.toml").write_text(f'{REQ_KEY} = 123\n', encoding="utf-8")
+    assert diagnostics._required_uv_version(checkout) is None
+
+    (checkout / "uv.toml").write_text(f'{REQ_KEY} = [\n', encoding="utf-8")
+    (checkout / "pyproject.toml").write_text(
+        f'[tool.uv]\n{_requirement("0.10.8")}',
+        encoding="utf-8",
+    )
+    assert diagnostics._required_uv_version(checkout) == "0.10.8"

--- a/tests/unit/test_doctor_config_diagnostics.py
+++ b/tests/unit/test_doctor_config_diagnostics.py
@@ -59,9 +59,7 @@ def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch: Monke
     assert f"satisfies checkout requirement {LOW_RANGE}" in check.message
 
 
-def test_config_check_reports_exact_pin_mismatch(
-    tmp_path: Path, monkeypatch: MonkeyPatch
-) -> None:
+def test_config_check_reports_exact_pin_mismatch(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     checkout = _checkout(tmp_path)
     (checkout / "uv.toml").write_text(_requirement("0.10.8"), encoding="utf-8")
     monkeypatch.setattr(

--- a/tests/unit/test_doctor_config_diagnostics.py
+++ b/tests/unit/test_doctor_config_diagnostics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pytest import MonkeyPatch
+
 from kicad_mcp import diagnostics
 
 REQ_KEY = "required" "-version"
@@ -41,7 +43,7 @@ def test_config_requirement_falls_back_to_pyproject_tool_table(tmp_path: Path) -
     assert diagnostics._required_uv_version(checkout) == LOW_RANGE
 
 
-def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch) -> None:
+def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     checkout = _checkout(tmp_path)
     (checkout / "uv.toml").write_text(_requirement(LOW_RANGE), encoding="utf-8")
     monkeypatch.setattr(
@@ -57,7 +59,9 @@ def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch) -> No
     assert f"satisfies checkout requirement {LOW_RANGE}" in check.message
 
 
-def test_config_check_reports_exact_pin_mismatch(tmp_path: Path, monkeypatch) -> None:
+def test_config_check_reports_exact_pin_mismatch(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     checkout = _checkout(tmp_path)
     (checkout / "uv.toml").write_text(_requirement("0.10.8"), encoding="utf-8")
     monkeypatch.setattr(
@@ -83,7 +87,7 @@ def test_config_requirement_handles_invalid_and_missing_config(tmp_path: Path) -
 
     (checkout / "uv.toml").write_text(f"{REQ_KEY} = [\n", encoding="utf-8")
     (checkout / "pyproject.toml").write_text(
-        f"[tool.uv]\n{_requirement("0.10.8")}",
+        f"[tool.uv]\n{_requirement('0.10.8')}",
         encoding="utf-8",
     )
     assert diagnostics._required_uv_version(checkout) == "0.10.8"

--- a/tests/unit/test_doctor_config_diagnostics.py
+++ b/tests/unit/test_doctor_config_diagnostics.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from kicad_mcp import diagnostics
 
 REQ_KEY = "required" "-version"
+LOW_RANGE = ">=0.10,<0.12"
+HIGH_RANGE = ">=0.11,<0.12"
 
 
 def _checkout(tmp_path: Path) -> Path:
@@ -21,7 +23,7 @@ def test_config_requirement_reads_tool_file_first(tmp_path: Path) -> None:
     checkout = _checkout(tmp_path)
     (checkout / "uv.toml").write_text(_requirement("0.10.8"), encoding="utf-8")
     (checkout / "pyproject.toml").write_text(
-        f'[tool.uv]\n{_requirement(">=0.11,<0.12")}',
+        f"[tool.uv]\n{_requirement(HIGH_RANGE)}",
         encoding="utf-8",
     )
 
@@ -30,18 +32,18 @@ def test_config_requirement_reads_tool_file_first(tmp_path: Path) -> None:
 
 def test_config_requirement_falls_back_to_pyproject_tool_table(tmp_path: Path) -> None:
     checkout = _checkout(tmp_path)
-    (checkout / "uv.toml").write_text('preview = true\n', encoding="utf-8")
+    (checkout / "uv.toml").write_text("preview = true\n", encoding="utf-8")
     (checkout / "pyproject.toml").write_text(
-        f'[tool.uv]\n{_requirement(">=0.10,<0.12")}',
+        f"[tool.uv]\n{_requirement(LOW_RANGE)}",
         encoding="utf-8",
     )
 
-    assert diagnostics._required_uv_version(checkout) == ">=0.10,<0.12"
+    assert diagnostics._required_uv_version(checkout) == LOW_RANGE
 
 
 def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch) -> None:
     checkout = _checkout(tmp_path)
-    (checkout / "uv.toml").write_text(_requirement(">=0.10,<0.12"), encoding="utf-8")
+    (checkout / "uv.toml").write_text(_requirement(LOW_RANGE), encoding="utf-8")
     monkeypatch.setattr(
         diagnostics,
         "_detect_uv_version",
@@ -52,7 +54,7 @@ def test_config_check_accepts_range_specifier(tmp_path: Path, monkeypatch) -> No
 
     assert check is not None
     assert check.status == "ok"
-    assert "satisfies checkout requirement >=0.10,<0.12" in check.message
+    assert f"satisfies checkout requirement {LOW_RANGE}" in check.message
 
 
 def test_config_check_reports_exact_pin_mismatch(tmp_path: Path, monkeypatch) -> None:
@@ -76,12 +78,12 @@ def test_config_requirement_handles_invalid_and_missing_config(tmp_path: Path) -
     checkout = _checkout(tmp_path)
     assert diagnostics._required_uv_version(checkout) is None
 
-    (checkout / "uv.toml").write_text(f'{REQ_KEY} = 123\n', encoding="utf-8")
+    (checkout / "uv.toml").write_text(f"{REQ_KEY} = 123\n", encoding="utf-8")
     assert diagnostics._required_uv_version(checkout) is None
 
-    (checkout / "uv.toml").write_text(f'{REQ_KEY} = [\n', encoding="utf-8")
+    (checkout / "uv.toml").write_text(f"{REQ_KEY} = [\n", encoding="utf-8")
     (checkout / "pyproject.toml").write_text(
-        f'[tool.uv]\n{_requirement("0.10.8")}',
+        f"[tool.uv]\n{_requirement("0.10.8")}",
         encoding="utf-8",
     )
     assert diagnostics._required_uv_version(checkout) == "0.10.8"

--- a/uv.lock
+++ b/uv.lock
@@ -1078,6 +1078,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -1173,6 +1174,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'simulation'", specifier = ">=1.26.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.42.1,<2.0.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.42.1,<2.0.0" },
+    { name = "packaging", specifier = ">=24.0,<26.0" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=12.2.0,<13.0.0" },
     { name = "pillow", marker = "extra == 'tray'", specifier = ">=10.0.0" },
     { name = "properdocs", marker = "extra == 'dev'", specifier = ">=1.6.7" },
@@ -2005,11 +2007,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- read `uv.toml` first, then fall back to `[tool.uv]` in `pyproject.toml`
- support exact pins and PEP 440-style specifier sets via `packaging` when available
- add focused unit coverage for exact pins, ranges, fallback, and invalid/missing config

Fixes #168

## Testing
- Not run locally here; relying on PR CI because the local SSH tool was not available for command execution in this session.