### PR TITLE
test(web): keep TestClient setup free of httpx deprecation (#187)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,10 @@ fail_under = 83
 
 [dependency-groups]
 dev = [
+    # httpx2 keeps starlette.testclient from emitting its httpx deprecation
+    # warning (issue #187); it lives in the default group so bare `uv run`
+    # test invocations stay warning-free, not only `--all-extras` runs.
+    "httpx2>=0.28.0",
     "pytest-asyncio>=0.25.0",
     "pytest-playwright>=0.8.0",
 ]

--- a/tests/unit/test_web_testclient_warnings.py
+++ b/tests/unit/test_web_testclient_warnings.py
@@ -1,0 +1,29 @@
+"""Regression guard for issue #187 — TestClient setup must stay warning-free.
+
+``starlette.testclient`` emits a ``StarletteDeprecationWarning`` at import time
+("Using ``httpx`` with ``starlette.testclient`` is deprecated; install
+``httpx2`` instead.") whenever ``httpx2`` is not importable. Because that warning
+fires once at module import and is then cached, capturing it inside a single
+test is unreliable — by the time this module runs, another test has already
+imported the client and the warning has been consumed.
+
+Instead this guard asserts the precondition that suppresses the warning: the
+test environment must provide ``httpx2``. ``httpx2`` is declared both in the
+``dev`` optional-dependency extra and in the default ``dependency-groups.dev``
+group, so any ``uv run`` invocation — bare or ``--all-extras`` — installs it and
+keeps the full unit run free of the Starlette/httpx deprecation. If a future
+change drops ``httpx2`` from the default test path, this test fails fast.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+
+def test_httpx2_available_so_testclient_does_not_warn() -> None:
+    spec = importlib.util.find_spec("httpx2")
+    assert spec is not None, (
+        "httpx2 is not importable in the test environment, so "
+        "starlette.testclient falls back to httpx and emits a deprecation "
+        "warning. Keep httpx2 in the default dependency-groups.dev group."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1134,6 +1134,7 @@ vcs = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest-asyncio" },
     { name = "pytest-playwright" },
 ]
@@ -1197,6 +1198,7 @@ provides-extras = ["components", "dev", "freerouting", "http", "tray", "simulati
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx2", specifier = ">=0.28.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-playwright", specifier = ">=0.8.0" },
 ]


### PR DESCRIPTION
## Summary
`starlette.testclient` emits a `StarletteDeprecationWarning` at import time —
*"Using `httpx` with `starlette.testclient` is deprecated; install `httpx2`
instead."* — whenever `httpx2` is not importable.

`httpx2` was already declared in the `dev` **optional-dependency extra**, so
`uv sync --all-extras` (CI) runs were clean. But the default `uv run pytest`
path installs only the `dependency-groups.dev` group (pytest comes in
transitively via `pytest-asyncio`), which lacked `httpx2` — so every bare full
unit run surfaced the warning.

## Change
- Move `httpx2>=0.28.0` into the default `[dependency-groups].dev` group so any
  `uv run` test invocation installs it and stays warning-free, not just
  `--all-extras` runs. No new dependency is introduced — `httpx2` was already
  locked and exercised in CI.
- Refresh `uv.lock`.
- Add `tests/unit/test_web_testclient_warnings.py`, a regression guard asserting
  `httpx2` stays importable in the test environment (the precondition that
  silences the warning). An import-time, cache-once warning can't be captured
  reliably inside a single test, so the guard checks the precondition instead.

## Verification
- Bare `uv run python -m pytest tests/unit/test_web_routes.py -W default` → 28
  passed, **no** Starlette/httpx deprecation warning.
- TestClient-heavy suites (web routes, wellknown/studio, telemetry, MCP
  protocol contract) still pass.

Closes #187