### PR TITLE
feat(emc): honest solver seam so EMC results are critic-only (#206)

### DIFF
--- a/src/kicad_mcp/tools/emc_compliance.py
+++ b/src/kicad_mcp/tools/emc_compliance.py
@@ -20,6 +20,7 @@ from ..connection import get_board
 from ..models.common import _FootprintLike
 from ..utils.impedance import propagation_delay_ps_per_mm
 from ..utils.layers import resolve_layer
+from ..utils.solver_seams import emc_method
 from ..utils.units import _coord_nm, nm_to_mm
 
 
@@ -523,4 +524,9 @@ def register(mcp: FastMCP) -> None:
         lines = [f"EMC compliance sweep ({standard.upper()}):", f"- Checks run: {len(checks)}"]
         for name, verdict, detail in checks:
             lines.append(f"- {name}: {verdict} | {detail}")
+        method = emc_method()
+        lines.append(
+            f"- Method: {method['method']} (solver_grade={method['solver_grade']}). "
+            f"{method['note']} Treat results as a critic, not a release sign-off."
+        )
         return "\n".join(lines)

--- a/src/kicad_mcp/utils/solver_seams.py
+++ b/src/kicad_mcp/utils/solver_seams.py
@@ -44,6 +44,11 @@ THERMAL_FD_ACCURACY = (
     "distributed steady-state lateral heat-spreading solve over the copper plane; not a "
     "3-D FEA with airflow, board-stack conduction, or radiation detail"
 )
+EMC_HEURISTIC_METHOD = "geometry/rule heuristics (return path, stitching, clearance, skew)"
+EMC_HEURISTIC_ACCURACY = (
+    "first-order geometric screening of emission/coupling risk; not a full-wave EM or "
+    "radiated-emissions simulation"
+)
 
 
 def pdn_solver_available() -> bool:
@@ -53,6 +58,11 @@ def pdn_solver_available() -> bool:
 
 def thermal_solver_available() -> bool:
     """Return ``True`` only when a thermal-network / FEA solver is wired."""
+    return False
+
+
+def emc_solver_available() -> bool:
+    """Return ``True`` only when a full-wave EM / radiated-emissions solver is wired."""
     return False
 
 
@@ -150,3 +160,19 @@ def thermal_fd_method() -> dict[str, Any]:
         "solver_grade": True,
         "accuracy": THERMAL_FD_ACCURACY,
     }
+
+
+def emc_method() -> dict[str, Any]:
+    """Describe the active EMC computation method, honestly.
+
+    The EMC checks (return-path continuity, via stitching, clearance, diff-pair skew)
+    are geometric/rule heuristics that screen for emission and coupling risk; they are a
+    critic, never a sign-off. They are not a full-wave EM or radiated-emissions solve.
+    """
+    return _method(
+        available=emc_solver_available(),
+        solver_method="full-wave EM / radiated-emissions solver",
+        closed_method=EMC_HEURISTIC_METHOD,
+        closed_accuracy=EMC_HEURISTIC_ACCURACY,
+        what="full-wave EM",
+    )

--- a/tests/unit/test_solver_seams.py
+++ b/tests/unit/test_solver_seams.py
@@ -7,9 +7,12 @@ solver it does not have, and results must be labeled with the honest method.
 from __future__ import annotations
 
 from kicad_mcp.utils.solver_seams import (
+    EMC_HEURISTIC_METHOD,
     PDN_CLOSED_FORM_METHOD,
     PDN_MESH_METHOD,
     THERMAL_CLOSED_FORM_METHOD,
+    emc_method,
+    emc_solver_available,
     ir_drop_method,
     pdn_mesh_method,
     pdn_solver_available,
@@ -39,4 +42,12 @@ def test_no_thermal_solver_is_integrated_yet() -> None:
     method = thermal_method()
     assert method["solver_grade"] is False
     assert method["method"] == THERMAL_CLOSED_FORM_METHOD
+    assert "not a" in method["note"].lower()
+
+
+def test_no_emc_solver_is_integrated_yet() -> None:
+    assert emc_solver_available() is False
+    method = emc_method()
+    assert method["solver_grade"] is False
+    assert method["method"] == EMC_HEURISTIC_METHOD
     assert "not a" in method["note"].lower()


### PR DESCRIPTION
## Context
Epic #206's first scope item: heuristic SI/PI/EMC/thermal results must be
**critic-only, never a blocking release PASS**, with a machine-readable
`requires-expert-solver` signal.

That seam already exists for three of the four domains:
- impedance → `field_solver.impedance_method()` (`solver_grade: False`)
- PDN / IR-drop → `solver_seams.ir_drop_method()` / `pdn_mesh_method()`
- thermal → `solver_seams.thermal_method()` / `thermal_fd_method()`

**EMC was the gap** — `emc_compliance.py` emits PASS/WARN verdicts and only the
module docstring noted the checks are geometric heuristics; nothing machine-
readable said "not an EM solver".

## Change
- Add `emc_method()` (and `emc_solver_available() -> False`) to
  `utils/solver_seams.py`, mirroring the PDN/thermal seams: it reports
  `solver_grade: False`, an honest method label, and a "not a full-wave EM /
  radiated-emissions simulation" note.
- Append that label to `emc_run_full_compliance` so the sweep output ends with
  `Method: ... (solver_grade=False) ... Treat results as a critic, not a release
  sign-off.`
- Mirror the existing seam test in `test_solver_seams.py`.

Additive only — no new tool, gate, or output removed (existing EMC substring
assertions still hold), so no docs/snapshot regeneration.

## Verification
- New seam test + EMC integration tests pass.
- Full unit suite + EMC integration: **1080 passed, 0 failed, 6 skipped**.
- `ruff` + `mypy` clean.

Refs #206