### PR TITLE
feat(schematic): reject duplicate-UUID writes (transactional write integrity)

### DIFF
--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -3741,6 +3741,25 @@ def _append_before_sheet_instances(content: str, block: str) -> str:
     return content.rstrip().rstrip(")") + f"\n{block}\n)\n"
 
 
+def _duplicate_uuids(content: str) -> set[str]:
+    """Return element UUIDs that appear more than once in a schematic.
+
+    Every KiCad schematic element carries a unique UUID. A regex/string mutation
+    that clones a block (instead of generating a fresh UUID) produces duplicates
+    that parse fine but corrupt connectivity and instance paths in KiCad — exactly
+    the silent-corruption class the transactional writer must refuse.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for match in re.finditer(r'\(uuid\s+"([0-9a-fA-F-]+)"', content):
+        value = match.group(1)
+        if value in seen:
+            duplicates.add(value)
+        else:
+            seen.add(value)
+    return duplicates
+
+
 def _validate_schematic_text(content: str) -> None:
     depth = 0
     in_string = False
@@ -3766,6 +3785,13 @@ def _validate_schematic_text(content: str) -> None:
     if re.search(r'\(paper\s+"User"\s*\)', content):
         raise ValueError(
             'Refusing to write an invalid schematic with incomplete (paper "User") dimensions.'
+        )
+    duplicate_uuids = _duplicate_uuids(content)
+    if duplicate_uuids:
+        sample = ", ".join(sorted(duplicate_uuids)[:5])
+        raise ValueError(
+            "Refusing to write a schematic with duplicate element UUIDs "
+            f"(a string/regex mutation likely cloned a block): {sample}."
         )
 
 

--- a/tests/unit/test_schematic_write_integrity.py
+++ b/tests/unit/test_schematic_write_integrity.py
@@ -1,0 +1,42 @@
+"""Schematic write-integrity guards (issue #193).
+
+The transactional writer validates more than balanced parentheses: it refuses
+output with duplicate element UUIDs, the classic silent-corruption signature of a
+regex/string mutation that cloned a block instead of minting a fresh UUID.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_mcp.tools.schematic import _duplicate_uuids, _validate_schematic_text
+
+_CLEAN = (
+    '(kicad_sch (uuid "00000000-0000-0000-0000-000000000001")'
+    ' (label "A" (at 0 0 0) (uuid "00000000-0000-0000-0000-000000000002"))'
+    ' (label "B" (at 0 5 0) (uuid "00000000-0000-0000-0000-000000000003")))'
+)
+_DUPLICATE = (
+    '(kicad_sch (uuid "00000000-0000-0000-0000-000000000001")'
+    ' (label "A" (at 0 0 0) (uuid "00000000-0000-0000-0000-000000000002"))'
+    ' (label "B" (at 0 5 0) (uuid "00000000-0000-0000-0000-000000000002")))'
+)
+
+
+def test_duplicate_uuids_detects_clones() -> None:
+    assert _duplicate_uuids(_CLEAN) == set()
+    assert _duplicate_uuids(_DUPLICATE) == {"00000000-0000-0000-0000-000000000002"}
+
+
+def test_validate_accepts_clean_schematic() -> None:
+    _validate_schematic_text(_CLEAN)  # must not raise
+
+
+def test_validate_refuses_duplicate_uuids() -> None:
+    with pytest.raises(ValueError, match="duplicate element UUIDs"):
+        _validate_schematic_text(_DUPLICATE)
+
+
+def test_validate_still_refuses_unbalanced_parens() -> None:
+    with pytest.raises(ValueError, match="unbalanced parentheses"):
+        _validate_schematic_text('(kicad_sch (uuid "x")')


### PR DESCRIPTION
## Summary

Hardens the schematic transactional writer against silent corruption (part of #193). `_validate_schematic_text` now refuses output containing **duplicate element UUIDs** — the classic signature of a regex/string mutation that cloned a block instead of minting a fresh UUID. Such output passes a balanced-parens check but corrupts connectivity and symbol instance paths in KiCad.

## Details
- New `_duplicate_uuids()` helper scans `(uuid "...")` occurrences; the validator raises a clear error listing the offending UUIDs.
- Runs on every transactional write (and the `sch_build_circuit` full rebuild), so it guards the whole authoring surface.

## Tests
- New `tests/unit/test_schematic_write_integrity.py` (clean passes, duplicate raises, unbalanced-parens guard intact).
- Full unit+integration suite: 1474 passed, 9 skipped, 0 failed — confirms no existing writer produces duplicate UUIDs.
- ruff + mypy clean.

Part of #193.