### PR TITLE
feat(footprint): pad-count vs package-name cross-check (#201)

### DIFF
--- a/src/kicad_mcp/utils/footprint_validate.py
+++ b/src/kicad_mcp/utils/footprint_validate.py
@@ -122,3 +122,150 @@ def validate_chip_footprint(
             f"{tol_mm:.3f} mm."
         )
     return FootprintCheck(verdict=verdict, summary=summary, findings=findings)
+
+
+# ---------------------------------------------------------------------------
+# Pad-count vs package cross-check (issue #201)
+# ---------------------------------------------------------------------------
+# A package name encodes its pin count; the footprint must actually carry that
+# many numbered pads. A footprint with fewer pads than its package promises is a
+# hard error (silent fab-killer). This is package-agnostic and complements the
+# chip-geometry check above.
+
+# Families where the integer right after the family token IS the pin/lead count
+# (e.g. SOIC-8, LQFP-48, QFN-32, TSSOP-20, PDIP-16). Longest names must be tried
+# first so "TSSOP" wins over "SOP"/"SO" and "SDIP" wins over "DIP".
+_PIN_COUNT_FAMILIES = (
+    "HTSSOP",
+    "TSSOP",
+    "VSSOP",
+    "SSOP",
+    "QSOP",
+    "MSOP",
+    "SOIC",
+    "SOP",
+    "SO",
+    "HVQFN",
+    "WQFN",
+    "UQFN",
+    "VQFN",
+    "TQFN",
+    "QFN",
+    "UDFN",
+    "WDFN",
+    "DFN",
+    "LQFP",
+    "TQFP",
+    "MQFP",
+    "HQFP",
+    "QFP",
+    "PLCC",
+    "PDIP",
+    "CDIP",
+    "SDIP",
+    "DIP",
+)
+# Families where the FIRST number is a JEDEC package code, not the pin count —
+# the lead count (if present) follows a second dash: SOT-23-5, SOT-23-3,
+# TO-252-3. Bare "SOT-23"/"SOT-223" carry no explicit lead count, so we skip
+# them rather than guess (no false positives).
+_CODE_FIRST_FAMILIES = ("SOT", "SOD", "SC", "TO")
+
+_PIN_COUNT_RE = re.compile(
+    r"(?<![A-Z])(?:" + "|".join(_PIN_COUNT_FAMILIES) + r")-(\d+)(?![0-9])",
+    re.IGNORECASE,
+)
+_CODE_FIRST_RE = re.compile(
+    r"(?<![A-Z])(?:" + "|".join(_CODE_FIRST_FAMILIES) + r")-\d+-(\d+)(?![0-9])",
+    re.IGNORECASE,
+)
+_PAD_NUM_RE = re.compile(
+    r'\(pad\s+"?(?P<num>[^"\s)]+)"?\s+(?:smd|thru_hole|connect)\b',
+    re.IGNORECASE,
+)
+
+
+def expected_pin_count_from_package(footprint_name: str) -> int | None:
+    """Return the pin count a footprint's package name implies, or ``None``.
+
+    Strips any ``Library:`` prefix. Returns ``None`` for packages whose name does
+    not unambiguously encode a pin count (bare ``SOT-23``, grid-array BGA/LGA,
+    plain chip codes), so the cross-check stays silent unless it is confident.
+    """
+    base = footprint_name.split(":")[-1]
+    code_first = _CODE_FIRST_RE.search(base)
+    if code_first is not None:
+        return int(code_first.group(1))
+    pin_count = _PIN_COUNT_RE.search(base)
+    if pin_count is not None:
+        return int(pin_count.group(1))
+    return None
+
+
+def count_numbered_pads(footprint_text: str) -> int:
+    """Count distinct positive-integer pad numbers (signal pins) in .kicad_mod text.
+
+    Mechanical/unnumbered pads (``np_thru_hole``, pads numbered ``""`` or ``0``)
+    and grid-reference pads (``A1``) are not counted as signal pins.
+    """
+    numbers: set[int] = set()
+    for match in _PAD_NUM_RE.finditer(footprint_text):
+        token = match.group("num")
+        if token.isdigit() and int(token) > 0:
+            numbers.add(int(token))
+    return len(numbers)
+
+
+def check_footprint_pad_count(
+    footprint_name: str,
+    footprint_text: str,
+    *,
+    exposed_pad_tolerance: int = 2,
+) -> FootprintCheck | None:
+    """Cross-check a footprint's numbered-pad count against its package name.
+
+    Returns ``None`` when the package name carries no certifiable pin count.
+    Fewer pads than the package implies is a blocking ``FAIL``; a small surplus
+    (within ``exposed_pad_tolerance``) is treated as an exposed/thermal pad and
+    ``PASS``es with a note; a larger surplus ``WARN``s.
+    """
+    expected = expected_pin_count_from_package(footprint_name)
+    if expected is None:
+        return None
+    actual = count_numbered_pads(footprint_text)
+    package = footprint_name.split(":")[-1]
+
+    if actual == expected:
+        return FootprintCheck(
+            verdict="PASS",
+            summary=(
+                f"Footprint '{package}' has {actual} numbered pads, "
+                f"matching its {expected}-pin package."
+            ),
+        )
+    if actual < expected:
+        return FootprintCheck(
+            verdict="FAIL",
+            summary=(
+                f"Footprint '{package}' has {actual} numbered pads but its package name implies "
+                f"{expected} pins — pins are missing, which will not match the part."
+            ),
+            findings=[f"pad count {actual} < expected {expected}"],
+        )
+    if actual <= expected + exposed_pad_tolerance:
+        extra = actual - expected
+        return FootprintCheck(
+            verdict="PASS",
+            summary=(
+                f"Footprint '{package}' has {actual} numbered pads for a {expected}-pin package; "
+                f"the {extra} extra is likely an exposed/thermal pad."
+            ),
+        )
+    return FootprintCheck(
+        verdict="WARN",
+        summary=(
+            f"Footprint '{package}' has {actual} numbered pads but its package name implies "
+            f"{expected} pins — more pads than expected."
+        ),
+        findings=[f"pad count {actual} > expected {expected} + {exposed_pad_tolerance}"],
+    )

--- a/tests/unit/test_footprint_validate.py
+++ b/tests/unit/test_footprint_validate.py
@@ -4,9 +4,19 @@ from __future__ import annotations
 
 from kicad_mcp.utils.footprint_gen import _chip_passive
 from kicad_mcp.utils.footprint_validate import (
+    check_footprint_pad_count,
+    count_numbered_pads,
+    expected_pin_count_from_package,
     parse_smd_pads,
     validate_chip_footprint,
 )
+
+
+def _pads_text(numbers: list[str], pad_type: str = "smd") -> str:
+    """Build minimal .kicad_mod pad lines for the given pad-number tokens."""
+    return "\n".join(
+        f'(pad "{num}" {pad_type} roundrect (at 0 0) (size 1 1) (layers "F.Cu"))' for num in numbers
+    )
 
 
 def test_generated_chip_footprint_validates_pass() -> None:
@@ -57,3 +67,67 @@ def test_parse_smd_pads_reads_position_and_size() -> None:
     # Pads are mirrored about the origin on the x-axis.
     assert pads[0].x == -pads[1].x
     assert pads[0].w == pads[1].w
+
+
+# --- Pad-count vs package cross-check (issue #201) --------------------------
+
+
+def test_expected_pin_count_from_package_reads_pin_count_families() -> None:
+    assert expected_pin_count_from_package("Package_SO:SOIC-8_3.9x4.9mm_P1.27mm") == 8
+    assert expected_pin_count_from_package("Package_QFP:LQFP-48_7x7mm_P0.5mm") == 48
+    assert expected_pin_count_from_package("Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm") == 32
+    assert expected_pin_count_from_package("Package_SO:TSSOP-20_4.4x6.5mm_P0.65mm") == 20
+    assert expected_pin_count_from_package("Package_DIP:PDIP-16_W7.62mm") == 16
+
+
+def test_expected_pin_count_handles_code_first_packages() -> None:
+    # For SOT/TO the first number is a JEDEC code; the lead count follows it.
+    assert expected_pin_count_from_package("Package_TO_SOT_SMD:SOT-23-5") == 5
+    assert expected_pin_count_from_package("Package_TO_SOT_SMD:SOT-23-3") == 3
+    assert expected_pin_count_from_package("Package_TO_SOT_THT:TO-252-3_TabPin2") == 3
+
+
+def test_expected_pin_count_returns_none_when_ambiguous() -> None:
+    # No explicit lead count, grid arrays, and plain chips are not certifiable here.
+    for name in [
+        "Package_TO_SOT_SMD:SOT-23",
+        "Package_TO_SOT_SMD:SOT-223",
+        "Package_BGA:BGA-256_17x17mm",
+        "Resistor_SMD:R_0805_2012Metric",
+        "Capacitor_SMD:C_0402_1005Metric",
+    ]:
+        assert expected_pin_count_from_package(name) is None, name
+
+
+def test_count_numbered_pads_ignores_mechanical_and_grid_pads() -> None:
+    assert count_numbered_pads(_pads_text(["1", "2", "3", "4"])) == 4
+    # Distinct integers only; an exposed pad numbered "5" counts, "" / "0" do not.
+    assert count_numbered_pads(_pads_text(["1", "2", "5", "", "0"])) == 3
+    # np_thru_hole mounting holes are not signal pins.
+    assert (
+        count_numbered_pads(_pads_text(["1", "2"]) + "\n" + _pads_text([""], "np_thru_hole")) == 2
+    )
+
+
+def test_check_footprint_pad_count_matches_and_misses() -> None:
+    soic8 = "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
+    ok = check_footprint_pad_count(soic8, _pads_text(["1", "2", "3", "4", "5", "6", "7", "8"]))
+    assert ok is not None and ok.verdict == "PASS"
+
+    missing = check_footprint_pad_count(soic8, _pads_text(["1", "2", "3", "4", "5", "6"]))
+    assert missing is not None and missing.verdict == "FAIL"
+    assert missing.findings
+
+    # QFN-32 with an exposed thermal pad (33 numbered pads) passes within tolerance.
+    qfn = "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm"
+    exposed = check_footprint_pad_count(qfn, _pads_text([str(n) for n in range(1, 34)]))
+    assert exposed is not None and exposed.verdict == "PASS"
+
+    # Far too many pads warns.
+    too_many = check_footprint_pad_count(soic8, _pads_text([str(n) for n in range(1, 13)]))
+    assert too_many is not None and too_many.verdict == "WARN"
+
+    # An uncertifiable package name yields no finding.
+    assert (
+        check_footprint_pad_count("Resistor_SMD:R_0805_2012Metric", _pads_text(["1", "2"])) is None
+    )


### PR DESCRIPTION
## Summary
Increment toward #201 (symbol/footprint certification). Implements the **"pad count vs package pins"** footprint check as a pure helper in `utils/footprint_validate.py`, complementing the existing two-terminal chip-geometry validator (P4-T3).

A package name encodes its pin count; a footprint that carries fewer numbered pads than its package promises is a silent fab-killer. This cross-check catches it package-agnostically (SOIC / QFP / QFN / TSSOP / SOT / DIP / PLCC …).

- **`expected_pin_count_from_package(name)`** — derives the implied pin count from the footprint name. Handles the **SOT/TO 'package-code-first' trap**: in `SOT-23-5` the `23` is a JEDEC code and the lead count is the *second* number (`5`). Returns `None` for ambiguous names (bare `SOT-23`, `SOT-223`, grid-array `BGA`/`LGA`, plain chip codes) so it never guesses.
- **`count_numbered_pads(text)`** — distinct positive-integer pad numbers (signal pins); ignores `np_thru_hole` mounting holes, unnumbered/`0` pads, and grid-ref (`A1`) pads.
- **`check_footprint_pad_count(...)`** — `FAIL` when actual < expected; `PASS` within an exposed/thermal-pad tolerance (default +2); `WARN` on a large surplus; `None` when uncertifiable.

## Verification
- New unit tests in `tests/unit/test_footprint_validate.py` (5 tests covering pin-count families, code-first SOT/TO, ambiguous→None, pad counting incl. mechanical/grid exclusion, and PASS/FAIL/exposed-pad/WARN verdicts). Full file: 10 passed.
- `ruff format` + `ruff check` clean.
- Pure helper, mirroring the existing `validate_chip_footprint` structure — **no tool-surface / schema / snapshot change, no regen**.

## Scope note
This lands the certification logic. Surfacing it through an MCP tool (a new `lib_*` tool, or folding into the footprint validator) is a follow-up — adding a tool triggers the tool-surface regen chain, so it's kept separate. Remaining #201 items (pad numbering vs package drawing, courtyard/silk/mask layers, pin-1 marker, IPC-7351 density on generated footprints, 3D origin checks) are further increments.

Refs #201