### PR TITLE
feat(schematic-rules): SMPS switching-regulator rule pack (#205)

### DIFF
--- a/src/kicad_mcp/utils/schematic_rules.py
+++ b/src/kicad_mcp/utils/schematic_rules.py
@@ -189,6 +189,25 @@ def is_usb_cc_name(name: str) -> bool:
     return bool(_USB_CC_RE.search(name.strip()))
 
 
+# --- Switching regulator / SMPS (issue #205, domain rule pack) ---------------
+# Explicit [^A-Z0-9] boundaries are used (not \b) because regex word boundaries
+# treat "_" as a word char, and KiCad net names are underscore-heavy
+# (e.g. "SW_BST", "BUCK_FB"). Bare "BOOT" is intentionally excluded so MCU
+# boot-mode straps (BOOT0/BOOT1/BOOTSEL) do not trip the bootstrap rule.
+_SMPS_BOOTSTRAP_RE = re.compile(r"(?:^|[^A-Z0-9])(?:V?BST|BOOTSTRAP)(?:[^A-Z0-9]|$)", re.IGNORECASE)
+_SMPS_FEEDBACK_RE = re.compile(r"(?:^|[^A-Z0-9])(?:V?FB|FEEDBACK)(?:[^A-Z0-9]|$)", re.IGNORECASE)
+
+
+def is_bootstrap_name(name: str) -> bool:
+    """Return whether a net name denotes a switching-regulator bootstrap (BST) node."""
+    return bool(_SMPS_BOOTSTRAP_RE.search(name.strip()))
+
+
+def is_feedback_name(name: str) -> bool:
+    """Return whether a net name denotes a regulator feedback (FB) node."""
+    return bool(_SMPS_FEEDBACK_RE.search(name.strip()))
+
+
 # --- Ethernet / MII differential pairs (issue #205, domain rule pack) --------
 # An Ethernet/MDI lane base (TX/RX/TD/RD/MDI/TRD/MX, with optional lane digits)
 # carrying an explicit polarity (+/-, _P/_N, trailing P/N). The required polarity
@@ -619,6 +638,60 @@ def _rule_ethernet_diff_pairs(nets: Sequence[NetView]) -> list[Finding]:
     return findings
 
 
+def _rule_smps_bootstrap_cap(nets: Sequence[NetView]) -> list[Finding]:
+    """Flag a switching-regulator bootstrap (BST) node with no bootstrap capacitor."""
+    findings: list[Finding] = []
+    for net in nets:
+        bst_names = [name for name in _net_names(net) if is_bootstrap_name(name)]
+        if not bst_names:
+            continue
+        ics = _net_refs(net, _IC_RE)
+        if not ics:
+            continue
+        if _net_refs(net, _CAP_RE):
+            continue
+        findings.append(
+            Finding(
+                rule_id="smps_bootstrap_cap",
+                severity="warning",
+                message=(
+                    f"Bootstrap net '{bst_names[0]}' on {', '.join(ics)} has no bootstrap "
+                    "capacitor. A switching regulator's BST pin needs a small capacitor "
+                    "(often 100nF) to the switch node to drive the high-side gate."
+                ),
+                refs=tuple(ics),
+            )
+        )
+    return findings
+
+
+def _rule_smps_feedback_divider(nets: Sequence[NetView]) -> list[Finding]:
+    """Flag a regulator feedback (FB) node that reaches an IC with no resistor divider."""
+    findings: list[Finding] = []
+    for net in nets:
+        fb_names = [name for name in _net_names(net) if is_feedback_name(name)]
+        if not fb_names:
+            continue
+        ics = _net_refs(net, _IC_RE)
+        if not ics:
+            continue
+        if _net_refs(net, _RESISTOR_RE):
+            continue
+        findings.append(
+            Finding(
+                rule_id="smps_feedback_divider",
+                severity="warning",
+                message=(
+                    f"Feedback net '{fb_names[0]}' on {', '.join(ics)} has no resistor. An "
+                    "adjustable regulator sets its output with a feedback resistor divider; "
+                    "check the divider is present (a fixed-output part can ignore this)."
+                ),
+                refs=tuple(ics),
+            )
+        )
+    return findings
+
+
 # Registry of active rules. Append new pure ``(nets) -> [Finding]`` callables here.
 DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_i2c_pullups,
@@ -633,6 +706,8 @@ DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_usb_diff_pair_complete,
     _rule_usbc_cc_resistors,
     _rule_ethernet_diff_pairs,
+    _rule_smps_bootstrap_cap,
+    _rule_smps_feedback_divider,
 )
 
 

