### PR TITLE
feat(footprint): documentation-layer completeness check (#201)

### DIFF
--- a/src/kicad_mcp/utils/footprint_validate.py
+++ b/src/kicad_mcp/utils/footprint_validate.py
@@ -269,3 +269,53 @@ def check_footprint_pad_count(
         ),
         findings=[f"pad count {actual} > expected {expected} + {exposed_pad_tolerance}"],
     )
+
+
+# ---------------------------------------------------------------------------
+# Documentation-layer completeness (issue #201)
+# ---------------------------------------------------------------------------
+# A complete footprint carries a courtyard (placement/DRC clearance), a
+# fabrication outline (assembly drawing), and a silkscreen outline (board
+# legend). A missing courtyard is a hard gate because KiCad relies on it for
+# component-to-component clearance; missing fab/silk degrade documentation.
+
+_COURTYARD_RE = re.compile(r"[FB]\.CrtYd", re.IGNORECASE)
+_FAB_RE = re.compile(r"[FB]\.Fab", re.IGNORECASE)
+_SILK_RE = re.compile(r"[FB]\.SilkS", re.IGNORECASE)
+
+
+def check_footprint_documentation_layers(footprint_text: str) -> FootprintCheck:
+    """Verify a footprint has courtyard, fabrication, and silkscreen graphics.
+
+    No courtyard is a blocking ``FAIL`` (KiCad uses it for placement clearance);
+    a missing fab or silkscreen outline ``WARN``s. All three present ``PASS``es.
+    """
+    has_courtyard = bool(_COURTYARD_RE.search(footprint_text))
+    has_fab = bool(_FAB_RE.search(footprint_text))
+    has_silk = bool(_SILK_RE.search(footprint_text))
+
+    findings: list[str] = []
+    if not has_fab:
+        findings.append("no fabrication-layer (F.Fab/B.Fab) outline")
+    if not has_silk:
+        findings.append("no silkscreen-layer (F.SilkS/B.SilkS) outline")
+
+    if not has_courtyard:
+        return FootprintCheck(
+            verdict="FAIL",
+            summary=(
+                "Footprint has no courtyard (F.CrtYd/B.CrtYd) — KiCad needs it for "
+                "component-to-component placement clearance; blocking."
+            ),
+            findings=["no courtyard-layer (F.CrtYd/B.CrtYd) graphics", *findings],
+        )
+    if findings:
+        return FootprintCheck(
+            verdict="WARN",
+            summary="Footprint has a courtyard but is missing documentation graphics.",
+            findings=findings,
+        )
+    return FootprintCheck(
+        verdict="PASS",
+        summary="Footprint has courtyard, fabrication, and silkscreen graphics.",
+    )

--- a/tests/unit/test_footprint_validate.py
+++ b/tests/unit/test_footprint_validate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from kicad_mcp.utils.footprint_gen import _chip_passive
 from kicad_mcp.utils.footprint_validate import (
+    check_footprint_documentation_layers,
     check_footprint_pad_count,
     count_numbered_pads,
     expected_pin_count_from_package,
@@ -131,3 +132,33 @@ def test_check_footprint_pad_count_matches_and_misses() -> None:
     assert (
         check_footprint_pad_count("Resistor_SMD:R_0805_2012Metric", _pads_text(["1", "2"])) is None
     )
+
+
+_FULL_FP = (
+    '(fp_line (start -1 -1) (end 1 -1) (layer "F.CrtYd"))\n'
+    '(fp_line (start -1 -1) (end 1 -1) (layer "F.Fab"))\n'
+    '(fp_line (start -1 -1) (end 1 -1) (layer "F.SilkS"))\n'
+)
+
+
+def test_documentation_layers_pass_when_all_present() -> None:
+    result = check_footprint_documentation_layers(_FULL_FP)
+    assert result.verdict == "PASS"
+
+
+def test_documentation_layers_fail_without_courtyard() -> None:
+    no_courtyard = (
+        '(fp_line (start -1 -1) (end 1 -1) (layer "F.Fab"))\n'
+        '(fp_line (start -1 -1) (end 1 -1) (layer "F.SilkS"))\n'
+    )
+    result = check_footprint_documentation_layers(no_courtyard)
+    assert result.verdict == "FAIL"
+    assert any("courtyard" in f for f in result.findings)
+
+
+def test_documentation_layers_warn_when_fab_or_silk_missing() -> None:
+    only_courtyard = '(fp_poly (pts (xy 0 0)) (layer "B.CrtYd"))\n'
+    result = check_footprint_documentation_layers(only_courtyard)
+    assert result.verdict == "WARN"
+    assert any("fabrication" in f for f in result.findings)
+    assert any("silkscreen" in f for f in result.findings)


### PR DESCRIPTION
## Summary
Second increment toward #201's footprint-checks list. Adds `check_footprint_documentation_layers()` to `utils/footprint_validate.py`, verifying a footprint carries the expected documentation graphics:

- **Courtyard** (`F.CrtYd`/`B.CrtYd`) — missing is a blocking **FAIL** (KiCad uses it for component-to-component placement clearance).
- **Fabrication** (`F.Fab`) and **silkscreen** (`F.SilkS`) outlines — missing **WARN**s.
- All three present → **PASS**.

## Verification
- New unit tests in `tests/unit/test_footprint_validate.py` (3 tests: all-present PASS, no-courtyard FAIL, missing-fab/silk WARN). Full file: 13 passed.
- `ruff format` + `ruff check` clean.
- Pure helper — no tool-surface / schema / snapshot change, no regen.

## Scope note
Remaining #201 footprint items: pad numbering vs package drawing, mask/paste-layer specifics, pin-1 marker detection, IPC-7351 density tag on generated footprints, 3D-origin checks. Surfacing these checks through an MCP tool is a follow-up.

Refs #201