### PR TITLE
docs: show OpenSSF Silver badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   <a href="https://github.com/oaslananka/kicad-mcp/actions/workflows/docs.yml"><img src="https://github.com/oaslananka/kicad-mcp/actions/workflows/docs.yml/badge.svg?branch=main" alt="Docs" /></a>
   <a href="https://github.com/oaslananka/kicad-mcp/actions/workflows/codeql.yml"><img src="https://github.com/oaslananka/kicad-mcp/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL" /></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/oaslananka/kicad-mcp"><img src="https://api.scorecard.dev/projects/github.com/oaslananka/kicad-mcp/badge" alt="OpenSSF Scorecard" /></a>
-  <a href="docs/openssf-best-practices.md"><img src="https://img.shields.io/badge/OpenSSF_best_practices-evidence-blue" alt="OpenSSF Best Practices evidence" /></a>
+  <a href="https://www.bestpractices.dev/projects/13377"><img src="https://www.bestpractices.dev/projects/13377/badge" alt="OpenSSF Best Practices: Silver" /></a>
 </p>
 
 <p>

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -4,7 +4,7 @@ This page maps the repository evidence used for the OpenSSF Best Practices check
 
 ## Current target
 
-The project has a Passing evidence set and now maintains a Silver evidence map. Silver evidence is tracked in [`openssf-silver-evidence.md`](openssf-silver-evidence.md). Baseline Level 1 is a separate OSPS series and is intentionally handled in a separate pass.
+The project has achieved the Silver badge and maintains a Silver evidence map. Silver evidence is tracked in [`openssf-silver-evidence.md`](openssf-silver-evidence.md). Baseline Level 1 is a separate OSPS series and is intentionally handled in a separate pass.
 
 ## Evidence map
 
@@ -28,7 +28,7 @@ The project has a Passing evidence set and now maintains a Silver evidence map. 
 | Release integrity | Met | [`docs/security/release-integrity.md`](security/release-integrity.md), SBOM/checksum/attestation release steps |
 | Branch protection policy as code | Met | [`.github/rulesets/main.json`](https://github.com/oaslananka/kicad-mcp/blob/main/.github/rulesets/main.json), [`docs/branch-protection.md`](branch-protection.md), Scorecard exceptions in [`docs/security/scorecard-exceptions.md`](security/scorecard-exceptions.md) |
 | Branch protection active in GitHub | Met | Repository ruleset `main` is active on `refs/heads/main`; verify with `gh api /repos/oaslananka/kicad-mcp/rulesets` |
-| OpenSSF Silver evidence | In progress | [`docs/openssf-silver-evidence.md`](openssf-silver-evidence.md) |
+| OpenSSF Silver evidence | Met | [`docs/openssf-silver-evidence.md`](openssf-silver-evidence.md), Silver badge for project `13377` |
 | HTTPS project URLs | Met | GitHub repository, documentation site, package URLs, and badges use HTTPS |
 | English documentation and reports | Met | Repository documentation, issue templates, security policy, and support documents are written in English |
 

--- a/docs/openssf-silver-evidence.md
+++ b/docs/openssf-silver-evidence.md
@@ -4,13 +4,13 @@ This page maps OpenSSF Silver criteria to repository evidence. It should be upda
 
 ## Status
 
-Passing has been achieved for project `13377`. Silver is the next Metal-series target. Baseline Level 1 is a separate OSPS series and should be handled in a separate hardening pass.
+Silver has been achieved for OpenSSF Best Practices project `13377`. Baseline Level 1 is a separate OSPS series and should be handled in a separate hardening pass.
 
 ## Evidence map
 
 | Criterion area | Proposed status | Evidence |
 | --- | --- | --- |
-| Achieve Passing | Met | OpenSSF project `13377` passing badge page |
+| Achieve Passing | Met | OpenSSF project `13377` has achieved the Silver badge, which includes Passing as a prerequisite |
 | Contribution requirements | Met | [`CONTRIBUTING.md`](https://github.com/oaslananka/kicad-mcp/blob/main/CONTRIBUTING.md), PR template, coding standards |
 | DCO / contribution authorization | Met | [`CONTRIBUTING.md`](https://github.com/oaslananka/kicad-mcp/blob/main/CONTRIBUTING.md) Developer Certificate of Origin section |
 | Governance | Met | [`GOVERNANCE.md`](https://github.com/oaslananka/kicad-mcp/blob/main/GOVERNANCE.md) |
@@ -58,4 +58,4 @@ Use the Silver edit URL:
 https://www.bestpractices.dev/en/projects/13377/silver/edit
 ```
 
-Do not submit Silver claims until the evidence files above are merged to `main` and the documentation site has published successfully.
+Silver claims have been submitted and accepted for project `13377`. Keep this evidence page current before any Silver resubmission or Gold preparation pass.


### PR DESCRIPTION
Updates the README to show the official OpenSSF Best Practices Silver badge and marks the Silver evidence pages as achieved for project 13377.