### PR TITLE
feat(schematic-rules): flag conflicting supply rails on one net (#197)

### DIFF
--- a/src/kicad_mcp/utils/schematic_rules.py
+++ b/src/kicad_mcp/utils/schematic_rules.py
@@ -103,6 +103,24 @@ def is_supply_rail_name(name: str) -> bool:
     return bool(_VOLTAGE_RAIL_RE.match(token)) and token not in {"0V"}
 
 
+# A rail whose name encodes an explicit voltage: +3V3, 3V3, +5V, 3.3V, +1V8, +12V.
+_RAIL_VOLTAGE_RE = re.compile(r"^\+?(\d+)(?:[V.](\d+))?V?$", re.IGNORECASE)
+
+
+def rail_voltage(name: str) -> float | None:
+    """Return the nominal voltage a rail name encodes, or ``None`` if it has none.
+
+    ``+3V3`` / ``3V3`` / ``3.3V`` -> 3.3, ``+5V`` -> 5.0, ``+1V8`` -> 1.8. Named
+    rails without an explicit number (``VCC``, ``VDD``, ``VBUS``) return ``None``
+    so they are never compared by value.
+    """
+    match = _RAIL_VOLTAGE_RE.match(name.strip().upper())
+    if match is None:
+        return None
+    whole, frac = match.group(1), match.group(2)
+    return float(whole) if frac is None else float(f"{whole}.{frac}")
+
+
 def is_i2c_name(name: str) -> bool:
     return bool(_I2C_TOKEN_RE.search(name.strip().upper()))
 
@@ -390,6 +408,45 @@ def _rule_interrupt_pullup(nets: Sequence[NetView]) -> list[Finding]:
     return findings
 
 
+def _rule_conflicting_supply_rails(nets: Sequence[NetView]) -> list[Finding]:
+    """Flag a single net carrying two different supply voltages (rails shorted).
+
+    Power-rail naming consistency (Rule 13/14): when one connectivity group holds
+    more than one explicit rail voltage — e.g. both ``+3V3`` and ``+5V`` — the
+    rails are electrically tied together, which is a short. Only rails with a
+    parseable numeric voltage are compared, so value-less aliases like ``VCC`` or
+    ``VBUS`` never trip this rule.
+    """
+    findings: list[Finding] = []
+    for net in nets:
+        by_voltage: dict[float, str] = {}
+        for name in _net_names(net):
+            if not is_supply_rail_name(name):
+                continue
+            voltage = rail_voltage(name)
+            if voltage is None:
+                continue
+            by_voltage.setdefault(round(voltage, 3), name)
+        if len(by_voltage) < 2:
+            continue
+        ordered = sorted(by_voltage.items())
+        rail_names = [name for _, name in ordered]
+        ics = _net_refs(net, _IC_RE)
+        findings.append(
+            Finding(
+                rule_id="conflicting_supply_rails",
+                severity="error",
+                message=(
+                    f"One net carries conflicting supply rails {', '.join(rail_names)} "
+                    f"({', '.join(format(v, 'g') + 'V' for v, _ in ordered)}). These rails "
+                    "are on the same net and are shorted together — give each rail its own net."
+                ),
+                refs=tuple(ics) or tuple(rail_names),
+            )
+        )
+    return findings
+
+
 # Registry of active rules. Append new pure ``(nets) -> [Finding]`` callables here.
 DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_i2c_pullups,
@@ -400,6 +457,7 @@ DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_nc_pin_connected,
     _rule_can_bus_termination,
     _rule_interrupt_pullup,
+    _rule_conflicting_supply_rails,
 )
 
 

--- a/tests/unit/test_schematic_rules.py
+++ b/tests/unit/test_schematic_rules.py
@@ -10,6 +10,7 @@ from kicad_mcp.utils.schematic_rules import (
     is_reset_name,
     is_supply_rail_name,
     merge_nets_by_name,
+    rail_voltage,
     run_schematic_design_rules,
 )
 
