### PR TITLE
fix(container): drop uv from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ COPY docker-entrypoint.sh /usr/local/bin/kicad-mcp-pro-entrypoint
 RUN uv pip install --system --no-cache --require-hashes --requirement /tmp/dist/requirements.txt \
   && uv pip install --system --no-cache --no-deps /tmp/dist/*.whl \
   && rm -rf /tmp/dist \
+  && rm -f /usr/local/bin/uv \
   && chmod 0755 /usr/local/bin/kicad-mcp-pro-entrypoint
 USER kicadmcp
 EXPOSE 3334


### PR DESCRIPTION
## Summary

Remove the build-time uv binary from the final runtime container image after dependencies and the first-party wheel are installed.

## Why

The v3.17.0 container publish failed at Trivy because the final image retained /usr/local/bin/uv, whose embedded Rust dependencies reported HIGH vulnerabilities. The runtime does not need uv after installation.

## Validation

- corepack pnpm run docker:metadata:check
- git diff --check