--- a/tests/unit/test_schematic_rules.py
+++ b/tests/unit/test_schematic_rules.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from kicad_mcp.utils.schematic_rules import (
     ethernet_pair_key,
     is_active_low_interrupt_name,
+    is_bootstrap_name,
     is_can_name,
+    is_feedback_name,
     is_ground_name,
     is_i2c_name,
     is_reset_name,
@@ -342,6 +344,41 @@ def test_ethernet_incomplete_lane_is_flagged_and_complete_is_clean() -> None:
     # Single-ended UART TX/RX must never be flagged as a half-pair.
     uart = run_schematic_design_rules([_net(["TX"], [("U1", "1")]), _net(["RX"], [("U1", "2")])])
     assert not any(f.rule_id == "ethernet_diff_pair" for f in uart)
+
+
+def test_smps_bootstrap_and_feedback_classification() -> None:
+    for name in ["BST", "VBST", "SW_BST", "BOOTSTRAP", "BUCK_BST"]:
+        assert is_bootstrap_name(name), name
+    # MCU boot-mode straps and unrelated words must not look like a bootstrap node.
+    for name in ["BOOT0", "BOOT1", "BOOTSEL", "BURST", "ROBUST", "VCC"]:
+        assert not is_bootstrap_name(name), name
+
+    for name in ["FB", "VFB", "FEEDBACK", "BUCK_FB", "FB_SENSE"]:
+        assert is_feedback_name(name), name
+    for name in ["FBGA", "AFB", "VCC", "GND"]:
+        assert not is_feedback_name(name), name
+
+
+def test_smps_bootstrap_cap_is_required_and_cap_clears_it() -> None:
+    flagged = run_schematic_design_rules([_net(["SW_BST"], [("U1", "3")])])
+    bst = [f for f in flagged if f.rule_id == "smps_bootstrap_cap"]
+    assert len(bst) == 1 and bst[0].refs == ("U1",)
+
+    with_cap = run_schematic_design_rules([_net(["SW_BST"], [("U1", "3"), ("C1", "1")])])
+    assert not any(f.rule_id == "smps_bootstrap_cap" for f in with_cap)
+
+    # A BST-named net that reaches no IC is not flagged.
+    no_ic = run_schematic_design_rules([_net(["BST"], [("J1", "1")])])
+    assert not any(f.rule_id == "smps_bootstrap_cap" for f in no_ic)
+
+
+def test_smps_feedback_divider_is_required_and_resistor_clears_it() -> None:
+    flagged = run_schematic_design_rules([_net(["VFB"], [("U1", "4")])])
+    fb = [f for f in flagged if f.rule_id == "smps_feedback_divider"]
+    assert len(fb) == 1 and fb[0].refs == ("U1",)
+
+    with_r = run_schematic_design_rules([_net(["VFB"], [("U1", "4"), ("R1", "1")])])
+    assert not any(f.rule_id == "smps_feedback_divider" for f in with_r)
 
 
 def test_findings_are_sorted_and_typed() -> None:


### PR DESCRIPTION
## Summary
Third domain rule pack for #205 (switching-regulator checkbox), added to the pure `schematic_design_rule_check` engine. Advances the epic, does not close it.

- **`smps_bootstrap_cap`** — flags a bootstrap (`BST`) node on a regulator IC with no bootstrap capacitor (the high-side gate-drive cap to the switch node).
- **`smps_feedback_divider`** — flags an adjustable-regulator feedback (`FB`) node reaching an IC with no resistor; message notes a fixed-output part can ignore it.

Classifiers `is_bootstrap_name()` / `is_feedback_name()` use explicit `[^A-Z0-9]` boundaries rather than `\b`, because regex word boundaries treat `_` as a word char and KiCad net names are underscore-heavy (`SW_BST`, `BUCK_FB`). Bare `BOOT` is deliberately excluded so MCU boot-mode straps (`BOOT0`/`BOOT1`/`BOOTSEL`) and words like `BURST`/`ROBUST`/`FBGA` never trip the rules.

## Verification
- New good/bad fixtures in `tests/unit/test_schematic_rules.py` (3 tests: bootstrap/feedback classification incl. boot-strap negatives; bootstrap cap required / cap clears / no-IC clean; feedback divider required / resistor clears). Full file: 31 passed.
- `ruff format` + `ruff check` clean.
- Internal to the existing tool — no tool-surface / docs / toolsets / MCP-metadata regeneration needed.

## Scope note
RF, HV/isolated, and battery/charger packs remain as follow-up increments under #205; CAN termination is already covered by `can_bus_termination`.

Refs #205