@@ -220,6 +221,42 @@ def test_design_rule_check_tool_is_declared_in_validation_category() -> None:
     from kicad_mcp.tools.router import TOOL_CATEGORIES
 
     assert "schematic_design_rule_check" in TOOL_CATEGORIES["validation"]["tools"]
+
+
+def test_rail_voltage_parsing() -> None:
+    assert rail_voltage("+3V3") == 3.3
+    assert rail_voltage("3V3") == 3.3
+    assert rail_voltage("3.3V") == 3.3
+    assert rail_voltage("+5V") == 5.0
+    assert rail_voltage("+1V8") == 1.8
+    assert rail_voltage("+12V") == 12.0
+    # Value-less aliases carry no comparable voltage.
+    assert rail_voltage("VCC") is None
+    assert rail_voltage("VBUS") is None
+    assert rail_voltage("GND") is None
+
+
+def test_conflicting_supply_rails_on_one_net_is_flagged() -> None:
+    flagged = run_schematic_design_rules([_net(["+3V3", "+5V"], [("U1", "1")])])
+    conflict = [f for f in flagged if f.rule_id == "conflicting_supply_rails"]
+    assert len(conflict) == 1
+    assert conflict[0].severity == "error"
+    assert "+3V3" in conflict[0].message and "+5V" in conflict[0].message
+    assert conflict[0].refs == ("U1",)
+
+
+def test_consistent_rail_aliases_are_not_flagged() -> None:
+    # Same voltage written two ways is consistent, not a conflict.
+    same = run_schematic_design_rules([_net(["+3V3", "3V3"], [("U1", "1")])])
+    assert not any(f.rule_id == "conflicting_supply_rails" for f in same)
+
+    # A value-less alias next to a numeric rail cannot be compared by value.
+    aliased = run_schematic_design_rules([_net(["VCC", "+5V"], [("U1", "1")])])
+    assert not any(f.rule_id == "conflicting_supply_rails" for f in aliased)
+
+    # A single rail is always clean.
+    single = run_schematic_design_rules([_net(["+3V3"], [("U1", "1"), ("C1", "1")])])
+    assert not any(f.rule_id == "conflicting_supply_rails" for f in single)
 
 
 def test_findings_are_sorted_and_typed() -> None:


### PR DESCRIPTION
## Context
Epic #197 builds out the electrical-correctness rule engine
(`schematic_design_rule_check` → `utils/schematic_rules.py`). Its scope includes
**consistent power-rail net naming (Rule 13/14)**, which was not yet implemented.
The engine already ships I2C pull-ups, rail decoupling, reset pull, crystal load
caps, decoupling-count, NC-pin, CAN termination, and interrupt-pull-up rules.

## Change
New pure rule `_rule_conflicting_supply_rails`: when one connectivity group
carries **two different explicit rail voltages** — e.g. both `+3V3` and `+5V` —
the rails are on the same net and are shorted together. It raises an
**error**-severity finding (the rest of the engine is advisory `warning`; this
one is a genuine electrical fault).

Guard rails against false positives:
- Only names with a parseable numeric voltage are compared, via a new
  `rail_voltage()` helper (`+3V3`/`3V3`/`3.3V` → 3.3, `+5V` → 5.0, `+1V8` → 1.8).
- Value-less aliases (`VCC`, `VBUS`, `VDD`) return `None` and are never compared.
- Same-voltage spellings (`+3V3` and `3V3`) collapse to one voltage → no flag.

## Verification
- New unit tests cover `rail_voltage` parsing, the conflict case (error + refs),
  and the consistent-alias / value-less-alias / single-rail clean cases.
- Full unit suite green (1081 passed, 0 failed); `ruff` + `mypy` clean.
- No tool-surface change (the rule is internal to the existing tool), so no
  docs/snapshot regeneration needed.

Refs #197