### PR TITLE
docs: document Scorecard exceptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ The docs are ordered from first setup to operations and maintenance.
 - [Security Threat Model](security/threat-model.md)
 - [Release Integrity](security/release-integrity.md)
 - [Release and Supply-Chain Security](security/release-security.md)
+- [Scorecard Exceptions](security/scorecard-exceptions.md)
 - [Workflow Security](workflow-security.md)
 
 ### Submission

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -26,7 +26,7 @@ The immediate target is to make the project pass the OpenSSF Best Practices base
 | Dependency and container scanning | Met | [`scripts/audit_dependencies.py`](https://github.com/oaslananka/kicad-mcp/blob/main/scripts/audit_dependencies.py), Trivy workflow steps, Gitleaks workflow |
 | Release process | Met | [`docs/release-process.md`](release-process.md), release-please workflow, publish workflows |
 | Release integrity | Met | [`docs/security/release-integrity.md`](security/release-integrity.md), SBOM/checksum/attestation release steps |
-| Branch protection policy as code | Met | [`.github/rulesets/main.json`](https://github.com/oaslananka/kicad-mcp/blob/main/.github/rulesets/main.json), [`docs/branch-protection.md`](branch-protection.md) |
+| Branch protection policy as code | Met | [`.github/rulesets/main.json`](https://github.com/oaslananka/kicad-mcp/blob/main/.github/rulesets/main.json), [`docs/branch-protection.md`](branch-protection.md), Scorecard exceptions in [`docs/security/scorecard-exceptions.md`](security/scorecard-exceptions.md) |
 | Branch protection active in GitHub | Met | Repository ruleset `main` is active on `refs/heads/main`; verify with `gh api /repos/oaslananka/kicad-mcp/rulesets` |
 | HTTPS project URLs | Met | GitHub repository, documentation site, package URLs, and badges use HTTPS |
 | English documentation and reports | Met | Repository documentation, issue templates, security policy, and support documents are written in English |

--- a/docs/security/scorecard-exceptions.md
+++ b/docs/security/scorecard-exceptions.md
@@ -1,0 +1,23 @@
+# Scorecard Exceptions and Remediation Plan
+
+This page records OpenSSF Scorecard findings that are not immediate code vulnerabilities and explains the current project policy, accepted risk, and remediation path.
+
+## Current accepted exceptions
+
+| Check | Current status | Rationale | Remediation path |
+| --- | --- | --- | --- |
+| Branch-Protection | Accepted temporary exception | `main` is protected by a GitHub ruleset that blocks deletion and force-pushes, requires pull requests, requires linear history, requires CI/CodeQL/Gitleaks checks, and requires resolved review threads. Required human approval, code-owner review, and last-push approval are intentionally not enabled while the repository has a single trusted maintainer because doing so can block routine maintenance and security fixes. | Enable required approvals, code-owner review, and last-push approval after adding a second trusted maintainer with verified signing and review availability. |
+| Code-Review | Accepted temporary exception | Recent changes are single-maintainer changes. Bot review and automated analysis are not a substitute for independent human review, so Scorecard correctly cannot award full credit yet. | Recruit at least one additional trusted maintainer and require independent human review for protected-branch merges. |
+| Maintained | Accepted time-based exception | The repository is new, and Scorecard intentionally treats projects younger than 90 days as too new to assess long-term maintenance. | Re-run Scorecard after the repository has more than 90 days of public history and weekly maintenance activity. |
+| SAST | Monitoring | CodeQL is configured for Python and JavaScript/TypeScript and runs on pull requests, pushes to `main`, schedules, and manual dispatches. Scorecard currently reports partial credit because recent commit history is still catching up with SAST evidence. | Continue running CodeQL on every protected branch change; the signal should improve as reviewed/merged changes accumulate with CodeQL results. |
+| CII-Best-Practices | Pending external form update | The repository has local evidence for OpenSSF Best Practices, but the public OpenSSF badge remains `InProgress` until the external Best Practices form is completed and submitted. | Complete the OpenSSF Best Practices checklist using `docs/openssf-best-practices.md` evidence links, then re-run Scorecard. |
+
+## Findings remediated in this hardening pass
+
+- CodeQL `js/path-injection` findings were remediated by `SafeFsPath` validation and upload-root containment in the ChatGPT Apps SDK integration.
+- Scorecard `Pinned-Dependencies` findings for the container build were remediated by replacing Dockerfile `pip install` steps with a digest-pinned `uv` image and `uv`-based install steps.
+- Scorecard `Fuzzing` was remediated by adding an Atheris fuzz target and scheduled fuzz workflow.
+
+## Review policy
+
+Accepted Scorecard exceptions must be revisited before each release and after any maintainer or repository-permission change. Do not dismiss a finding without either fixing it or documenting the accepted-risk rationale here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
       - Threat Model: security/threat-model.md
       - Release Integrity: security/release-integrity.md
       - Release and Supply-Chain Security: security/release-security.md
+      - Scorecard Exceptions: security/scorecard-exceptions.md
       - Workflow Security: workflow-security.md
   - Submission:
       - Overview: submission/README.md


### PR DESCRIPTION
Documents the remaining Scorecard signals that require additional maintainers, repository age, or external OpenSSF form completion, and links the exception policy from the documentation site and OpenSSF evidence map.