### PR TITLE
fix(capabilities): classify lib_certify_footprint as a READ tool

### DIFF
--- a/integrations/common/toolsets.json
+++ b/integrations/common/toolsets.json
@@ -52,6 +52,7 @@
         "kicad_list_recent_projects",
         "kicad_list_tool_categories",
         "kicad_set_project",
+        "lib_certify_footprint",
         "lib_check_derating",
         "lib_check_stock_availability",
         "lib_find_alternative_parts",

--- a/src/kicad_mcp/capabilities.py
+++ b/src/kicad_mcp/capabilities.py
@@ -354,6 +354,7 @@ def _is_read_tool(name: str, category: str) -> bool:
         "pcb_placement_quality_report",
         "pcb_transfer_quality_gate",
         "pcb_transfer_quality_report",
+        "lib_certify_footprint",
     }:
         return True
     return name.startswith(


### PR DESCRIPTION
## Summary

`lib_certify_footprint` (added in #229) is a read-only, file-backed footprint-certification tool that performs **no writes**. However, its name matches none of the read-name prefixes the auto-classifier recognizes (`lib_get_`/`lib_list_`/`lib_search_`/`lib_check_`/`lib_find_`/`lib_recommend_`), so `_is_read_tool` returned `False` and `_tier_for_tool` defaulted it to `AccessTier.WRITE`.

This misclassification (from #229) wrongly excluded the tool from read-only/beginner profiles and would return `MODE_FORBIDDEN` in readonly mode. Its integration test passed only because that test runs in write mode.

## Fix

Add `lib_certify_footprint` to the explicit read-name set in `_is_read_tool` (alongside `kicad_set_project`, `project_design_workflow`, `pcb_placement_quality_gate`, etc.).

Regenerated `integrations/common/toolsets.json` via the standard chain — the tool now correctly appears in the **readonly** toolset.

## Verification

- `UPDATE_TOOL_SURFACE_SNAPSHOT=1 pytest tests/integration/test_tool_surface_snapshot.py` — no surface drift (snapshot fields are category-derived, not tier-derived)
- Regen chain: `generate_tools_reference.py` + `build_toolsets.py` + `sync_mcp_metadata.py --write` (only toolsets.json changed; MCP metadata already in sync)
- `pytest tests/unit/test_capabilities.py tests/unit/test_tool_metadata_lint.py tests/unit/test_tool_registry_consistency.py tests/unit/test_toolsets_parity.py tests/integration/test_library_tools_extended.py` — 29 passed
- `scripts/check_tool_contracts.py` — passed
- `ruff format` + `ruff check` — clean