### PR TITLE
Fix documented CLI command name

### DIFF
--- a/docs/agents/antigravity.md
+++ b/docs/agents/antigravity.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup antigravity
+kicad-mcp-pro setup antigravity
 ```
 
 Or manually add to `~/.gemini/config/mcp_config.json`:

--- a/docs/agents/claude-desktop.md
+++ b/docs/agents/claude-desktop.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup claude-desktop
+kicad-mcp-pro setup claude-desktop
 ```
 
 Or manually:
@@ -40,7 +40,7 @@ Claude Desktop local config is **separate** from Claude.ai custom connectors. Lo
 ## Verification
 
 ```bash
-kicad-mcp doctor --agent claude-desktop
+kicad-mcp-pro doctor --agent claude-desktop
 ```
 
 In Claude Desktop, ask: *"Use the kicad MCP server to inspect the current project."*

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup codex
+kicad-mcp-pro setup codex
 ```
 
 Or manually add to `~/.codex/config.toml`:
@@ -33,7 +33,7 @@ KICAD_MCP_OPERATING_MODE = "readonly"
 
 ## Verification
 
-Run: `kicad-mcp doctor --agent codex`
+Run: `kicad-mcp-pro doctor --agent codex`
 
 The kicad tools appear automatically in Codex CLI when the config is present.
 

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup cursor
+kicad-mcp-pro setup cursor
 ```
 
 Or manually:

--- a/docs/agents/gemini-cli.md
+++ b/docs/agents/gemini-cli.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup gemini
+kicad-mcp-pro setup gemini
 ```
 
 Or manually add to `~/.gemini/settings.json`:

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup opencode
+kicad-mcp-pro setup opencode
 ```
 
 Or manually add to `opencode.json`:
@@ -43,7 +43,7 @@ Or manually add to `opencode.json`:
 
 ```bash
 opencode mcp list
-kicad-mcp doctor --agent opencode
+kicad-mcp-pro doctor --agent opencode
 ```
 
 ## Plugin

--- a/docs/agents/vscode-copilot.md
+++ b/docs/agents/vscode-copilot.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-kicad-mcp setup vscode
+kicad-mcp-pro setup vscode
 ```
 
 Or manually add `.vscode/mcp.json`:


### PR DESCRIPTION
## Summary
- replace documented `kicad-mcp setup ...` commands with the actual console script `kicad-mcp-pro setup ...`
- replace documented `kicad-mcp doctor ...` verification commands with `kicad-mcp-pro doctor ...`
- keep package/repository names unchanged

## Rationale
`pyproject.toml` exposes only the `kicad-mcp-pro` console script, so examples using `kicad-mcp` are not runnable for users.

## Testing
- documentation-only change; no local tests run