### PR TITLE
fix: unblock release readiness checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         run: uv run properdocs build -f mkdocs.yml --strict
 
       - name: Publish static site to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -91,6 +91,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Download all Tauri bundles
         env:

--- a/.github/workflows/publish-mcp-container.yml
+++ b/.github/workflows/publish-mcp-container.yml
@@ -148,4 +148,5 @@ jobs:
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign --yes "${GHCR_IMAGE}@${{ steps.build-push.outputs.digest }}"
+          IMAGE_DIGEST: ${{ steps.build-push.outputs.digest }}
+        run: cosign sign --yes "${GHCR_IMAGE}@${IMAGE_DIGEST}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -93,10 +93,11 @@ jobs:
           else
             echo "already_published=false" >> "$GITHUB_OUTPUT"
           fi
-      - run: npm publish "${{ steps.npm-evidence.outputs.tarball }}" --access public --provenance
+      - run: npm publish "${NPM_TARBALL}" --access public --provenance
         if: steps.check-published.outputs.already_published != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TARBALL: ${{ steps.npm-evidence.outputs.tarball }}
       - name: Verify npm published tarball digest
         shell: bash
         run: |

--- a/.github/workflows/publish-protocol-schemas.yml
+++ b/.github/workflows/publish-protocol-schemas.yml
@@ -97,9 +97,10 @@ jobs:
           fi
       - name: Publish to npm
         if: steps.check-published.outputs.already_published != 'true'
-        run: npm publish "${{ steps.pack-evidence.outputs.tarball }}" --access public --provenance --ignore-scripts
+        run: npm publish "${NPM_TARBALL}" --access public --provenance --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TARBALL: ${{ steps.pack-evidence.outputs.tarball }}
       - name: Verify published tarball
         shell: bash
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,17 +42,24 @@ jobs:
         with:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - if: ${{ steps.release.outputs.pr }}
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: false
       - if: ${{ steps.release.outputs.pr }}
         name: Sync version-derived MCP metadata onto the release PR
+        env:
+          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           uv run --all-extras python scripts/sync_mcp_metadata.py --write
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git commit -am "chore: sync version-derived MCP metadata"
-            git push
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+            export GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${RELEASE_PUSH_TOKEN}"
+            git push origin "HEAD:${RELEASE_PR_BRANCH}"
           fi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 repository-code: "https://github.com/oaslananka/kicad-mcp"
 url: "https://oaslananka.github.io/kicad-mcp"
 license: MIT
-version: "3.16.0"
-date-released: "2026-07-01"
+version: "3.17.1"
+date-released: "2026-07-03"
 keywords:
   - KiCad
   - EDA

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The documentation is organized from setup to operation:
 10. [Work-order audit](docs/status/work-order-audit-2026-06-17.md) — current status of the hardening work order
 
 The `kicad_capability_parity()` tool reports, per workflow domain, what fraction of
-KiCad's programmatically reachable surface this server can drive (currently **75.0%**),
+KiCad's programmatically reachable surface this server can drive (currently **76.3%**),
 keeping genuine `gap`s distinct from `gui-only-no-api` items that KiCad exposes no
 headless API for.
 

--- a/scripts/run_pytest.py
+++ b/scripts/run_pytest.py
@@ -18,6 +18,8 @@ SUITES = {
         "tests/integration/",
         "tests/e2e/",
         "-q",
+        "-m",
+        "not benchmark",
         "--cov=kicad_mcp",
         "--cov-report=term-missing",
         "--cov-report=xml",

--- a/tests/integration/data/tool_surface_snapshot.json
+++ b/tests/integration/data/tool_surface_snapshot.json
@@ -2449,6 +2449,27 @@
   {
     "destructive": true,
     "experimental": false,
+    "headless": true,
+    "idempotent": false,
+    "name": "pcb_add_bitmap_board_art",
+    "open_world": false,
+    "profiles": [
+      "agent_full",
+      "builder",
+      "expert",
+      "full",
+      "high_speed",
+      "pcb",
+      "pcb_layout",
+      "pcb_only",
+      "power"
+    ],
+    "read_only": false,
+    "requires_kicad_running": false
+  },
+  {
+    "destructive": true,
+    "experimental": false,
     "headless": false,
     "idempotent": false,
     "name": "pcb_add_blind_via",
@@ -6898,6 +6919,24 @@
       "high_speed"
     ],
     "read_only": false,
+    "requires_kicad_running": false
+  },
+  {
+    "destructive": false,
+    "experimental": false,
+    "headless": false,
+    "idempotent": true,
+    "name": "si_get_solver_capabilities",
+    "open_world": false,
+    "profiles": [
+      "agent_full",
+      "analysis",
+      "critic",
+      "expert",
+      "full",
+      "high_speed"
+    ],
+    "read_only": true,
     "requires_kicad_running": false
   },
   {


### PR DESCRIPTION
## Summary
- unblock release readiness by syncing citation/parity/tool-surface metadata
- keep full pytest release gate deterministic by excluding benchmark-marked tests from the full coverage suite
- pin docs publish action to an immutable SHA
- harden workflow credential persistence and publish/sign command interpolation

## Validation
- `corepack pnpm run test` → pass, coverage 85.55% >= 83%
- `uv run --all-extras python scripts/run_pytest.py benchmark` → pass
- `corepack pnpm run package:check` → pass
- `corepack pnpm run release:check` → pass
- `corepack pnpm run submission:check` → pass
- `corepack pnpm run check:workflows` → pass, zizmor no findings
- `corepack pnpm run format:check` → pass
- `corepack pnpm run lint` → pass
- `uv run --all-extras python -m mypy src/kicad_mcp/` → pass
- `uv run --all-extras python scripts/audit_dependencies.py` → pass
- `uv run --all-extras python -m bandit -r src/ -ll -s B104` → pass
- `uv run --all-extras python scripts/build_parity_matrix.py --check-regression` → pass, 76.3% >= baseline
- `uv run --all-extras python -m pytest tests/integration/test_schematic_netlist_smoke.py -q` → pass
- `uv run --all-extras python -m pytest tests/integration/test_tool_surface_snapshot.py -q` → pass

## Notes
- Local VPS environment was also fixed to make KiCad smoke tests reproducible: `uv`, `uvx`, KiCad CLI HOME wrapper, and `kicad-symbols` are now available on ops-vps-03.
