### PR TITLE
fix: address code-review feedback on merged #167

### DIFF
--- a/src/kicad_mcp/companion/context.py
+++ b/src/kicad_mcp/companion/context.py
@@ -81,6 +81,8 @@ class _HttpResponse(Protocol):
 
     def read(self) -> bytes | str: ...
 
+    def close(self) -> None: ...
+
 
 Opener = Callable[[urllib.request.Request], _HttpResponse]
 
@@ -159,10 +161,13 @@ class StudioContextClient:
             self._url, data=body, headers=headers, method="POST"
         )
         response = self._opener(request)
-        raw = response.read()
-        if isinstance(raw, bytes):
-            raw = raw.decode("utf-8")
-        return json.loads(raw) if raw else {}
+        try:
+            raw = response.read()
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            return json.loads(raw) if raw else {}
+        finally:
+            response.close()
 
     def push(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """POST the context to the server and return the decoded JSON response."""

--- a/src/kicad_mcp/ipc/command_queue.py
+++ b/src/kicad_mcp/ipc/command_queue.py
@@ -161,8 +161,23 @@ class KiCadCommandQueue:
                         and attempts <= self._max_retries
                     )
                     if can_retry:
-                        if self._reconnect is not None:
-                            self._reconnect()
+                        try:
+                            if self._reconnect is not None:
+                                self._reconnect()
+                        except Exception as reconnect_exc:  # noqa: BLE001 - journaled, then re-raised
+                            self._journal.append(
+                                JournalEntry(
+                                    operation=operation,
+                                    correlation_id=correlation_id,
+                                    idempotency_key=idempotency_key,
+                                    attempts=attempts,
+                                    status="failed",
+                                    duration_s=self._time() - started,
+                                    error_code=getattr(reconnect_exc, "code", None),
+                                    error_class=type(reconnect_exc).__name__,
+                                )
+                            )
+                            raise
                         self._sleep(self.backoff_delay(attempts))
                         continue
                     self._journal.append(

--- a/src/kicad_mcp/models/contract_verifier.py
+++ b/src/kicad_mcp/models/contract_verifier.py
@@ -113,34 +113,51 @@ def extract_balanced_block(text: str, start: int) -> str:
 def parse_symbol_pins(symbol_block: str) -> tuple[Pin, ...]:
     """Extract pins from a ``(symbol "Lib:Name" ...)`` definition block.
 
-    KiCad stores pins inside the symbol's unit sub-symbols; a single ``findall``
-    over the whole block captures them all. Duplicate pin numbers (which can
-    appear when a part is drawn as multiple units) are collapsed to the first
-    occurrence so the count reflects distinct electrical pins.
+    Each ``(pin ...)`` sub-expression is isolated as a balanced block and parsed
+    on its own, so a pin missing a name or number cannot bleed into the next
+    pin's fields (a single non-greedy ``findall`` over the whole block could).
+    Duplicate pin numbers (parts drawn as multiple units) are collapsed to the
+    first occurrence so the count reflects distinct electrical pins.
     """
 
-    matches = re.findall(
-        r'\(pin\s+(\w+)\s+\w+.*?\(name\s+"([^"]*)".*?\(number\s+"([^"]*)"',
-        symbol_block,
-        re.DOTALL,
-    )
     seen: set[str] = set()
     pins: list[Pin] = []
-    for electrical_type, name, number in matches:
+    cursor = 0
+    while True:
+        index = symbol_block.find("(pin ", cursor)
+        if index == -1:
+            break
+        pin_block = extract_balanced_block(symbol_block, index)
+        cursor = index + len(pin_block)
+        type_match = re.match(r"\(pin\s+(\w+)", pin_block)
+        name_match = re.search(r'\(name\s+"([^"]*)"', pin_block)
+        number_match = re.search(r'\(number\s+"([^"]*)"', pin_block)
+        if not (type_match and name_match and number_match):
+            continue
+        number = number_match.group(1)
         if number in seen:
             continue
         seen.add(number)
-        pins.append(Pin(number=number, name=name, electrical_type=electrical_type))
+        pins.append(
+            Pin(
+                number=number,
+                name=name_match.group(1),
+                electrical_type=type_match.group(1),
+            )
+        )
     return tuple(pins)
 
 
 def parse_footprint(text: str) -> FootprintShape:
     """Extract structural facts from ``.kicad_mod`` footprint text."""
 
-    pads = re.findall(r'\(pad\s+"([^"]*)"\s+(\w+)', text)
+    # Pad numbers may be quoted (``(pad "1" ...)``, modern KiCad) or bare
+    # (``(pad 1 ...)``, older/hand-written footprints); accept both.
+    pads = re.findall(r'\(pad\s+(?:"([^"]*)"|([^\s()]+))\s+(\w+)', text)
     connectable: list[str] = []
     mechanical = 0
-    for number, _pad_type in pads:
+    for quoted, unquoted, _pad_type in pads:
+        number = quoted if quoted else unquoted
         if number == "":
             mechanical += 1
         else:

--- a/src/kicad_mcp/models/contract_verifier.py
+++ b/src/kicad_mcp/models/contract_verifier.py
@@ -120,18 +120,24 @@ def parse_symbol_pins(symbol_block: str) -> tuple[Pin, ...]:
     first occurrence so the count reflects distinct electrical pins.
     """
 
+    # ``(pin`` + word boundary tolerates any whitespace after the keyword
+    # (space/tab/newline) while still excluding ``(pin_numbers``/``(pin_names``.
+    pin_start = re.compile(r"\(pin\b")
     seen: set[str] = set()
     pins: list[Pin] = []
     cursor = 0
     while True:
-        index = symbol_block.find("(pin ", cursor)
-        if index == -1:
+        match = pin_start.search(symbol_block, cursor)
+        if match is None:
             break
+        index = match.start()
         pin_block = extract_balanced_block(symbol_block, index)
         cursor = index + len(pin_block)
         type_match = re.match(r"\(pin\s+(\w+)", pin_block)
-        name_match = re.search(r'\(name\s+"([^"]*)"', pin_block)
-        number_match = re.search(r'\(number\s+"([^"]*)"', pin_block)
+        # Quoted values may contain escaped chars (e.g. ``\"``); consume escape
+        # pairs so an escaped quote inside a name does not truncate the match.
+        name_match = re.search(r'\(name\s+"([^"\\]*(?:\\.[^"\\]*)*)"', pin_block)
+        number_match = re.search(r'\(number\s+"([^"\\]*(?:\\.[^"\\]*)*)"', pin_block)
         if not (type_match and name_match and number_match):
             continue
         number = number_match.group(1)

--- a/src/kicad_mcp/tools/library.py
+++ b/src/kicad_mcp/tools/library.py
@@ -860,7 +860,7 @@ def register(mcp: FastMCP) -> None:
             fp_library, fp_name = footprint_id.split(":", 1)
             try:
                 fp_path = _footprint_file(fp_library, fp_name)
-            except FileNotFoundError:
+            except (OSError, ValueError):
                 fp_path = None
             if fp_path is not None and fp_path.exists():
                 footprint_shape = cv.parse_footprint(

--- a/tests/unit/test_companion_context.py
+++ b/tests/unit/test_companion_context.py
@@ -76,10 +76,14 @@ def test_client_rejects_non_loopback_url() -> None:
 
 def test_client_push_posts_to_mcp_endpoint() -> None:
     captured: dict[str, object] = {}
+    closed: list[bool] = []
 
     class _FakeResponse:
         def read(self) -> bytes:
             return json.dumps({"result": {"status": "ok"}}).encode("utf-8")
+
+        def close(self) -> None:
+            closed.append(True)
 
     def fake_opener(request: urllib.request.Request) -> _FakeResponse:
         captured["url"] = request.full_url
@@ -103,6 +107,7 @@ def test_client_push_posts_to_mcp_endpoint() -> None:
     body = captured["body"]
     assert body["params"]["name"] == "studio_push_context"  # type: ignore[index]
     assert body["params"]["arguments"]["active_file"] == "b.kicad_pcb"  # type: ignore[index]
+    assert closed == [True], "the HTTP response must be closed after reading"
 
 
 def test_client_render_and_highlight_helpers_call_expected_tools() -> None:
@@ -111,6 +116,9 @@ def test_client_render_and_highlight_helpers_call_expected_tools() -> None:
     class _FakeResponse:
         def read(self) -> bytes:
             return json.dumps({"result": "ok"}).encode("utf-8")
+
+        def close(self) -> None:
+            pass
 
     def fake_opener(request: urllib.request.Request) -> _FakeResponse:
         bodies.append(json.loads(request.data.decode("utf-8")))  # type: ignore[union-attr]

--- a/tests/unit/test_contract_verifier.py
+++ b/tests/unit/test_contract_verifier.py
@@ -131,6 +131,19 @@ def test_parse_footprint_counts_mechanical_pads() -> None:
     assert not shape.has_3d_model
 
 
+def test_parse_footprint_accepts_unquoted_pad_numbers() -> None:
+    # Older/hand-written footprints write bare, unquoted pad numbers.
+    footprint = """
+(footprint "Legacy_2pad"
+    (pad 1 smd rect (at 0 0) (size 1 1) (layers "F.Cu"))
+    (pad 2 smd rect (at 2 0) (size 1 1) (layers "F.Cu"))
+)
+"""
+    shape = parse_footprint(footprint)
+    assert shape.connectable_pads == ("1", "2")
+    assert shape.mechanical_pad_count == 0
+
+
 def test_verify_good_resistor_passes() -> None:
     report = verify_contract(
         reference="R5",

--- a/tests/unit/test_contract_verifier.py
+++ b/tests/unit/test_contract_verifier.py
@@ -113,6 +113,33 @@ def test_parse_symbol_pins_resistor() -> None:
     assert all(pin.electrical_type == "passive" for pin in pins)
 
 
+def test_parse_symbol_pins_tolerates_tab_and_newline_whitespace() -> None:
+    # S-expressions are whitespace-insensitive; a tab/newline after (pin must
+    # not cause the pin to be skipped.
+    symbol = (
+        '(symbol "X"\n'
+        "\t(pin\tinput line (at 0 0 0) (length 1)\n"
+        '\t\t(name "A" (effects))\n'
+        '\t\t(number "1" (effects))))'
+    )
+    pins = parse_symbol_pins(symbol)
+    assert {pin.number for pin in pins} == {"1"}
+    assert pins[0].electrical_type == "input"
+
+
+def test_parse_symbol_pins_handles_escaped_quote_in_name() -> None:
+    # An escaped quote inside a pin name must not truncate the captured value.
+    symbol = (
+        '(symbol "X"\n'
+        "  (pin input line (at 0 0 0) (length 1)\n"
+        '    (name "A\\"B" (effects))\n'
+        '    (number "1" (effects))))'
+    )
+    pins = parse_symbol_pins(symbol)
+    assert {pin.number for pin in pins} == {"1"}
+    assert pins[0].name == 'A\\"B'
+
+
 def test_parse_footprint_resistor_is_complete() -> None:
     shape = parse_footprint(RESISTOR_FOOTPRINT)
     assert shape.connectable_pads == ("1", "2")


### PR DESCRIPTION
Follow-up to the squash-merged #167. Addresses the structural-parser and resource-handling findings raised in code review on that PR (the PR merged before the comments could be applied).

## Changes
- **`contract_verifier.parse_footprint`** — accept bare (unquoted) pad numbers `(pad 1 ...)` in addition to quoted `(pad "1" ...)`, so older / hand-written `.kicad_mod` files are parsed correctly. *(high-priority review finding)*
- **`contract_verifier.parse_symbol_pins`** — isolate each `(pin ...)` as a balanced block and parse it individually, so a pin missing a name/number can no longer bleed its fields into the next pin (the prior whole-block non-greedy `findall` could mis-map).
- **`companion/context.py`** — close the HTTP response after reading (`try/finally`) to avoid socket/connection leaks; `_HttpResponse` protocol now requires `close()`.
- **`ipc/command_queue.py`** — journal a failed reconnect attempt before re-raising, instead of letting a reconnect exception silently bypass the journal.
- **`tools/library.py`** (`lib_verify_component_contract`) — catch `(OSError, ValueError)` when locating the footprint file, not just `FileNotFoundError`, so the tool degrades gracefully.

The escaped-backslash fix in `extract_balanced_block` (also raised in review) already landed with #167.

## Tests
- New: unquoted-pad parsing, and an assertion that the HTTP response is closed.
- `ruff format/check`, `mypy` (134 files), and the full `-m "not benchmark"` unit lane all pass locally.