### PR TITLE
feat: add tool-selection eval harness and golden dataset

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,49 @@
+# kicad-mcp evals
+
+Measurable quality signals for the agent-facing surface. The first harness is
+**tool selection**: with ~350 tools, the biggest risk is the model calling the
+*wrong* tool — or a destructive one for a read-only request — not missing features.
+
+## Tool-selection eval
+
+- Dataset: [`tool_selection/cases.yaml`](tool_selection/cases.yaml) — each case maps
+  a user intent to `expected_tools` (should be called) and `forbidden_tools` (must
+  not be called). A case passes when every expected tool was called and no forbidden
+  tool was.
+- Harness: [`src/kicad_mcp/evals/tool_selection.py`](../src/kicad_mcp/evals/tool_selection.py)
+  — pure, dependency-free loader + scorer (`recall`, forbidden-tool `violations`,
+  per-case `passed`) and an `aggregate` roll-up (pass rate, mean recall).
+- The dataset is kept honest by `tests/unit/test_tool_selection_eval.py`, which
+  validates the schema and asserts every referenced tool name is actually
+  registered — so the suite cannot drift to stale/typo'd tool names.
+
+### Running against a model
+
+The harness is model-agnostic. Supply an `agent` callable that returns the tool
+names a model chose for a prompt, then score:
+
+```python
+from kicad_mcp.evals.tool_selection import load_cases, run_eval, aggregate
+
+cases = load_cases("evals/tool_selection/cases.yaml")
+
+def agent(prompt: str) -> list[str]:
+    # Drive your MCP host / model here and return the tool names it called.
+    ...
+
+results = run_eval(cases, agent)
+print(aggregate(results))            # {'cases': 8, 'passed': ..., 'pass_rate': ..., ...}
+for r in results:
+    if not r.passed:
+        print(r.case_id, "missing", r.missing_expected, "forbidden", r.forbidden_called)
+```
+
+Wiring a live model is intentionally left to the caller so the dataset and scorer
+stay fast and headless in CI; the model run is a separate, billed step.
+
+### Adding cases
+
+Add an entry to `cases.yaml` with a unique `id`, a `prompt`, `expected_tools`, and
+(usually) `forbidden_tools`. Keep tool names spelled exactly as registered — the
+integrity test will fail otherwise. Prefer cases that pin a *behavioural contract*:
+read-only intents should forbid mutating/destructive tools.

--- a/evals/tool_selection/cases.yaml
+++ b/evals/tool_selection/cases.yaml
@@ -1,0 +1,55 @@
+# Golden tool-selection eval cases for kicad-mcp.
+#
+# Each case maps a user intent to the tools an agent SHOULD call (expected_tools)
+# and tools it MUST NOT call for that intent (forbidden_tools — typically
+# destructive/mutating tools for a read-only request). A case passes when every
+# expected tool was called and no forbidden tool was.
+#
+# Run with src/kicad_mcp/evals/tool_selection.py by supplying an agent callable
+# that returns the tool names a model chose for each prompt. Tool names are
+# validated against the live registry by tests/unit/test_tool_selection_eval.py,
+# so keep them spelled exactly as registered.
+
+cases:
+  - id: drc_report
+    prompt: "Run a design rule check on the board and show me the violations."
+    expected_tools: [run_drc]
+    forbidden_tools: [pcb_save, pcb_delete_items]
+    notes: Read-only diagnostic; must not mutate or save the board.
+
+  - id: erc_report
+    prompt: "Check the schematic for electrical rule errors."
+    expected_tools: [run_erc]
+    forbidden_tools: [sch_apply_plan, pcb_delete_items]
+    notes: Read-only schematic check.
+
+  - id: footprint_parity
+    prompt: "Do the PCB footprints match the schematic symbols?"
+    expected_tools: [validate_footprints_vs_schematic]
+    forbidden_tools: [pcb_save, pcb_delete_items]
+
+  - id: board_overview
+    prompt: "Give me a high-level summary of this board."
+    expected_tools: [pcb_get_board_summary]
+    forbidden_tools: [pcb_save, pcb_delete_items, sch_apply_plan]
+    notes: Pure inspection; no mutation of any kind.
+
+  - id: manufacturing_readiness
+    prompt: "Is this project ready for manufacturing?"
+    expected_tools: [project_quality_gate]
+    forbidden_tools: [pcb_delete_items]
+
+  - id: component_contract
+    prompt: "Verify that R1's symbol, footprint, and pins actually match."
+    expected_tools: [lib_verify_component_contract]
+    forbidden_tools: [pcb_save, pcb_delete_items]
+
+  - id: schematic_readability
+    prompt: "Check the schematic for overlapping labels and readability problems."
+    expected_tools: [sch_visual_qa]
+    forbidden_tools: [sch_apply_plan]
+
+  - id: bom_with_pricing
+    prompt: "Generate a bill of materials with pricing."
+    expected_tools: [lib_get_bom_with_pricing]
+    forbidden_tools: [pcb_delete_items]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
   "pytest-testmon>=2.1.1",
   "pytest-xdist>=3.6.0",
   "pyright>=1.1.390",
