### PR TITLE
docs: align Silver coverage evidence

### DIFF
--- a/docs/development/testing-policy.md
+++ b/docs/development/testing-policy.md
@@ -20,7 +20,7 @@ Bug fixes should include a regression test when the defect is reproducible in un
 
 ## Coverage policy
 
-The project does not currently claim an 80% statement-coverage guarantee. Coverage should increase over time, but critical tool paths are prioritized over raw percentage targets.
+The Python coverage gate is configured in `pyproject.toml` with `tool.coverage.report.fail_under = 83`, which satisfies the OpenSSF Silver 80% statement-coverage target for the Python package. Coverage should continue to increase over time, but critical tool paths remain prioritized over raw percentage targets.
 
 ## Continuous integration
 

--- a/docs/openssf-silver-evidence.md
+++ b/docs/openssf-silver-evidence.md
@@ -38,7 +38,7 @@ Passing has been achieved for project `13377`. Silver is the next Metal-series t
 | External dependencies | Met | [`docs/development/dependency-management.md`](development/dependency-management.md), lockfiles, dependency audit |
 | Automated integration testing | Met | GitHub Actions CI on pull requests and `main` |
 | Regression testing | Met | [`docs/development/testing-policy.md`](development/testing-policy.md) |
-| Coverage 80% | Unmet with justification | No 80% statement-coverage claim yet; tracked as future quality work |
+| Coverage 80% | Met | Python coverage is configured with `tool.coverage.report.fail_under = 83` in [`pyproject.toml`](https://github.com/oaslananka/kicad-mcp/blob/main/pyproject.toml), and the testing policy documents the 80% Silver target. |
 | Mandatory new functionality tests | Met | [`docs/development/testing-policy.md`](development/testing-policy.md), [`CONTRIBUTING.md`](https://github.com/oaslananka/kicad-mcp/blob/main/CONTRIBUTING.md) |
 | Strict warnings | Met | Ruff, mypy, TypeScript, CodeQL, security jobs, workflow checks |
 | Secure design implementation | Met | [`docs/security/requirements.md`](security/requirements.md), [`docs/security/assurance-case.md`](security/assurance-case.md) |


### PR DESCRIPTION
Updates the Silver evidence and testing policy to reflect the existing Python coverage gate configured with fail_under = 83 in pyproject.toml.