### PR TITLE
feat(schematic-rules): external-port ESD/TVS/protection rule pack (#205)

### DIFF
--- a/src/kicad_mcp/utils/schematic_rules.py
+++ b/src/kicad_mcp/utils/schematic_rules.py
@@ -86,6 +86,16 @@ _IC_RE = re.compile(r"^(?:U|IC)\d")
 _CRYSTAL_RE = re.compile(r"^(?:Y|X)\d")
 _CONNECTOR_RE = re.compile(r"^(?:J|CN|CON)\d")
 _RESET_TOKENS = frozenset({"RST", "NRST", "RSTN", "POR"})
+_EXTERNAL_PORT_TOKEN_RE = re.compile(
+    r"(?:^|[^A-Z0-9])(?:VBUS|VIN|VBAT|RS[ _-]?485|UART|TXD|RXD|GPIO|IO)(?:[^A-Z0-9]|$)",
+    re.IGNORECASE,
+)
+_PROTECTION_REF_RE = re.compile(r"^(?:ESD|TVS|F|PTC|RV)\d", re.IGNORECASE)
+_PROTECTION_VALUE_RE = re.compile(
+    r"(?:TVS|ESD|PESD|TPD|USBLC|SP[0-9]|SMF|SMAJ|SMBJ|SMCJ|ESDA|"
+    r"PROTECT|POLYFUSE|PTC|FUSE|SCHOTTKY|REVERSE|VARISTOR|MOV|SS[0-9]|1N581)",
+    re.IGNORECASE,
+)
 
 
 def is_ground_name(name: str) -> bool:
@@ -231,6 +241,33 @@ def ethernet_pair_key(name: str) -> tuple[str, str] | None:
     base = match.group(1).upper()
     raw = match.group(2).upper()
     return base, ("P" if raw in {"+", "P"} else "N")
+
+
+def is_external_port_name(name: str) -> bool:
+    """Return whether a net name strongly implies an externally exposed port."""
+    return bool(
+        usb_data_polarity(name)
+        or is_usb_cc_name(name)
+        or is_can_name(name)
+        or ethernet_pair_key(name)
+        or _EXTERNAL_PORT_TOKEN_RE.search(name.strip())
+    )
+
+
+def _pin_value(pin: Mapping[str, Any]) -> str:
+    return str(pin.get("value", "") or "")
+
+
+def _net_has_protection_evidence(net: NetView) -> bool:
+    """Return whether a net carries ESD/TVS/fuse/reverse-protection evidence."""
+    for pin in net.get("pins", []):
+        ref = str(pin.get("reference", ""))
+        value = _pin_value(pin)
+        if _PROTECTION_REF_RE.match(ref):
+            return True
+        if _PROTECTION_VALUE_RE.search(value):
+            return True
+    return False
 
 
 def merge_nets_by_name(nets: Iterable[NetView]) -> list[dict[str, Any]]:
@@ -692,6 +729,37 @@ def _rule_smps_feedback_divider(nets: Sequence[NetView]) -> list[Finding]:
     return findings
 
 
+def _rule_external_port_protection(nets: Sequence[NetView]) -> list[Finding]:
+    """Flag externally exposed connector nets with no ESD/TVS/reverse-protection evidence."""
+    findings: list[Finding] = []
+    for net in nets:
+        external_names = [name for name in _net_names(net) if is_external_port_name(name)]
+        if not external_names:
+            continue
+        connectors = _net_refs(net, _CONNECTOR_RE)
+        if not connectors:
+            continue
+        ics = _net_refs(net, _IC_RE)
+        if not ics:
+            continue
+        if _net_has_protection_evidence(net):
+            continue
+        findings.append(
+            Finding(
+                rule_id="external_port_protection",
+                severity="warning",
+                message=(
+                    f"External port net '{external_names[0]}' reaches connector "
+                    f"{', '.join(connectors)} and IC {', '.join(ics)} with no ESD/TVS, "
+                    "fuse, or reverse-polarity protection evidence. Add appropriate "
+                    "protection at the connector or document why the port is internal."
+                ),
+                refs=tuple([*connectors, *ics]),
+            )
+        )
+    return findings
+
+
 # Registry of active rules. Append new pure ``(nets) -> [Finding]`` callables here.
 DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_i2c_pullups,
@@ -708,6 +776,7 @@ DESIGN_RULES: tuple[Callable[[Sequence[NetView]], list[Finding]], ...] = (
     _rule_ethernet_diff_pairs,
     _rule_smps_bootstrap_cap,
     _rule_smps_feedback_divider,
+    _rule_external_port_protection,
 )
 
 

--- a/tests/unit/test_schematic_rules.py
+++ b/tests/unit/test_schematic_rules.py
@@ -7,6 +7,7 @@ from kicad_mcp.utils.schematic_rules import (
     is_active_low_interrupt_name,
     is_bootstrap_name,
     is_can_name,
+    is_external_port_name,
     is_feedback_name,
     is_ground_name,
     is_i2c_name,
@@ -24,6 +25,13 @@ def _net(names: list[str], pins: list[tuple[str, str]]) -> dict:
     return {
         "names": names,
         "pins": [{"reference": ref, "pin": pin, "value": ""} for ref, pin in pins],
+    }
+
+
+def _net_v(names: list[str], pins: list[tuple[str, str, str]]) -> dict:
+    return {
+        "names": names,
+        "pins": [{"reference": ref, "pin": pin, "value": value} for ref, pin, value in pins],
     }
 
 
@@ -344,6 +352,39 @@ def test_ethernet_incomplete_lane_is_flagged_and_complete_is_clean() -> None:
     # Single-ended UART TX/RX must never be flagged as a half-pair.
     uart = run_schematic_design_rules([_net(["TX"], [("U1", "1")]), _net(["RX"], [("U1", "2")])])
     assert not any(f.rule_id == "ethernet_diff_pair" for f in uart)
+
+
+def test_external_port_name_classification() -> None:
+    for name in ["USB_DP", "CC1", "CANH", "ETH_TX_P", "RS485_A", "UART_TXD", "VBUS", "VIN"]:
+        assert is_external_port_name(name), name
+    for name in ["+3V3", "VCC", "RESET", "LED_A", "SENSOR_SDA"]:
+        assert not is_external_port_name(name), name
+
+
+def test_external_port_without_protection_is_flagged_and_protection_clears_it() -> None:
+    flagged = run_schematic_design_rules([_net(["USB_DP"], [("J1", "3"), ("U1", "10")])])
+    protection = [f for f in flagged if f.rule_id == "external_port_protection"]
+    assert len(protection) == 1
+    assert protection[0].refs == ("J1", "U1")
+    assert "ESD/TVS" in protection[0].message
+
+    with_esd = run_schematic_design_rules(
+        [_net_v(["USB_DP"], [("J1", "3", ""), ("U1", "10", ""), ("D1", "1", "ESD9M5V")])]
+    )
+    assert not any(f.rule_id == "external_port_protection" for f in with_esd)
+
+    with_fuse = run_schematic_design_rules(
+        [_net_v(["VBUS"], [("J1", "1", ""), ("U1", "5", ""), ("F1", "1", "polyfuse")])]
+    )
+    assert not any(f.rule_id == "external_port_protection" for f in with_fuse)
+
+
+def test_external_port_protection_ignores_connector_only_and_internal_nets() -> None:
+    connector_only = run_schematic_design_rules([_net(["USB_DP"], [("J1", "3")])])
+    assert not any(f.rule_id == "external_port_protection" for f in connector_only)
+
+    internal = run_schematic_design_rules([_net(["SENSOR_SDA"], [("U1", "3"), ("U2", "5")])])
+    assert not any(f.rule_id == "external_port_protection" for f in internal)
 
 
 def test_smps_bootstrap_and_feedback_classification() -> None:


### PR DESCRIPTION
## Summary
Another #205 domain-rule increment (covers the USB *ESD-diodes/inrush-fuse* and HV/protection themes generically). Adds `external_port_protection` to the pure `schematic_design_rule_check` engine.

- **`external_port_protection`** — flags an externally exposed connector net (USB D±, USB-C CC, CAN, Ethernet, RS-485, UART, VBUS/VIN/VBAT) that reaches **both** a connector and an IC but carries **no** ESD/TVS, fuse, or reverse-polarity protection.

Protection evidence is recognized by designator (`ESD`/`TVS`/`F`/`PTC`/`RV`) or part value (`TVS`/`ESD`/`PESD`/`TPD`/`USBLC`/`SMAJ`/`polyfuse`/…). New classifier `is_external_port_name()` reuses the existing USB/CC/CAN/Ethernet detectors.

Conservative by design: fires only when a net reaches **both** a connector and an IC, so internal buses and connector-only nets are never flagged.

## Verification
- New good/bad fixtures in `tests/unit/test_schematic_rules.py` (3 tests: classification incl. negatives; flagged-then-cleared by ESD diode and by polyfuse; connector-only/internal not flagged). Full file: 34 passed.
- `ruff format`/`check` clean.
- Internal to the existing tool — no tool-surface/docs/snapshot regeneration.

Refs #205