### PR TITLE
feat(contracts): enforce tier/side-effect consistency in tool-contract lint (#196)

### DIFF
--- a/scripts/check_tool_contracts.py
+++ b/scripts/check_tool_contracts.py
@@ -53,6 +53,27 @@ async def lint() -> list[str]:
                 errors.append(f"{name} must explicitly declare rollback support.")
             if not isinstance(record.supports_dry_run, bool):
                 errors.append(f"{name} must explicitly declare dry-run support.")
+
+    # Contract/tier consistency: the side-effect flags an agent reads to decide
+    # whether a call is safe must never contradict the access tier. A READ tool
+    # that writes files or mutates GUI state would be wrongly surfaced in
+    # read-only profiles; a human-gated op whose tier is not HUMAN_ONLY (or vice
+    # versa) lets an agent auto-run something that needs a person.
+    for name, record in records.items():
+        if record.tier is AccessTier.READ:
+            if record.writes_files:
+                errors.append(f"READ-tier tool {name} must not declare writes_files=True.")
+            if record.writes_kicad_gui_state:
+                errors.append(
+                    f"READ-tier tool {name} must not declare writes_kicad_gui_state=True."
+                )
+        is_human_only = record.tier is AccessTier.HUMAN_ONLY
+        if is_human_only and not record.human_gate_required:
+            errors.append(f"HUMAN_ONLY tool {name} must declare human_gate_required=True.")
+        if record.human_gate_required and not is_human_only:
+            errors.append(
+                f"{name} declares human_gate_required=True but its tier is not HUMAN_ONLY."
+            )
     return errors
 
 

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -64,6 +64,19 @@ def test_registered_tools_have_valid_verification_levels() -> None:
         assert record.verification_level in valid_levels
 
 
+def test_contract_side_effect_flags_are_consistent_with_access_tier() -> None:
+    """Contract invariants (#196): the side-effect flags an agent reads to decide
+    whether a call is safe must never contradict the access tier."""
+    for record in all_records().values():
+        if record.tier is AccessTier.READ:
+            assert record.writes_files is False, record.name
+            assert record.writes_kicad_gui_state is False, record.name
+        if record.tier is AccessTier.HUMAN_ONLY:
+            assert record.human_gate_required is True, record.name
+        if record.human_gate_required:
+            assert record.tier is AccessTier.HUMAN_ONLY, record.name
+
+
 def test_oaslana_119_pcb_live_editing_tools_require_kicad_ipc() -> None:
     records = all_records()
     pcb_tools = {name for name in REQUIRED_OASLANA_119_TOOLS if name.startswith("pcb_")}


### PR DESCRIPTION
## Summary
An increment toward #196 (tool contract standardization). Rather than hand-author free-text contracts for all ~368 tools at once, this **closes a contract-drift hole** in the existing capability-record framework by enforcing that the safety-critical flags an agent relies on can never contradict a tool's access tier.

Three new invariants in `check_tool_contracts.lint()`:
- **READ-tier ⟹ not `writes_files`** — a read tool that writes files would be wrongly surfaced in read-only/beginner profiles.
- **READ-tier ⟹ not `writes_kicad_gui_state`** — same hazard for GUI mutation.
- **`human_gate_required` ⟺ HUMAN_ONLY tier** — a human-gated op whose tier isn't HUMAN_ONLY lets an agent auto-run something that needs a person (and vice-versa).

## Why this slice
The epic's end state (a full `when_to_use`/`preconditions`/`example_io` block on every tool) is multi-PR. Adding a field to the advertised `to_protocol_metadata` would bump `PROTOCOL_TOOL_CAPABILITY_SCHEMA_VERSION` and force server.json / protocol-schema / snapshot regen. This increment instead hardens the contract guarantees that already matter most for agent safety, with **no schema change and no regeneration**.

## Verification
- All 368 current capability records already satisfy the invariants (verified), so this is a pure regression guard — it fails CI the moment a future tool is misclassified.
- Enforced two ways: the existing `test_every_published_tool...`/lint assertion (`await lint() == []`) now covers them, plus a new dedicated `test_contract_side_effect_flags_are_consistent_with_access_tier` documenting the contract.
- `ruff format`/`check` clean; `scripts/check_tool_contracts.py` exits 0; `test_capabilities.py` + `test_tool_metadata_lint.py` = 14 passed.

Refs #196