+  "types-PyYAML>=6.0.12.20250822",
   "radon>=6.0.1",
   "ruff!=0.15.10,>=0.15.0",
   "vulture>=2.11",

--- a/src/kicad_mcp/evals/__init__.py
+++ b/src/kicad_mcp/evals/__init__.py
@@ -1,0 +1,28 @@
+"""Evaluation harnesses for kicad-mcp.
+
+Currently hosts the tool-selection eval: a golden prompt suite plus a pure scorer
+that measures whether an agent calls the right tools (recall) and avoids the wrong
+ones (forbidden-tool violations) for a given intent. The scoring and dataset are
+dependency-free and headless; running the suite against a live model is done by
+injecting an ``agent`` callable.
+"""
+
+from .tool_selection import (
+    CaseResult,
+    EvalCase,
+    aggregate,
+    all_referenced_tools,
+    load_cases,
+    run_eval,
+    score_case,
+)
+
+__all__ = [
+    "CaseResult",
+    "EvalCase",
+    "aggregate",
+    "all_referenced_tools",
+    "load_cases",
+    "run_eval",
+    "score_case",
+]

--- a/src/kicad_mcp/evals/tool_selection.py
+++ b/src/kicad_mcp/evals/tool_selection.py
@@ -15,7 +15,7 @@ names the model chose; the model itself lives outside this module.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -62,6 +62,25 @@ class EvalDatasetError(ValueError):
     """Raised when an eval dataset is structurally invalid."""
 
 
+def _tool_name_list(raw: Mapping[str, Any], key: str, case_id: str) -> tuple[str, ...]:
+    value = raw.get(key, [])
+    if value is None:
+        value = []
+    if not isinstance(value, list):
+        raise EvalDatasetError(f"Case {case_id!r} field {key!r} must be a list of tool names.")
+
+    tools: list[str] = []
+    for item_index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise EvalDatasetError(
+                f"Case {case_id!r} field {key!r} item #{item_index} must be a string."
+            )
+        name = item.strip()
+        if name:
+            tools.append(name)
+    return tuple(tools)
+
+
 def load_cases(path: str | Path) -> list[EvalCase]:
     """Load and validate eval cases from a YAML file (``{cases: [...]}``)."""
     data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
@@ -78,12 +97,8 @@ def load_cases(path: str | Path) -> list[EvalCase]:
             raise EvalDatasetError(f"Case #{index} must be a mapping.")
         case_id = str(raw.get("id", "")).strip()
         prompt = str(raw.get("prompt", "")).strip()
-        expected = tuple(
-            str(t).strip() for t in (raw.get("expected_tools") or []) if str(t).strip()
-        )
-        forbidden = tuple(
-            str(t).strip() for t in (raw.get("forbidden_tools") or []) if str(t).strip()
-        )
+        expected = _tool_name_list(raw, "expected_tools", case_id or f"#{index}")
+        forbidden = _tool_name_list(raw, "forbidden_tools", case_id or f"#{index}")
         if not case_id:
             raise EvalDatasetError(f"Case #{index} is missing an 'id'.")
         if case_id in seen:

