### PR TITLE
ci: query release PR with explicit repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,8 +41,9 @@ jobs:
         id: release-pr-branch
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          REPOSITORY_NAME: ${{ github.repository }}
         run: |
-          branch="$(gh pr list --state open --head release-please--branches--main --json headRefName --jq '.[0].headRefName // ""')"
+          branch="$(gh pr list --repo "${REPOSITORY_NAME}" --state open --head release-please--branches--main --json headRefName --jq '.[0].headRefName // ""')"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
       - if: ${{ steps.release-pr-branch.outputs.branch != '' }}


### PR DESCRIPTION
## Summary
- pass `--repo` to `gh pr list` in release-please branch detection
- avoid requiring a local checkout before detecting the release PR branch

## Validation
- `corepack pnpm run check:workflows` → pass, zizmor no findings
