### PR TITLE
fix: guard schematic writes against structural loss

### DIFF
--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -23,6 +23,7 @@ from mcp.types import CallToolResult
 from ..config import get_config
 from ..connection import KiCadConnectionError, get_kicad
 from ..discovery import is_numbered_duplicate_kicad_file
+from ..errors import SchematicWriteUnsafeError
 from ..mcp_media import image_tool_result, text_tool_result
 from ..models.schematic import (
     AddBusInput,
@@ -52,6 +53,7 @@ from ..utils.cache import clear_ttl_cache, ttl_cache
 from ..utils.field_placer import FieldSpec, autoplace_fields
 from ..utils.geometry import Box as GeoBox
 from ..utils.geometry import body_box_from_pins, text_extent
+from ..utils.schematic_roundtrip import dropped_nodes
 from ..utils.schematic_router import RouterBBox, SchematicRouter
 from ..utils.sexpr import (
     _escape_sexpr_string,
@@ -4469,6 +4471,36 @@ def _validate_schematic_text(content: str) -> None:
         )
 
 
+def _guard_schematic_structural_loss(
+    sch_file: Path,
+    before: str,
+    after: str,
+    *,
+    allow_node_loss: bool = False,
+) -> None:
+    """Refuse accidental structural loss before committing a schematic write.
+
+    Most file-backed schematic tools still apply deterministic text mutations rather
+    than a fully lossless kicad-sch-api serializer.  The same round-trip safety
+    invariant still applies: a mutator may add or move structure, but it must not
+    silently drop fragile constructs such as global labels, hierarchical labels,
+    buses, sheets, power symbols, or wires.  Intentional delete/replace workflows
+    must opt in with ``allow_node_loss=True`` so destructive behavior is explicit at
+    the call site.
+    """
+    if allow_node_loss or before == after:
+        return
+    lost = dropped_nodes(before, after)
+    if not lost:
+        return
+    detail = ", ".join(f"{kind} {b}->{a}" for kind, (b, a) in sorted(lost.items()))
+    raise SchematicWriteUnsafeError(
+        f"Refusing to write {sch_file.name}: the schematic mutation dropped structure "
+        f"({detail}). The original file was preserved; use an explicit destructive "
+        "path only for intentional delete/replace operations."
+    )
+
+
 def _find_placed_symbol_blocks(
     content: str,
     reference: str,
@@ -4544,7 +4576,12 @@ def _next_reference(prefix: str) -> str:
     return f"{prefix}{highest + 1}"
 
 
-def _transactional_write_to_schematic_file(sch_file: Path, mutator: Callable[[str], str]) -> str:
+def _transactional_write_to_schematic_file(
+    sch_file: Path,
+    mutator: Callable[[str], str],
+    *,
+    allow_node_loss: bool = False,
+) -> str:
     """Read, mutate, validate, and atomically rewrite a schematic file.
 
     File-backed schematic tools are often invoked in batches.  Keep the full
@@ -4556,6 +4593,9 @@ def _transactional_write_to_schematic_file(sch_file: Path, mutator: Callable[[st
         current = sch_file.read_text(encoding="utf-8")
         updated = _normalize_schematic_wire_connectivity(mutator(current))
         _validate_schematic_text(updated)
+        _guard_schematic_structural_loss(
+            sch_file, current, updated, allow_node_loss=allow_node_loss
+        )
         with NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=sch_file.parent) as handle:
             handle.write(updated)
             temp_path = Path(handle.name)
@@ -4573,15 +4613,30 @@ def _transactional_write_to_schematic_file(sch_file: Path, mutator: Callable[[st
         return str(sch_file)
 
 
-def _transactional_write_to_schematic(mutator: Callable[[str], str]) -> str:
+def _transactional_write_to_schematic(
+    mutator: Callable[[str], str],
+    *,
+    allow_node_loss: bool = False,
+) -> str:
     """Read, mutate, validate, and atomically rewrite the active schematic."""
-    return _transactional_write_to_schematic_file(_get_schematic_file(), mutator)
+    return _transactional_write_to_schematic_file(
+        _get_schematic_file(), mutator, allow_node_loss=allow_node_loss
+    )
 
 
-def transactional_write(mutator: Callable[[str], str], sch_file: Path | None = None) -> str:
+def transactional_write(
+    mutator: Callable[[str], str],
+    sch_file: Path | None = None,
+    *,
+    allow_node_loss: bool = False,
+) -> str:
     """Read, mutate, validate, and atomically rewrite a schematic file."""
     if sch_file is not None:
-        return _transactional_write_to_schematic_file(sch_file, mutator)
+        return _transactional_write_to_schematic_file(
+            sch_file, mutator, allow_node_loss=allow_node_loss
+        )
+    if allow_node_loss:
+        return _transactional_write_to_schematic(mutator, allow_node_loss=True)
     return get_schematic_backend().transactional_write(mutator)
 
 
@@ -6047,7 +6102,7 @@ def register(mcp: FastMCP) -> None:
             return "".join(pieces)
 
         try:
-            transactional_write(mutator)
+            transactional_write(mutator, allow_node_loss=True)
         except ValueError as exc:
             return str(exc)
         return (
@@ -6104,7 +6159,7 @@ def register(mcp: FastMCP) -> None:
             return "".join(pieces)
 
         try:
-            transactional_write(mutator)
+            transactional_write(mutator, allow_node_loss=True)
         except ValueError as exc:
             return str(exc)
 
@@ -6156,7 +6211,7 @@ def register(mcp: FastMCP) -> None:
             return "".join(pieces)
 
         try:
-            transactional_write(mutator)
+            transactional_write(mutator, allow_node_loss=True)
         except ValueError as exc:
             return str(exc)
         return (
@@ -6494,7 +6549,7 @@ def register(mcp: FastMCP) -> None:
         )
         content = _normalize_schematic_wire_connectivity(content)
         _validate_schematic_text(content)
-        transactional_write(lambda _current: content, sch_file)
+        transactional_write(lambda _current: content, sch_file, allow_node_loss=True)
         result = _reload_schematic()
         notes: list[str] = []
         if auto_layout:

--- a/tests/unit/test_schematic_write_integrity.py
+++ b/tests/unit/test_schematic_write_integrity.py
@@ -7,9 +7,16 @@ regex/string mutation that cloned a block instead of minting a fresh UUID.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from kicad_mcp.tools.schematic import _duplicate_uuids, _validate_schematic_text
+from kicad_mcp.errors import SchematicWriteUnsafeError
+from kicad_mcp.tools.schematic import (
+    _duplicate_uuids,
+    _validate_schematic_text,
+    transactional_write,
+)
 
 _CLEAN = (
     '(kicad_sch (uuid "00000000-0000-0000-0000-000000000001")'
@@ -40,3 +47,136 @@ def test_validate_refuses_duplicate_uuids() -> None:
 def test_validate_still_refuses_unbalanced_parens() -> None:
     with pytest.raises(ValueError, match="unbalanced parentheses"):
         _validate_schematic_text('(kicad_sch (uuid "x")')
+
+
+_REFERENCE_PROP = (
+    '    (property "Reference" "#PWR01" (at 10 12 0) '
+    "(effects (font (size 1.27 1.27)) (hide yes)))\n"
+)
+_VALUE_PROP = '    (property "Value" "GND" (at 10 14 0) (effects (font (size 1.27 1.27))))\n'
+_LOCAL_LABEL = (
+    '  (label "LOCAL" (at 20 20 0) (effects (font (size 1.524 1.524))) '
+    '(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc"))\n'
+)
+_GLOBAL_LABEL = (
+    '  (global_label "GLOBAL" (shape input) (at 30 30 0) '
+    "(effects (font (size 1.524 1.524))) "
+    '(uuid "dddddddd-dddd-dddd-dddd-dddddddddddd"))\n'
+)
+_HIER_LABEL = (
+    '  (hierarchical_label "HIER" (shape output) (at 40 40 0) '
+    "(effects (font (size 1.524 1.524))) "
+    '(uuid "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"))\n'
+)
+_SHEETNAME_PROP = (
+    '    (property "Sheetname" "child" (at 70 69.293 0) (effects (font (size 1.27 1.27))))\n'
+)
+_SHEETFILE_PROP = (
+    '    (property "Sheetfile" "child.kicad_sch" (at 70 91.353 0) '
+    "(effects (font (size 1.27 1.27))))\n"
+)
+
+_FRAGILE_SCHEMATIC = "".join(
+    [
+        "(kicad_sch\n",
+        "  (version 20250316)\n",
+        '  (generator "test")\n',
+        '  (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")\n',
+        '  (paper "A4")\n',
+        "  (lib_symbols)\n",
+        "  (symbol\n",
+        '    (lib_id "power:GND")\n',
+        "    (at 10 10 0)\n",
+        "    (unit 1)\n",
+        "    (exclude_from_sim no)\n",
+        "    (in_bom yes)\n",
+        "    (on_board yes)\n",
+        "    (dnp no)\n",
+        '    (uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")\n',
+        _REFERENCE_PROP,
+        _VALUE_PROP,
+        "  )\n",
+        _LOCAL_LABEL,
+        _GLOBAL_LABEL,
+        _HIER_LABEL,
+        "  (bus\n",
+        "    (pts (xy 50 50) (xy 60 50))\n",
+        "    (stroke (width 0) (type solid))\n",
+        '    (uuid "ffffffff-ffff-ffff-ffff-ffffffffffff")\n',
+        "  )\n",
+        "  (bus_entry\n",
+        "    (at 55 50)\n",
+        "    (size 2.54 -2.54)\n",
+        "    (stroke (width 0) (type solid))\n",
+        '    (uuid "11111111-2222-3333-4444-555555555555")\n',
+        "  )\n",
+        "  (sheet\n",
+        "    (at 70 70)\n",
+        "    (size 25 20)\n",
+        "    (fields_autoplaced yes)\n",
+        "    (stroke (width 0.1524) (type solid))\n",
+        "    (fill (color 0 0 0 0.0000))\n",
+        '    (uuid "22222222-3333-4444-5555-666666666666")\n',
+        _SHEETNAME_PROP,
+        _SHEETFILE_PROP,
+        "  )\n",
+        '  (sheet_instances (path "/" (page "1")))\n',
+        "  (embedded_fonts no)\n",
+        ")\n",
+    ]
+)
+
+
+def _write_schematic(tmp_path: Path) -> Path:
+    path = tmp_path / "fragile.kicad_sch"
+    path.write_text(_FRAGILE_SCHEMATIC, encoding="utf-8")
+    return path
+
+
+def test_transactional_write_preserves_fragile_constructs_on_additive_edit(tmp_path: Path) -> None:
+    path = _write_schematic(tmp_path)
+    original = path.read_text(encoding="utf-8")
+
+    def add_wire(text: str) -> str:
+        block = (
+            "  (wire\n"
+            "    (pts (xy 1 1) (xy 2 2))\n"
+            "    (stroke (width 0) (type solid))\n"
+            '    (uuid "33333333-4444-5555-6666-777777777777")\n'
+            "  )\n"
+        )
+        return text.replace("  (sheet_instances", block + "  (sheet_instances", 1)
+
+    transactional_write(add_wire, path)
+    updated = path.read_text(encoding="utf-8")
+    for marker in ("GLOBAL", "HIER", "power:GND", "(bus", "(bus_entry", "Sheetname"):
+        assert marker in updated
+    assert updated.count("(wire") == original.count("(wire") + 1
+
+
+def test_transactional_write_refuses_unintentional_structural_loss_and_preserves_original(
+    tmp_path: Path,
+) -> None:
+    path = _write_schematic(tmp_path)
+    original = path.read_text(encoding="utf-8")
+
+    def accidentally_drop_global_label(text: str) -> str:
+        return text.replace(_GLOBAL_LABEL, "", 1)
+
+    with pytest.raises(SchematicWriteUnsafeError, match="global_label"):
+        transactional_write(accidentally_drop_global_label, path)
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_transactional_write_requires_explicit_opt_in_for_destructive_edits(tmp_path: Path) -> None:
+    path = _write_schematic(tmp_path)
+
+    def delete_local_label(text: str) -> str:
+        return text.replace(_LOCAL_LABEL, "", 1)
+
+    with pytest.raises(SchematicWriteUnsafeError, match="label"):
+        transactional_write(delete_local_label, path)
+
+    transactional_write(delete_local_label, path, allow_node_loss=True)
+    assert "LOCAL" not in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a structural-loss guard to schematic transactional writes
- refuse accidental drops of fragile schematic constructs before committing file changes
- require `allow_node_loss=True` for intentional destructive schematic operations
- cover global labels, hierarchical labels, buses, bus entries, sheets, and power symbols in write-integrity tests

Closes #273.

## Validation
- `corepack pnpm run format:check` → pass
- `corepack pnpm run lint` → pass
- `uv run --all-extras python -m mypy src/kicad_mcp/` → pass
- `corepack pnpm run test:unit` → pass
- `corepack pnpm run docs:tools:check` → pass
- `corepack pnpm run tool-contracts:check` → pass
- `uv run --all-extras python -m pytest tests/integration/test_roundtrip_fidelity.py tests/integration/test_schematic_tools.py tests/integration/test_schematic_extended.py tests/integration/test_schematic_netlist_smoke.py -q` → pass
- `corepack pnpm run test` → pass, coverage 85.56% >= 83%
