### PR TITLE
feat(schematic-rules): Ethernet diff-pair rule pack (#205)

### DIFF
--- a/src/kicad_mcp/utils/schematic_rules.py
+++ b/src/kicad_mcp/utils/schematic_rules.py
@@ -189,6 +189,31 @@ def is_usb_cc_name(name: str) -> bool:
     return bool(_USB_CC_RE.search(name.strip()))
 
 
+# --- Ethernet / MII differential pairs (issue #205, domain rule pack) --------
+# An Ethernet/MDI lane base (TX/RX/TD/RD/MDI/TRD/MX, with optional lane digits)
+# carrying an explicit polarity (+/-, _P/_N, trailing P/N). The required polarity
+# is what excludes single-ended UART TX/RX and MII control lines (TXEN, RXDV).
+_ETH_PAIR_RE = re.compile(
+    r"^(?:ETH(?:ERNET)?[ _-]*)?(?:PHY[ _-]*)?((?:MDI|MX|TRD|TX|RX|TD|RD)\d*)[ _-]*([+\-]|[PN])$",
+    re.IGNORECASE,
+)
+
+
+def ethernet_pair_key(name: str) -> tuple[str, str] | None:
+    """Return ``(base, polarity)`` for an Ethernet diff-pair net, else ``None``.
+
+    ``polarity`` is canonicalized to ``"P"``/``"N"`` (so ``TX+`` and ``TX_P`` are
+    the same half). ``base`` is upper-cased and keeps any lane digit, e.g.
+    ``("MDI0", "P")`` for ``MDI0_P``.
+    """
+    match = _ETH_PAIR_RE.match(name.strip())
+    if match is None:
+        return None
+    base = match.group(1).upper()
+    raw = match.group(2).upper()
+    return base, ("P" if raw in {"+", "P"} else "N")
+
+
 def merge_nets_by_name(nets: Iterable[NetView]) -> list[dict[str, Any]]:
     """Union nets that share a name so cross-sheet named rails analyze as one net.
 
@@ -549,6 +574,51 @@ def _rule_usbc_cc_resistors(nets: Sequence[NetView]) -> list[Finding]:
     return findings
 
 
+def _rule_ethernet_diff_pairs(nets: Sequence[NetView]) -> list[Finding]:
+    """Flag an Ethernet/MDI differential lane wired with only one polarity half.
+
+    Each lane base (e.g. ``TX``, ``MDI0``, ``TRD1``) must carry both a P and an N
+    half. When only one polarity is present across the design, the complement is
+    missing or mis-named. Single-ended UART ``TX``/``RX`` carry no polarity and so
+    are never considered. Fires once per incomplete lane.
+    """
+    lanes: dict[str, dict[str, Any]] = {}
+    for net in nets:
+        for name in _net_names(net):
+            key = ethernet_pair_key(name)
+            if key is None:
+                continue
+            base, polarity = key
+            lane = lanes.setdefault(base, {"polarities": set(), "labels": {}, "refs": []})
+            lane["polarities"].add(polarity)
+            lane["labels"].setdefault(polarity, name)
+            for ref in _net_refs(net, _IC_RE) + _net_refs(net, _CONNECTOR_RE):
+                if ref not in lane["refs"]:
+                    lane["refs"].append(ref)
+
+    findings: list[Finding] = []
+    for base in sorted(lanes):
+        lane = lanes[base]
+        if len(lane["polarities"]) != 1:
+            continue
+        have = next(iter(lane["polarities"]))
+        have_sign, missing_sign = ("+", "-") if have == "P" else ("-", "+")
+        label = lane["labels"][have]
+        findings.append(
+            Finding(
+                rule_id="ethernet_diff_pair",
+                severity="warning",
+                message=(
+                    f"Differential net '{label}' ({base}{have_sign}) has no matching "
+                    f"{base}{missing_sign} half. Ethernet/MDI lanes (TX±, RX±, MDI±) must be "
+                    "wired as complete differential pairs."
+                ),
+                refs=tuple(lane["refs"]) or (label,),
+            )
+        )
+    return findings
+
+
 # Registry of active rules. Append new pure ``(nets) -> [Finding]`` callables here.
 DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_i2c_pullups,
@@ -562,6 +632,7 @@ DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_conflicting_supply_rails,
     _rule_usb_diff_pair_complete,
     _rule_usbc_cc_resistors,
+    _rule_ethernet_diff_pairs,
 )
 
 

--- a/tests/unit/test_schematic_rules.py
+++ b/tests/unit/test_schematic_rules.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from kicad_mcp.utils.schematic_rules import (
+    ethernet_pair_key,
     is_active_low_interrupt_name,
     is_can_name,
     is_ground_name,
@@ -311,6 +312,36 @@ def test_usbc_cc_resistor_is_required_and_resistor_clears_it() -> None:
     # A CC net with no part on it (stray label) is not flagged.
     stray = run_schematic_design_rules([_net(["CC2"], [("TP1", "1")])])
     assert not any(f.rule_id == "usbc_cc_resistors" for f in stray)
+
+
+def test_ethernet_pair_key_classification() -> None:
+    assert ethernet_pair_key("TX+") == ("TX", "P")
+    assert ethernet_pair_key("TX-") == ("TX", "N")
+    assert ethernet_pair_key("MDI0_P") == ("MDI0", "P")
+    assert ethernet_pair_key("MDI0_N") == ("MDI0", "N")
+    assert ethernet_pair_key("ETH_TX_P") == ("TX", "P")
+    assert ethernet_pair_key("TRD1-") == ("TRD1", "N")
+    assert ethernet_pair_key("RX0_N") == ("RX0", "N")
+    # Single-ended UART / MII control lines carry no polarity -> not a pair.
+    for name in ["TX", "RX", "TXD", "RXD0", "TXEN", "RX_DV", "RXER", "DATA", "VCC"]:
+        assert ethernet_pair_key(name) is None, name
+
+
+def test_ethernet_incomplete_lane_is_flagged_and_complete_is_clean() -> None:
+    # Only TX+ present -> the missing TX- half is flagged once.
+    half = run_schematic_design_rules([_net(["ETH_TX_P"], [("U1", "1"), ("J1", "2")])])
+    eth = [f for f in half if f.rule_id == "ethernet_diff_pair"]
+    assert len(eth) == 1
+    assert "TX-" in eth[0].message
+    assert set(eth[0].refs) == {"U1", "J1"}
+
+    # Both halves present -> clean.
+    full = run_schematic_design_rules([_net(["TX+"], [("U1", "1")]), _net(["TX-"], [("U1", "2")])])
+    assert not any(f.rule_id == "ethernet_diff_pair" for f in full)
+
+    # Single-ended UART TX/RX must never be flagged as a half-pair.
+    uart = run_schematic_design_rules([_net(["TX"], [("U1", "1")]), _net(["RX"], [("U1", "2")])])
+    assert not any(f.rule_id == "ethernet_diff_pair" for f in uart)
 
 
 def test_findings_are_sorted_and_typed() -> None:


### PR DESCRIPTION
## Summary
Second domain rule pack for #205, added to the pure `schematic_design_rule_check` engine. Advances the epic (Ethernet checkbox), does not close it.

- **`ethernet_diff_pair`** — flags an Ethernet/MDI lane wired with only one polarity half (e.g. `TX+` present but `TX-` missing, `MDI0_P` without `MDI0_N`). Fires once per incomplete lane.

New classifier `ethernet_pair_key(name) -> (base, polarity)` is conservative: it requires an **explicit polarity** (`+`/`-`, `_P`/`_N`, trailing `P`/`N`) on a lane base (`TX`/`RX`/`TD`/`RD`/`MDI`/`TRD`/`MX` with optional lane digits). Because the polarity is mandatory, single-ended **UART** `TX`/`RX` and MII control lines (`TXEN`, `RX_DV`, `RXER`, `TXD`) are never mistaken for a differential half. Polarity is canonicalized so `TX+` and `TX_P` are the same half.

## Verification
- New good/bad fixtures in `tests/unit/test_schematic_rules.py` (2 tests: pair-key classification incl. UART/MII negatives; incomplete-lane flagged / complete-pair clean / UART-not-flagged). Full file: 28 passed.
- `ruff format` + `ruff check` clean.
- Internal to the existing tool — no tool-surface / docs / toolsets / MCP-metadata regeneration needed.

## Scope note
Lands the Ethernet diff-pair check. Magnetics placement and Bob-Smith termination are PCB/placement concerns tracked separately under #205; SMPS/RF/HV/battery packs remain as follow-up increments.

Refs #205