--- a/src/kicad_mcp/evals/tool_selection.py
+++ b/src/kicad_mcp/evals/tool_selection.py
@@ -1,0 +1,165 @@
+"""Tool-selection eval harness (external review's top recommendation).
+
+With ~350 tools, the dominant quality risk is not missing features but the model
+picking the *wrong* tool — or a destructive one for a read-only intent. This module
+turns that into a measurable signal:
+
+- a golden dataset of (prompt -> expected_tools / forbidden_tools) cases;
+- a pure scorer computing per-case recall and forbidden-tool violations;
+- an aggregate roll-up (pass rate, mean recall, total violations).
+
+Everything here is dependency-free and headless. To actually exercise a model, call
+``run_eval(cases, agent)`` where ``agent(prompt) -> list[str]`` returns the tool
+names the model chose; the model itself lives outside this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class EvalCase:
+    """One golden tool-selection expectation."""
+
+    id: str
+    prompt: str
+    expected_tools: tuple[str, ...]
+    forbidden_tools: tuple[str, ...] = ()
+    notes: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CaseResult:
+    """The scored outcome of running one case against an agent."""
+
+    case_id: str
+    called: tuple[str, ...]
+    matched_expected: tuple[str, ...]
+    missing_expected: tuple[str, ...]
+    forbidden_called: tuple[str, ...]
+    recall: float
+    passed: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "case_id": self.case_id,
+            "called": list(self.called),
+            "matched_expected": list(self.matched_expected),
+            "missing_expected": list(self.missing_expected),
+            "forbidden_called": list(self.forbidden_called),
+            "recall": round(self.recall, 4),
+            "passed": self.passed,
+        }
+
+
+class EvalDatasetError(ValueError):
+    """Raised when an eval dataset is structurally invalid."""
+
+
+def load_cases(path: str | Path) -> list[EvalCase]:
+    """Load and validate eval cases from a YAML file (``{cases: [...]}``)."""
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "cases" not in data:
+        raise EvalDatasetError("Dataset must be a mapping with a top-level 'cases' list.")
+    raw_cases = data["cases"]
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise EvalDatasetError("'cases' must be a non-empty list.")
+
+    seen: set[str] = set()
+    cases: list[EvalCase] = []
+    for index, raw in enumerate(raw_cases):
+        if not isinstance(raw, dict):
+            raise EvalDatasetError(f"Case #{index} must be a mapping.")
+        case_id = str(raw.get("id", "")).strip()
+        prompt = str(raw.get("prompt", "")).strip()
+        expected = tuple(
+            str(t).strip() for t in (raw.get("expected_tools") or []) if str(t).strip()
+        )
+        forbidden = tuple(
+            str(t).strip() for t in (raw.get("forbidden_tools") or []) if str(t).strip()
+        )
+        if not case_id:
+            raise EvalDatasetError(f"Case #{index} is missing an 'id'.")
+        if case_id in seen:
+            raise EvalDatasetError(f"Duplicate case id: {case_id!r}.")
+        seen.add(case_id)
+        if not prompt:
+            raise EvalDatasetError(f"Case {case_id!r} is missing a 'prompt'.")
+        if not expected:
+            raise EvalDatasetError(f"Case {case_id!r} needs at least one expected tool.")
+        overlap = set(expected) & set(forbidden)
+        if overlap:
+            raise EvalDatasetError(
+                f"Case {case_id!r} lists {sorted(overlap)} as both expected and forbidden."
+            )
+        cases.append(
+            EvalCase(
+                id=case_id,
+                prompt=prompt,
+                expected_tools=expected,
+                forbidden_tools=forbidden,
+                notes=str(raw.get("notes", "")).strip(),
+            )
+        )
+    return cases
+
+
+def score_case(case: EvalCase, called_tools: Iterable[str]) -> CaseResult:
+    """Score one case: full recall of expected tools and zero forbidden calls = pass."""
+    called = tuple(called_tools)
+    called_set = set(called)
+    expected_set = set(case.expected_tools)
+    forbidden_set = set(case.forbidden_tools)
+
+    matched = expected_set & called_set
+    missing = expected_set - called_set
+    forbidden_called = forbidden_set & called_set
+    recall = len(matched) / len(expected_set) if expected_set else 1.0
+    passed = not missing and not forbidden_called
+
+    return CaseResult(
+        case_id=case.id,
+        called=called,
+        matched_expected=tuple(sorted(matched)),
+        missing_expected=tuple(sorted(missing)),
+        forbidden_called=tuple(sorted(forbidden_called)),
+        recall=recall,
+        passed=passed,
+    )
+
+
+def aggregate(results: Sequence[CaseResult]) -> dict[str, Any]:
+    """Roll case results up into headline metrics."""
+    total = len(results)
+    if total == 0:
+        return {"cases": 0, "passed": 0, "pass_rate": 0.0, "mean_recall": 0.0, "violations": 0}
+    passed = sum(1 for result in results if result.passed)
+    violations = sum(len(result.forbidden_called) for result in results)
+    mean_recall = sum(result.recall for result in results) / total
+    return {
+        "cases": total,
+        "passed": passed,
+        "pass_rate": round(passed / total, 4),
+        "mean_recall": round(mean_recall, 4),
+        "violations": violations,
+    }
+
+
+def run_eval(cases: Sequence[EvalCase], agent: Callable[[str], Iterable[str]]) -> list[CaseResult]:
+    """Run every case through ``agent`` (``prompt -> called tool names``) and score it."""
+    return [score_case(case, agent(case.prompt)) for case in cases]
+
+
+def all_referenced_tools(cases: Iterable[EvalCase]) -> set[str]:
+    """Return every tool name referenced (expected or forbidden) across cases."""
+    names: set[str] = set()
+    for case in cases:
+        names.update(case.expected_tools)
+        names.update(case.forbidden_tools)
+    return names

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -6425,7 +6425,7 @@ def register(mcp: FastMCP) -> None:
             return "No subcircuit templates are available."
 
         try:
-            import yaml  # type: ignore[import-untyped]
+            import yaml
         except ImportError:
             return "Template tools require PyYAML. Install it to inspect bundled templates."
 

--- a/tests/unit/test_tool_selection_eval.py
+++ b/tests/unit/test_tool_selection_eval.py
@@ -1,0 +1,121 @@
+"""Tests for the tool-selection eval harness + golden dataset integrity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.evals.tool_selection import (
+    EvalCase,
+    EvalDatasetError,
+    aggregate,
+    all_referenced_tools,
+    load_cases,
+    run_eval,
+    score_case,
+)
+
+CASES_PATH = Path(__file__).resolve().parents[2] / "evals" / "tool_selection" / "cases.yaml"
+
+
+def _case(**kwargs: object) -> EvalCase:
+    base: dict[str, object] = {
+        "id": "c",
+        "prompt": "do a thing",
+        "expected_tools": ("run_drc",),
+        "forbidden_tools": (),
+    }
+    base.update(kwargs)
+    return EvalCase(**base)  # type: ignore[arg-type]
+
+
+def test_score_full_match_passes() -> None:
+    result = score_case(_case(expected_tools=("run_drc",)), ["run_drc"])
+    assert result.passed
+    assert result.recall == 1.0
+    assert result.missing_expected == ()
+
+
+def test_score_missing_expected_fails() -> None:
+    result = score_case(_case(expected_tools=("run_drc", "run_erc")), ["run_drc"])
+    assert not result.passed
+    assert result.recall == 0.5
+    assert result.missing_expected == ("run_erc",)
+
+
+def test_score_forbidden_call_fails_even_with_full_recall() -> None:
+    case = _case(expected_tools=("run_drc",), forbidden_tools=("pcb_delete_items",))
+    result = score_case(case, ["run_drc", "pcb_delete_items"])
+    assert result.recall == 1.0
+    assert not result.passed
+    assert result.forbidden_called == ("pcb_delete_items",)
+
+
+def test_aggregate_rolls_up() -> None:
+    results = [
+        score_case(_case(id="a", expected_tools=("run_drc",)), ["run_drc"]),
+        score_case(
+            _case(id="b", expected_tools=("run_erc",), forbidden_tools=("pcb_save",)),
+            ["run_erc", "pcb_save"],
+        ),
+    ]
+    summary = aggregate(results)
+    assert summary["cases"] == 2
+    assert summary["passed"] == 1
+    assert summary["pass_rate"] == 0.5
+    assert summary["violations"] == 1
+
+
+def test_run_eval_with_fake_agent() -> None:
+    cases = [
+        _case(id="a", prompt="p1", expected_tools=("run_drc",)),
+        _case(id="b", prompt="p2", expected_tools=("run_erc",)),
+    ]
+
+    def agent(prompt: str) -> list[str]:
+        return {"p1": ["run_drc"], "p2": ["pcb_save"]}.get(prompt, [])
+
+    results = run_eval(cases, agent)
+    assert [r.passed for r in results] == [True, False]
+
+
+def test_load_cases_rejects_bad_datasets(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("cases: []\n", encoding="utf-8")
+    with pytest.raises(EvalDatasetError):
+        load_cases(bad)
+
+    dup = tmp_path / "dup.yaml"
+    dup.write_text(
+        "cases:\n"
+        "  - {id: x, prompt: a, expected_tools: [run_drc]}\n"
+        "  - {id: x, prompt: b, expected_tools: [run_erc]}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(EvalDatasetError, match="Duplicate"):
+        load_cases(dup)
+
+    overlap = tmp_path / "overlap.yaml"
+    overlap.write_text(
+        "cases:\n  - {id: y, prompt: a, expected_tools: [run_drc], forbidden_tools: [run_drc]}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(EvalDatasetError, match="both expected and forbidden"):
+        load_cases(overlap)
+
+
+def test_golden_dataset_loads() -> None:
+    cases = load_cases(CASES_PATH)
+    assert len(cases) >= 5
+    assert all(case.expected_tools for case in cases)
+
+
+def test_golden_dataset_only_references_real_tools() -> None:
+    """Every expected/forbidden tool name must be a registered tool (no typos/stale)."""
+    from scripts.generate_tools_reference import collect_rows
+
+    registered = {row.name for row in collect_rows()}
+    referenced = all_referenced_tools(load_cases(CASES_PATH))
+    unknown = sorted(referenced - registered)
+    assert unknown == [], f"Dataset references unregistered tools: {unknown}"

--- a/tests/unit/test_tool_selection_eval.py
+++ b/tests/unit/test_tool_selection_eval.py
@@ -119,3 +119,29 @@ def test_golden_dataset_only_references_real_tools() -> None:
     referenced = all_referenced_tools(load_cases(CASES_PATH))
     unknown = sorted(referenced - registered)
     assert unknown == [], f"Dataset references unregistered tools: {unknown}"
+
+
+def test_load_cases_requires_tool_fields_to_be_lists(tmp_path: Path) -> None:
+    bad = tmp_path / "bad-tool-list.yaml"
+    bad.write_text(
+        "cases:\n  - id: bad\n    prompt: run DRC\n    expected_tools: run_drc\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EvalDatasetError, match="expected_tools.*list"):
+        load_cases(bad)
+
+
+def test_load_cases_requires_tool_list_items_to_be_strings(tmp_path: Path) -> None:
+    bad = tmp_path / "bad-tool-item.yaml"
+    bad.write_text(
+        "cases:\n"
+        "  - id: bad\n"
+        "    prompt: run DRC\n"
+        "    expected_tools: [run_drc]\n"
+        "    forbidden_tools: [null]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EvalDatasetError, match="forbidden_tools.*string"):
+        load_cases(bad)

--- a/uv.lock
+++ b/uv.lock
@@ -1118,6 +1118,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "radon" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "vulture" },
     { name = "watchfiles" },
     { name = "zizmor" },
@@ -1195,6 +1196,7 @@ requires-dist = [
     { name = "starlette", specifier = ">=1.0.1,<2.0.0" },
     { name = "structlog", specifier = ">=24.2.0" },
     { name = "typer", specifier = ">=0.12.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250822" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'http'", specifier = ">=0.30.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
@@ -3250,6 +3252,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the external review's **top recommendation**: with ~350 tools, the
dominant quality risk is the model selecting the *wrong* tool — or a destructive one
for a read-only intent — not missing features. This adds a measurable signal for it.

## What's added

- `src/kicad_mcp/evals/tool_selection.py` — a dependency-free, headless harness:
  - `load_cases` (YAML loader with validation),
  - `score_case` (per-case **recall** of expected tools + **forbidden-tool
    violations**; a case passes only with full recall and zero violations),
  - `aggregate` (pass rate, mean recall, total violations),
  - `run_eval(cases, agent)` — model-agnostic; you inject an `agent(prompt) -> tool
    names` callable, so scoring stays fast in CI and the live model run is a separate
    billed step.
- `evals/tool_selection/cases.yaml` — 8 golden cases (DRC, ERC, footprint parity,
  board summary, manufacturing readiness, component contract, schematic readability,
  BOM). Read-only intents forbid mutating/destructive tools.
- `tests/unit/test_tool_selection_eval.py` — scorer math + dataset validation, and a
  guard asserting **every referenced tool name is actually registered**, so the suite
  can't drift to stale/typo'd names.
- `evals/README.md` — how to wire a live model.

## Testing

- `pytest tests/unit/test_tool_selection_eval.py`: green (8 tests).
- `ruff check/format src/ tests/`: clean.
- No new MCP tools are registered (internal harness), so the tool catalog and
  surface snapshot are unchanged.
