### PR TITLE
fix(rules): recognise suffixed/compound supply-rail names

### DIFF
--- a/src/kicad_mcp/utils/schematic_rules.py
+++ b/src/kicad_mcp/utils/schematic_rules.py
@@ -50,6 +50,19 @@ _SUPPLY_TOKENS = (
 
 # e.g. +3V3, 3V3, +5V, 5V, +1V8, +12V, 3.3V
 _VOLTAGE_RAIL_RE = re.compile(r"^\+?\d+(?:[V.]\d+)?V?$", re.IGNORECASE)
+
+# A voltage token embedded in a suffixed/compound rail name: the ``3V3`` in
+# ``3V3_DIG``/``3V3_ANA``, the ``5V`` in ``5V_SYS``/``VBUS_5V``/``VPOE_5V``. The
+# ``V`` is required so plain numeric domain suffixes (``BANK_12``, ``GPIO_5``) are
+# not mistaken for rails.
+_VOLTAGE_TOKEN_RE = re.compile(r"^\d+V\d*$", re.IGNORECASE)
+
+
+def _has_voltage_token(token: str) -> bool:
+    """Whether any ``_``/``-`` delimited part of ``token`` encodes a voltage."""
+    return any(_VOLTAGE_TOKEN_RE.match(part) for part in re.split(r"[_-]", token) if part)
+
+
 _I2C_TOKEN_RE = re.compile(r"(?:^|[^A-Z])(SDA|SCL)(?:[^A-Z]|\d|$)")
 
 
@@ -111,6 +124,8 @@ def is_supply_rail_name(name: str) -> bool:
         return True
     if any(supply in token for supply in _SUPPLY_TOKENS):
         return True
+    if _has_voltage_token(token):
+        return True
     return bool(_VOLTAGE_RAIL_RE.match(token)) and token not in {"0V"}
 
 
@@ -125,7 +140,15 @@ def rail_voltage(name: str) -> float | None:
     rails without an explicit number (``VCC``, ``VDD``, ``VBUS``) return ``None``
     so they are never compared by value.
     """
-    match = _RAIL_VOLTAGE_RE.match(name.strip().upper())
+    token = name.strip().upper()
+    match = _RAIL_VOLTAGE_RE.match(token)
+    if match is None:
+        # Suffixed/compound names (3V3_DIG, 5V_SYS, VBUS_5V): parse the embedded
+        # voltage token so value-conflict checks still apply.
+        for part in re.split(r"[_-]", token):
+            if _VOLTAGE_TOKEN_RE.match(part):
+                match = _RAIL_VOLTAGE_RE.match(part)
+                break
     if match is None:
         return None
     whole, frac = match.group(1), match.group(2)

--- a/tests/unit/test_schematic_rules.py
+++ b/tests/unit/test_schematic_rules.py
@@ -42,6 +42,26 @@ def test_supply_rail_classification() -> None:
         assert not is_supply_rail_name(name), name
 
 
+def test_supply_rail_classification_suffixed_and_compound_names() -> None:
+    # Common project naming with a domain suffix or an embedded voltage token
+    # (e.g. SismoSmart's rails) must still read as supply rails.
+    for name in ["3V3_DIG", "3V3_ANA", "5V_SYS", "VBUS_5V", "VPOE_5V", "3V3-DIG"]:
+        assert is_supply_rail_name(name), name
+    # A plain numeric domain suffix is not a rail (no V token).
+    for name in ["GPIO_5", "BANK_12", "SPI_SCLK", "CS_ADXL", "DATA0"]:
+        assert not is_supply_rail_name(name), name
+
+
+def test_rail_voltage_parses_embedded_voltage_token() -> None:
+    assert rail_voltage("3V3_DIG") == 3.3
+    assert rail_voltage("3V3_ANA") == 3.3
+    assert rail_voltage("5V_SYS") == 5.0
+    assert rail_voltage("VBUS_5V") == 5.0
+    assert rail_voltage("VPOE_5V") == 5.0
+    assert rail_voltage("VBAT") is None  # named rail, no explicit voltage
+    assert rail_voltage("GPIO_5") is None
+
+
 def test_ground_and_i2c_classification() -> None:
     assert is_ground_name("GND") and is_ground_name("agnd")
     assert is_i2c_name("SDA") and is_i2c_name("I2C_SCL") and is_i2c_name("SENSOR_SDA")


### PR DESCRIPTION
The design-rule critic recognised `+3V3`/`3V3`/`VBUS` but missed common project rail names with a domain suffix or embedded voltage token (`3V3_DIG`, `3V3_ANA`, `5V_SYS`, `VPOE_5V`), so power-rail decoupling and rail-conflict checks silently skipped those rails. Surfaced by running the critic against a real hierarchical design whose rails are named per digital/analog/system domain.

Recognise a voltage token in any `_`/`-` delimited part of the name — the `V` is required so plain numeric suffixes (`GPIO_5`, `BANK_12`) are not mistaken for rails — and parse the embedded voltage so value-conflict checks apply. Tests cover both the new positives and the non-rail negatives.