### PR TITLE
feat: standardize structured verdict payloads

### DIFF
--- a/src/kicad_mcp/models/__init__.py
+++ b/src/kicad_mcp/models/__init__.py
@@ -37,7 +37,7 @@ from .state import (
     WorkspaceState,
 )
 from .tool_result import ArtifactRef, StateDelta, ToolResult
-from .verdict import Finding, SuggestedFix, Verdict, VerdictReport, stable_finding_id
+from .verdict import FailureMode, Finding, SuggestedFix, Verdict, VerdictReport, stable_finding_id
 
 __all__ = [
     "ACAnalysisInput",
@@ -59,6 +59,7 @@ __all__ = [
     "DifferentialPairSkewInput",
     "ExportBOMInput",
     "ExportGerberInput",
+    "FailureMode",
     "Finding",
     "ImpedanceForTraceInput",
     "LayerViaInput",

--- a/src/kicad_mcp/models/verdict.py
+++ b/src/kicad_mcp/models/verdict.py
@@ -2,9 +2,10 @@
 
 A ``VerdictReport`` carries both a human-readable ``text`` block (kept for clients that
 only read text) and structured fields an agent can act on without parsing English:
-a PASS/WARN/FAIL ``verdict``, a list of ``findings`` with stable, diffable IDs and an
-optional ``suggested_fix``, and a ``next_action``. FastMCP returns the model as MCP
-structured content alongside the JSON text, so both surfaces stay in sync.
+a PASS/WARN/FAIL ``verdict``, a list of ``findings`` with stable, diffable IDs,
+evidence, remediation, retryability, and an optional ``suggested_fix``. FastMCP
+returns the model as MCP structured content alongside the JSON text, so both surfaces
+stay in sync.
 """
 
 from __future__ import annotations
@@ -12,9 +13,10 @@ from __future__ import annotations
 import hashlib
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 Verdict = Literal["PASS", "WARN", "FAIL"]
+FailureMode = Literal["none", "design", "environment", "configuration", "manual_review"]
 
 _FAIL_SEVERITIES = frozenset({"error", "fail", "failed", "critical"})
 _WARN_SEVERITIES = frozenset({"warning", "warn", "marginal"})
@@ -41,7 +43,7 @@ class SuggestedFix(BaseModel):
 
 
 class Finding(BaseModel):
-    """A single structured finding with a stable id."""
+    """A single structured finding with a stable id and agent-actionable context."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -49,23 +51,52 @@ class Finding(BaseModel):
     severity: str = "error"
     location: str = ""
     description: str = ""
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+    remediation: str = ""
+    retryable: bool = False
+    failure_mode: FailureMode = "design"
     suggested_fix: SuggestedFix | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class VerdictReport(BaseModel):
-    """Verdict triplet returned by high-traffic gate/check tools."""
+    """Stable verdict envelope returned by quality gates and critic tools.
+
+    ``retryable`` is intentionally about retrying the same tool call without changing
+    the design. Environment/configuration failures may be retryable after setup; design
+    failures are non-transient and require remediation first.
+    """
 
     model_config = ConfigDict(frozen=False)
 
+    schema_version: str = "verdict.v1"
     # Human-readable rendering, preserved alongside the structured fields so text-only
     # clients keep working. FastMCP serializes the whole model to JSON text content.
     text: str = ""
     summary: str = ""
     verdict: Verdict = "PASS"
+    severity: str = "info"
+    failure_mode: FailureMode = "none"
+    retryable: bool = False
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+    remediation: str = ""
     findings: list[Finding] = Field(default_factory=list)
     next_action: str = ""
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _normalize_envelope(self) -> VerdictReport:
+        if self.severity == "info" and self.verdict != "PASS":
+            self.severity = self.severity_for(self.verdict)
+        if self.failure_mode == "none" and self.verdict != "PASS":
+            self.failure_mode = self.failure_mode_for(self.verdict, self.retryable)
+        if not self.evidence and self.findings:
+            self.evidence = [item for finding in self.findings for item in finding.evidence]
+        if not self.remediation and self.findings:
+            remediations = [finding.remediation for finding in self.findings if finding.remediation]
+            if remediations:
+                self.remediation = remediations[0]
+        return self
 
     @staticmethod
     def verdict_for(severities: list[str]) -> Verdict:
@@ -76,3 +107,58 @@ class VerdictReport(BaseModel):
         if lowered & _WARN_SEVERITIES:
             return "WARN"
         return "PASS"
+
+    @staticmethod
+    def severity_for(verdict: Verdict) -> str:
+        """Return the default machine severity for a PASS/WARN/FAIL verdict."""
+        return {"PASS": "info", "WARN": "warning", "FAIL": "error"}[verdict]
+
+    @staticmethod
+    def failure_mode_for(verdict: Verdict, retryable: bool = False) -> FailureMode:
+        """Return a conservative failure mode when a caller has no richer signal."""
+        if verdict == "PASS":
+            return "none"
+        return "environment" if retryable else "design"
+
+    @classmethod
+    def from_text_verdict(
+        cls,
+        *,
+        text: str,
+        summary: str,
+        verdict: Verdict,
+        source: str,
+        evidence: list[dict[str, Any]] | None = None,
+        remediation: str = "",
+        next_action: str = "",
+        retryable: bool = False,
+        failure_mode: FailureMode | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> VerdictReport:
+        """Wrap a legacy text critic result in the standard verdict envelope."""
+        resolved_failure_mode = failure_mode or cls.failure_mode_for(verdict, retryable)
+        finding: Finding | None = None
+        if verdict != "PASS":
+            finding = Finding(
+                id=stable_finding_id(source, verdict, summary),
+                severity=cls.severity_for(verdict),
+                location=source,
+                description=summary,
+                evidence=evidence or [],
+                remediation=remediation,
+                retryable=retryable,
+                failure_mode=resolved_failure_mode,
+            )
+        return cls(
+            text=text,
+            summary=summary,
+            verdict=verdict,
+            severity=cls.severity_for(verdict),
+            failure_mode=resolved_failure_mode,
+            retryable=retryable,
+            evidence=evidence or [],
+            remediation=remediation,
+            findings=[] if finding is None else [finding],
+            next_action=next_action or remediation,
+            metadata=metadata or {"source": source},
+        )

--- a/src/kicad_mcp/tools/dfm.py
+++ b/src/kicad_mcp/tools/dfm.py
@@ -14,6 +14,7 @@ from kipy.proto.board.board_types_pb2 import BoardLayer
 from mcp.server.fastmcp import FastMCP
 
 from ..connection import KiCadConnectionError, get_board
+from ..models.verdict import Verdict, VerdictReport
 from ..utils.sexpr import _extract_block
 from ..utils.units import nm_to_mm
 from .export_support import _ensure_output_dir, _get_pcb_file, _run_cli_variants
@@ -210,6 +211,35 @@ def _format_status(status: str, message: str) -> str:
     return f"- {status}: {message}"
 
 
+def _status_lines_verdict(lines: list[str]) -> Verdict:
+    if any(line.startswith("- FAIL:") for line in lines):
+        return "FAIL"
+    if any(line.startswith("- WARN:") for line in lines):
+        return "WARN"
+    return "PASS"
+
+
+def _dfm_verdict_report(lines: list[str]) -> VerdictReport:
+    verdict = _status_lines_verdict(lines)
+    text = "\n".join(lines)
+    return VerdictReport.from_text_verdict(
+        text=text,
+        summary="DFM profile check passed."
+        if verdict == "PASS"
+        else "DFM profile check has actionable manufacturing findings.",
+        verdict=verdict,
+        source="dfm_run_manufacturer_check",
+        evidence=[{"lines": lines}],
+        remediation="Resolve FAIL/WARN DFM profile lines, then rerun dfm_run_manufacturer_check()."
+        if verdict != "PASS"
+        else "",
+        next_action="Resolve DFM profile findings before manufacturing handoff."
+        if verdict != "PASS"
+        else "Proceed to manufacturing_quality_gate().",
+        metadata={"profile_check": True},
+    )
+
+
 def _dfm_check_lines(
     profile: dict[str, Any],
     *,
@@ -394,10 +424,10 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool()
     @headless_compatible
-    def dfm_run_manufacturer_check() -> str:
+    def dfm_run_manufacturer_check() -> VerdictReport:
         """Run a manufacturer-aware DFM review using the active bundled profile."""
         profile = _selected_profile()
-        return "\n".join(_dfm_check_lines(profile))
+        return _dfm_verdict_report(_dfm_check_lines(profile))
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/emc_compliance.py
+++ b/src/kicad_mcp/tools/emc_compliance.py
@@ -18,6 +18,7 @@ from mcp.server.fastmcp import FastMCP
 from ..config import get_config
 from ..connection import get_board
 from ..models.common import _FootprintLike
+from ..models.verdict import Verdict, VerdictReport
 from ..utils.impedance import propagation_delay_ps_per_mm
 from ..utils.layers import resolve_layer
 from ..utils.solver_seams import emc_method, format_solver_verdict
@@ -77,6 +78,25 @@ def _zone_net_name(zone: _ZoneLike) -> str:
 def _is_ground_like_net(net_name: str) -> bool:
     normalized = net_name.strip().upper()
     return normalized in {"GND", "AGND", "DGND", "PGND", "GROUND"} or normalized.startswith("GND_")
+
+
+def _emc_verdict_report(title: str, source: str, verdict: str, detail: str) -> VerdictReport:
+    resolved_verdict = cast(Verdict, verdict)
+    text = f"{title} ({resolved_verdict}):\n- {detail}"
+    return VerdictReport.from_text_verdict(
+        text=text,
+        summary=detail,
+        verdict=resolved_verdict,
+        source=source,
+        evidence=[{"check": source, "detail": detail}],
+        remediation=(
+            "Review layout EMC geometry, apply the recommended correction, and rerun this check."
+        )
+        if verdict != "PASS"
+        else "",
+        next_action="Treat this result as an EMC critic, not formal compliance sign-off.",
+        metadata={"domain": "emc", "check": source},
+    )
 
 
 def _footprint_reference(footprint: _FootprintLike) -> str:
@@ -427,64 +447,99 @@ def register(mcp: FastMCP) -> None:
     """Register EMC-oriented review tools."""
 
     @mcp.tool()
-    def emc_check_ground_plane_voids(max_void_area_mm2: float = 25.0) -> str:
+    def emc_check_ground_plane_voids(max_void_area_mm2: float = 25.0) -> VerdictReport:
         """Review GND plane presence and a simple void-risk proxy."""
         verdict, detail = _emc_check_ground_plane_voids_text(max_void_area_mm2)
-        return f"Ground plane void review ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "Ground plane void review",
+            "emc_check_ground_plane_voids",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
     def emc_check_return_path_continuity(
         signal_net: str = "",
         reference_plane_layer: str = "auto",
         search_radius_mm: float = 2.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Check EMC return-path continuity for a signal or all critical high-speed nets."""
         verdict, detail = _emc_check_return_path_text(
             signal_net,
             reference_plane_layer,
             search_radius_mm,
         )
-        return f"Return path continuity ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "Return path continuity",
+            "emc_check_return_path_continuity",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
-    def emc_check_split_plane_crossing(signal_nets: list[str]) -> str:
+    def emc_check_split_plane_crossing(signal_nets: list[str]) -> VerdictReport:
         """Warn when routed signals share layers with split non-ground planes."""
         verdict, detail = _emc_check_split_plane_text(signal_nets)
-        return f"Split-plane crossing review ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "Split-plane crossing review",
+            "emc_check_split_plane_crossing",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
-    def emc_check_decoupling_placement(max_distance_mm: float = 3.0) -> str:
+    def emc_check_decoupling_placement(max_distance_mm: float = 3.0) -> VerdictReport:
         """Review whether ICs have nearby decoupling capacitors."""
         verdict, detail = _emc_check_decoupling_text(max_distance_mm)
-        return f"Decoupling placement review ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "Decoupling placement review",
+            "emc_check_decoupling_placement",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
-    def emc_check_via_stitching(max_gap_mm: float = 5.0, ground_net: str = "GND") -> str:
+    def emc_check_via_stitching(max_gap_mm: float = 5.0, ground_net: str = "GND") -> VerdictReport:
         """Estimate via-stitching density from existing ground vias."""
         verdict, detail = _emc_check_via_stitching_text(max_gap_mm, ground_net)
-        return f"Via stitching review ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "Via stitching review",
+            "emc_check_via_stitching",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
     def emc_check_differential_pair_symmetry(
         net_p: str,
         net_n: str,
         max_skew_ps: float = 10.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Review diff-pair skew and width symmetry."""
         verdict, detail = _emc_check_diff_pair_text(net_p, net_n, max_skew_ps)
-        return f"Differential-pair symmetry ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "Differential-pair symmetry",
+            "emc_check_differential_pair_symmetry",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
     def emc_check_high_speed_routing_rules(
         net_class: str,
         max_stub_length_mm: float = 1.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Review a high-speed net class for a short-stub proxy."""
         verdict, detail = _emc_check_high_speed_rules_text(net_class, max_stub_length_mm)
-        return f"High-speed routing rule review ({verdict}):\n- {detail}"
+        return _emc_verdict_report(
+            "High-speed routing rule review",
+            "emc_check_high_speed_routing_rules",
+            verdict,
+            detail,
+        )
 
     @mcp.tool()
-    def emc_run_full_compliance(standard: str = "FCC") -> str:
+    def emc_run_full_compliance(standard: str = "FCC") -> VerdictReport:
         """Run a lightweight EMC sweep with at least ten heuristic checks."""
         diff_pair = _find_diff_pair()
         signal_net = next(iter(_high_speed_nets()), "")
@@ -531,4 +586,27 @@ def register(mcp: FastMCP) -> None:
         )
         lines.append(f"- {format_solver_verdict(method)}")
         lines.append(f"- Note: {method['note']} Treat results as a critic, not a release sign-off.")
-        return "\n".join(lines)
+        overall: Verdict = "PASS"
+        if any(verdict == "FAIL" for _, verdict, _ in checks):
+            overall = "FAIL"
+        elif any(verdict == "WARN" for _, verdict, _ in checks):
+            overall = "WARN"
+        return VerdictReport.from_text_verdict(
+            text="\n".join(lines),
+            summary=f"EMC compliance sweep completed with {overall} verdict.",
+            verdict=overall,
+            source="emc_run_full_compliance",
+            evidence=[
+                {"check": name, "verdict": verdict, "detail": detail}
+                for name, verdict, detail in checks
+            ],
+            remediation=(
+                "Review WARN/FAIL EMC checks and rerun the sweep." if overall != "PASS" else ""
+            ),
+            next_action="Treat results as a critic, not formal compliance sign-off.",
+            metadata={
+                "domain": "emc",
+                "standard": standard.upper(),
+                "checks_run": len(checks),
+            },
+        )

--- a/src/kicad_mcp/tools/power_integrity.py
+++ b/src/kicad_mcp/tools/power_integrity.py
@@ -28,6 +28,7 @@ from ..models.power_integrity import (
     ThermalViaInput,
     VoltageDropInput,
 )
+from ..models.verdict import Verdict, VerdictReport
 from ..utils.impedance import copper_thickness_mm, recommended_decoupling_distance_mm
 from ..utils.layers import resolve_layer
 from ..utils.pdn_mesh import (
@@ -308,7 +309,7 @@ def register(mcp: FastMCP) -> None:
         target_impedance_ohm: float | None = None,
         decoupling_esr_mohm: float = 20.0,
         decoupling_esl_nh: float = 1.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Run a lightweight PDN mesh voltage-drop check for a power net."""
         loads = [
             PdnLoad(
@@ -355,7 +356,32 @@ def register(mcp: FastMCP) -> None:
         mesh_method = pdn_mesh_method()
         lines.append(f"- Method: {mesh_method['method']} — {mesh_method['accuracy']}")
         lines.append(f"- {format_solver_verdict(mesh_method)}")
-        return "\n".join(lines)
+        verdict: Verdict = "FAIL" if result.violations or result.impedance_violations else "PASS"
+        return VerdictReport.from_text_verdict(
+            text="\n".join(lines),
+            summary=(
+                f"PDN mesh check completed for {net_name} with "
+                f"{len(result.violations) + len(result.impedance_violations)} violation(s)."
+            ),
+            verdict=verdict,
+            source="check_power_integrity",
+            evidence=[
+                {
+                    "net_name": net_name,
+                    "source_ref": source_ref,
+                    "load_refs": load_refs,
+                    "max_drop_mv": result.max_drop_mv,
+                    "violations": result.violations,
+                    "impedance_violations": result.impedance_violations,
+                }
+            ],
+            remediation=(
+                "Widen copper, shorten paths, add decoupling, then rerun check_power_integrity()."
+            )
+            if verdict != "PASS"
+            else "",
+            metadata={"domain": "power_integrity"},
+        )
 
     @mcp.tool()
     def pdn_recommend_decoupling_caps(
@@ -403,7 +429,7 @@ def register(mcp: FastMCP) -> None:
         expected_current_a: float,
         ambient_temp_c: float = 25.0,
         max_temp_rise_c: float = 10.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Check whether the routed copper for a net looks sufficient for the load current."""
         payload = CopperWeightCheckInput(
             net_name=net_name,
@@ -413,7 +439,17 @@ def register(mcp: FastMCP) -> None:
         )
         tracks = _matching_tracks(payload.net_name)
         if not tracks:
-            return f"No routed tracks were found for net '{payload.net_name}'."
+            message = f"No routed tracks were found for net '{payload.net_name}'."
+            return VerdictReport.from_text_verdict(
+                text=message,
+                summary=message,
+                verdict="WARN",
+                source="pdn_check_copper_weight",
+                evidence=[{"net_name": payload.net_name, "track_count": 0}],
+                remediation="Route copper for this net, then rerun pdn_check_copper_weight().",
+                failure_mode="configuration",
+                metadata={"domain": "power_integrity"},
+            )
 
         min_width_mm = min(nm_to_mm(int(track.width)) for track in tracks)
         avg_width_mm = sum(nm_to_mm(int(track.width)) for track in tracks) / len(tracks)
@@ -432,21 +468,45 @@ def register(mcp: FastMCP) -> None:
             external=external,
             max_temp_rise_c=payload.max_temp_rise_c,
         )
-        verdict = "PASS" if capacity_a >= payload.expected_current_a else "WARN"
+        verdict: Verdict = "PASS" if capacity_a >= payload.expected_current_a else "WARN"
 
-        return "\n".join(
-            [
-                f"Copper weight check for {payload.net_name} ({verdict}):",
-                f"- Routed track count: {len(tracks)}",
-                f"- Minimum width: {min_width_mm:.3f} mm",
-                f"- Average width: {avg_width_mm:.3f} mm",
-                f"- Copper thickness: {copper_thickness:.4f} mm",
-                f"- Assumed temperature rise limit: {payload.max_temp_rise_c:.1f} C",
-                f"- Estimated conservative current capacity: {capacity_a:.3f} A",
-                f"- Expected current: {payload.expected_current_a:.3f} A",
-                f"- Recommended minimum width: {required_width_mm:.3f} mm",
-                "- Uses a conservative IPC-style current-carrying estimate for quick review.",
-            ]
+        lines = [
+            f"Copper weight check for {payload.net_name} ({verdict}):",
+            f"- Routed track count: {len(tracks)}",
+            f"- Minimum width: {min_width_mm:.3f} mm",
+            f"- Average width: {avg_width_mm:.3f} mm",
+            f"- Copper thickness: {copper_thickness:.4f} mm",
+            f"- Assumed temperature rise limit: {payload.max_temp_rise_c:.1f} C",
+            f"- Estimated conservative current capacity: {capacity_a:.3f} A",
+            f"- Expected current: {payload.expected_current_a:.3f} A",
+            f"- Recommended minimum width: {required_width_mm:.3f} mm",
+            "- Uses a conservative IPC-style current-carrying estimate for quick review.",
+        ]
+        return VerdictReport.from_text_verdict(
+            text="\n".join(lines),
+            summary=(
+                f"Copper capacity is {capacity_a:.3f} A for "
+                f"{payload.expected_current_a:.3f} A expected."
+            ),
+            verdict=verdict,
+            source="pdn_check_copper_weight",
+            evidence=[
+                {
+                    "net_name": payload.net_name,
+                    "track_count": len(tracks),
+                    "min_width_mm": min_width_mm,
+                    "capacity_a": capacity_a,
+                    "expected_current_a": payload.expected_current_a,
+                    "required_width_mm": required_width_mm,
+                }
+            ],
+            remediation=(
+                "Increase copper width/weight or reduce current, then rerun "
+                "pdn_check_copper_weight()."
+            )
+            if verdict != "PASS"
+            else "",
+            metadata={"domain": "power_integrity"},
         )
 
     @mcp.tool()
@@ -573,7 +633,7 @@ def register(mcp: FastMCP) -> None:
         net_name: str,
         expected_power_w: float,
         preferred_layer: str = "auto",
-    ) -> str:
+    ) -> VerdictReport:
         """Check whether the board already has copper pour support for the net."""
         payload = ThermalPourInput(
             net_name=net_name,
@@ -586,12 +646,27 @@ def register(mcp: FastMCP) -> None:
             if str(getattr(getattr(zone, "net", None), "name", "") or "") == payload.net_name
         ]
         if not zones:
-            return (
+            message = (
                 f"No copper pours were found for net '{payload.net_name}'. "
                 "Add a pour or plane for thermal spreading before release."
             )
+            return VerdictReport.from_text_verdict(
+                text=message,
+                summary=message,
+                verdict="WARN",
+                source="thermal_check_copper_pour",
+                evidence=[{"net_name": payload.net_name, "matching_pours": 0}],
+                remediation=(
+                    "Add a copper pour or plane for thermal spreading, then rerun "
+                    "thermal_check_copper_pour()."
+                ),
+                failure_mode="configuration",
+                metadata={"domain": "thermal"},
+            )
 
-        verdict = "PASS" if len(zones) >= max(1, math.ceil(payload.expected_power_w)) else "WARN"
+        verdict: Verdict = (
+            "PASS" if len(zones) >= max(1, math.ceil(payload.expected_power_w)) else "WARN"
+        )
         lines = [
             f"Thermal copper-pour review for {payload.net_name} ({verdict}):",
             f"- Expected dissipation: {payload.expected_power_w:.3f} W",
@@ -602,7 +677,26 @@ def register(mcp: FastMCP) -> None:
             lines.append(f"- {zone.name or '(unnamed)'} on {zone_layers or '(unknown layers)'}")
         if verdict == "WARN":
             lines.append("- Consider a wider pour, more copper area, and stitched thermal vias.")
-        return "\n".join(lines)
+        return VerdictReport.from_text_verdict(
+            text="\n".join(lines),
+            summary=f"Thermal copper support has {len(zones)} matching pour(s)/plane(s).",
+            verdict=verdict,
+            source="thermal_check_copper_pour",
+            evidence=[
+                {
+                    "net_name": payload.net_name,
+                    "expected_power_w": payload.expected_power_w,
+                    "matching_pours": len(zones),
+                }
+            ],
+            remediation=(
+                "Increase thermal copper area and stitching, then rerun "
+                "thermal_check_copper_pour()."
+            )
+            if verdict != "PASS"
+            else "",
+            metadata={"domain": "thermal"},
+        )
 
     @mcp.tool()
     def thermal_simulate_plane_spreading(
@@ -615,7 +709,7 @@ def register(mcp: FastMCP) -> None:
         ambient_c: float = 25.0,
         film_coefficient_w_per_m2_k: float = 20.0,
         max_temp_rise_c: float = 40.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Solve copper-plane heat spreading with a 2-D finite-difference thermal solver.
 
         Models a hot source dissipating ``power_w`` into a copper plane that loses heat to
@@ -669,4 +763,29 @@ def register(mcp: FastMCP) -> None:
         method = thermal_fd_method()
         lines.append(f"- Method: {method['method']} — {method['accuracy']}")
         lines.append(f"- {format_solver_verdict(method)}")
-        return "\n".join(lines)
+        return VerdictReport.from_text_verdict(
+            text="\n".join(lines),
+            summary=(
+                f"Peak temperature rise is {result.peak_rise_c:.1f} C against "
+                f"{payload.max_temp_rise_c:.1f} C limit."
+            ),
+            verdict=verdict,
+            source="thermal_simulate_plane_spreading",
+            evidence=[
+                {
+                    "power_w": payload.power_w,
+                    "peak_rise_c": result.peak_rise_c,
+                    "average_rise_c": result.average_rise_c,
+                    "max_temp_rise_c": payload.max_temp_rise_c,
+                    "converged": result.converged,
+                    "iterations": result.iterations,
+                }
+            ],
+            remediation=(
+                "Increase copper area, reduce power density, or add thermal vias, then "
+                "rerun thermal_simulate_plane_spreading()."
+            )
+            if verdict != "PASS"
+            else "",
+            metadata={"domain": "thermal", "solver": method["method"]},
+        )

--- a/src/kicad_mcp/tools/signal_integrity.py
+++ b/src/kicad_mcp/tools/signal_integrity.py
@@ -29,6 +29,7 @@ from ..models.signal_integrity import (
     TraceWidthForImpedanceInput,
     ViaStubInput,
 )
+from ..models.verdict import VerdictReport
 from ..utils.channel import (
     ChannelMetrics,
     ChannelSpec,
@@ -627,7 +628,7 @@ def register(mcp: FastMCP) -> None:
         er: float = 4.2,
         trace_type: str = "microstrip",
         skew_budget_ps: float = 0.0,
-    ) -> str:
+    ) -> VerdictReport:
         """Estimate differential-pair length skew and delay mismatch from board tracks.
 
         Returns a PASS/WARN/FAIL verdict. The skew budget comes from ``skew_budget_ps``
@@ -637,9 +638,24 @@ def register(mcp: FastMCP) -> None:
         payload = DifferentialPairSkewInput(net_p=net_p, net_n=net_n, er=er, trace_type=trace_type)
         lengths = _track_lengths_by_net()
         if payload.net_p not in lengths or payload.net_n not in lengths:
-            return (
+            message = (
                 "Could not compute differential-pair skew because one or both nets "
                 "have no routed track segments on the active board."
+            )
+            return VerdictReport.from_text_verdict(
+                text=message,
+                summary=message,
+                verdict="WARN",
+                source="si_check_differential_pair_skew",
+                evidence=[
+                    {"net_p": payload.net_p, "net_n": payload.net_n, "routed_lengths": lengths}
+                ],
+                remediation=(
+                    "Route both differential-pair nets, then rerun "
+                    "si_check_differential_pair_skew()."
+                ),
+                failure_mode="configuration",
+                metadata={"domain": "signal_integrity"},
             )
 
         height_mm = _outer_dielectric_height_mm()
@@ -664,19 +680,41 @@ def register(mcp: FastMCP) -> None:
         fail_ps = warn_max_from(budget_ps)
         verdict = three_level_verdict(skew_ps, pass_max=budget_ps, warn_max=fail_ps)
 
-        return "\n".join(
-            [
-                f"Differential-pair skew analysis ({verdict}):",
-                f"- Net P: {payload.net_p} length={length_p:.3f} mm",
-                f"- Net N: {payload.net_n} length={length_n:.3f} mm",
-                f"- Skew: {skew_mm:.3f} mm",
-                f"- Estimated delay mismatch: {skew_ps:.3f} ps",
-                f"- Effective permittivity used: {effective_er:.3f}",
-                f"- Assumed outer dielectric height: {height_mm:.3f} mm",
-                f"- Skew budget: {budget_ps:.1f} ps (source: {budget_source})",
-                f"- Thresholds: PASS <= {budget_ps:.1f} ps, WARN <= {fail_ps:.1f} ps, "
-                f"FAIL > {fail_ps:.1f} ps.",
-            ]
+        lines = [
+            f"Differential-pair skew analysis ({verdict}):",
+            f"- Net P: {payload.net_p} length={length_p:.3f} mm",
+            f"- Net N: {payload.net_n} length={length_n:.3f} mm",
+            f"- Skew: {skew_mm:.3f} mm",
+            f"- Estimated delay mismatch: {skew_ps:.3f} ps",
+            f"- Effective permittivity used: {effective_er:.3f}",
+            f"- Assumed outer dielectric height: {height_mm:.3f} mm",
+            f"- Skew budget: {budget_ps:.1f} ps (source: {budget_source})",
+            f"- Thresholds: PASS <= {budget_ps:.1f} ps, WARN <= {fail_ps:.1f} ps, "
+            f"FAIL > {fail_ps:.1f} ps.",
+        ]
+        return VerdictReport.from_text_verdict(
+            text="\n".join(lines),
+            summary=(
+                f"Differential-pair skew is {skew_ps:.3f} ps against {budget_ps:.1f} ps budget."
+            ),
+            verdict=verdict,
+            source="si_check_differential_pair_skew",
+            evidence=[
+                {
+                    "net_p": payload.net_p,
+                    "net_n": payload.net_n,
+                    "length_p_mm": length_p,
+                    "length_n_mm": length_n,
+                    "skew_mm": skew_mm,
+                    "skew_ps": skew_ps,
+                    "budget_ps": budget_ps,
+                    "budget_source": budget_source,
+                }
+            ],
+            remediation="Tune pair lengths/routing, then rerun si_check_differential_pair_skew()."
+            if verdict != "PASS"
+            else "",
+            metadata={"domain": "signal_integrity"},
         )
 
     @mcp.tool()

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -297,6 +297,10 @@ def _report_entry_finding(
         severity=severity,
         location=location,
         description=description,
+        evidence=[{"source": source, "entry": dict(entry)}],
+        remediation=f"Fix the {source} finding and rerun {fix_tool}(save_report=True).",
+        retryable=False,
+        failure_mode="design",
         suggested_fix=SuggestedFix(tool=fix_tool, args={"save_report": True}),
         metadata=metadata,
     )
@@ -326,12 +330,22 @@ def _finding_for_gate_detail(outcome: GateOutcome, detail: str) -> Finding:
         cleaned.removeprefix("FAIL: ").removeprefix("WARN: ").removeprefix("BLOCKED: ").strip()
         or outcome.summary
     )
+    suggested_fix = _fix_for_gate(outcome.name)
+    remediation = (
+        f"Run {suggested_fix.tool} and re-run this gate."
+        if suggested_fix is not None
+        else "Inspect this gate and re-run it after remediation."
+    )
     return Finding(
         id=stable_finding_id("gate", outcome.name, outcome.status, description),
         severity=severity,
         location=outcome.name,
         description=description,
-        suggested_fix=_fix_for_gate(outcome.name),
+        evidence=[{"gate": outcome.name, "status": outcome.status, "detail": cleaned}],
+        remediation=remediation,
+        retryable=False,
+        failure_mode="configuration" if outcome.status == "BLOCKED" else "design",
+        suggested_fix=suggested_fix,
     )
 
 
@@ -365,10 +379,17 @@ def _gate_report(outcome: GateOutcome) -> VerdictReport:
             if fixer is not None
             else "Inspect this gate and re-run it after remediation."
         )
+    failure_mode = "none" if verdict == "PASS" else "design"
+    if verdict != "PASS" and outcome.status == "BLOCKED":
+        failure_mode = "configuration"
     return VerdictReport(
         text=_format_gate(outcome),
         summary=outcome.summary,
         verdict=verdict,
+        failure_mode=failure_mode,
+        retryable=False,
+        evidence=[{"gate": outcome.name, "status": outcome.status, "details": outcome.details}],
+        remediation="" if verdict == "PASS" else next_action,
         findings=findings,
         next_action=next_action,
         metadata={"gate": outcome.name, "status": outcome.status, "details": outcome.details},
@@ -383,7 +404,7 @@ def _drc_report_payload(
     save_report: bool,
 ) -> VerdictReport:
     if report is None:
-        message = f"DRC failed: {error or 'unknown error'}"
+        message = f"DRC report unavailable: {error or 'unknown error'}"
         return VerdictReport(
             text=message,
             summary="DRC report is unavailable.",
@@ -394,11 +415,18 @@ def _drc_report_payload(
                     severity="error",
                     location=str(path),
                     description=message,
+                    evidence=[{"report_path": str(path), "error": error or "unknown error"}],
+                    remediation="Make kicad-cli/report generation available, then rerun run_drc().",
+                    retryable=True,
+                    failure_mode="environment",
                     suggested_fix=SuggestedFix(tool="run_drc", args={"save_report": True}),
                 )
             ],
+            failure_mode="environment",
+            retryable=True,
+            remediation="Make kicad-cli/report generation available, then rerun run_drc().",
             next_action="Make kicad-cli/report generation available, then rerun run_drc().",
-            metadata={"report_path": str(path), "available": False},
+            metadata={"report_path": str(path), "available": False, "failure_mode": "environment"},
         )
 
     violations = _entries(report, "violations")
@@ -442,6 +470,12 @@ def _drc_report_payload(
             else f"DRC reported {len(findings)} actionable finding(s)."
         ),
         verdict=verdict,
+        failure_mode="none" if verdict == "PASS" else "design",
+        retryable=False,
+        evidence=[{"report_path": str(path), "violations": report}],
+        remediation=(
+            "" if verdict == "PASS" else "Fix DRC findings and rerun run_drc(save_report=True)."
+        ),
         findings=findings,
         next_action=(
             "No DRC action required."
@@ -466,7 +500,7 @@ def _erc_report_payload(
     save_report: bool,
 ) -> VerdictReport:
     if report is None:
-        message = f"ERC failed: {error or 'unknown error'}"
+        message = f"ERC report unavailable: {error or 'unknown error'}"
         return VerdictReport(
             text=message,
             summary="ERC report is unavailable.",
@@ -477,11 +511,18 @@ def _erc_report_payload(
                     severity="error",
                     location=str(path),
                     description=message,
+                    evidence=[{"report_path": str(path), "error": error or "unknown error"}],
+                    remediation="Make kicad-cli/report generation available, then rerun run_erc().",
+                    retryable=True,
+                    failure_mode="environment",
                     suggested_fix=SuggestedFix(tool="run_erc", args={"save_report": True}),
                 )
             ],
+            failure_mode="environment",
+            retryable=True,
+            remediation="Make kicad-cli/report generation available, then rerun run_erc().",
             next_action="Make kicad-cli/report generation available, then rerun run_erc().",
-            metadata={"report_path": str(path), "available": False},
+            metadata={"report_path": str(path), "available": False, "failure_mode": "environment"},
         )
 
     violations = _erc_violations(report)
@@ -500,6 +541,12 @@ def _erc_report_payload(
             else f"ERC reported {len(findings)} actionable finding(s)."
         ),
         verdict=verdict,
+        failure_mode="none" if verdict == "PASS" else "design",
+        retryable=False,
+        evidence=[{"report_path": str(path), "violations": report}],
+        remediation=(
+            "" if verdict == "PASS" else "Fix ERC findings and rerun run_erc(save_report=True)."
+        ),
         findings=findings,
         next_action=(
             "No ERC action required."

--- a/tests/integration/test_verdict_reports.py
+++ b/tests/integration/test_verdict_reports.py
@@ -187,3 +187,81 @@ async def test_pcb_board_summary_returns_verdict_report(mock_board: object) -> N
     assert payload["verdict"] == "PASS"
     assert payload["metadata"]["source"] == "live-gui"
     assert payload["metadata"]["tracks"] == 0
+
+
+@pytest.mark.anyio
+async def test_verdict_findings_include_evidence_remediation_and_retryability(
+    sample_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = {
+        "violations": [
+            {
+                "uuid": "clearance-1",
+                "severity": "error",
+                "type": "clearance",
+                "description": "Clearance violation",
+            }
+        ],
+        "unconnected_items": [],
+        "items_not_passing_courtyard": [],
+    }
+
+    def fake_run_drc(report_name: str) -> tuple[Path, dict[str, object], None]:
+        return sample_project / "output" / report_name, report, None
+
+    monkeypatch.setattr("kicad_mcp.tools.validation._run_drc_report", fake_run_drc)
+    server = build_server("full")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    payload = await call_tool_payload(server, "run_drc", {"save_report": True})
+
+    assert payload["schema_version"] == "verdict.v1"
+    assert payload["failure_mode"] == "design"
+    assert payload["retryable"] is False
+    assert payload["remediation"] == "Fix DRC findings and rerun run_drc(save_report=True)."
+    assert payload["evidence"][0]["report_path"].endswith("drc_report.json")
+    finding = payload["findings"][0]
+    assert finding["failure_mode"] == "design"
+    assert finding["retryable"] is False
+    assert finding["remediation"].startswith("Fix the drc finding")
+    assert finding["evidence"][0]["entry"]["uuid"] == "clearance-1"
+
+
+@pytest.mark.anyio
+async def test_environment_gate_error_is_retryable_and_distinct_from_design_failure(
+    sample_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run_erc(report_name: str) -> tuple[Path, None, str]:
+        return sample_project / "output" / report_name, None, "kicad-cli unavailable"
+
+    monkeypatch.setattr("kicad_mcp.tools.validation._run_erc_report", fake_run_erc)
+    server = build_server("full")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    payload = await call_tool_payload(server, "run_erc", {"save_report": True})
+
+    assert payload["verdict"] == "FAIL"
+    assert payload["failure_mode"] == "environment"
+    assert payload["retryable"] is True
+    assert payload["findings"][0]["failure_mode"] == "environment"
+    assert payload["findings"][0]["retryable"] is True
+
+
+@pytest.mark.anyio
+async def test_critic_tools_return_standard_verdict_payloads(sample_project, mock_board) -> None:
+    server = build_server("full")
+    mock_board.get_tracks.return_value = []
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    payload = await call_tool_payload(
+        server,
+        "si_check_differential_pair_skew",
+        {"net_p": "USB_DP", "net_n": "USB_DN"},
+    )
+
+    assert payload["schema_version"] == "verdict.v1"
+    assert payload["verdict"] == "WARN"
+    assert payload["failure_mode"] == "configuration"
+    assert payload["findings"][0]["remediation"].startswith("Route both differential-pair nets")


### PR DESCRIPTION
## Summary
- extend `VerdictReport` and `Finding` with a stable `verdict.v1` envelope
- add machine-readable severity, failure mode, retryability, evidence, and remediation fields
- distinguish design failures from environment/configuration failures for DRC/ERC and gates
- wrap DFM, EMC, SI, PI, and thermal critic outputs in the same structured verdict payload
- keep human-readable `text` output compatible for text-only MCP clients

Closes #274.

## Validation
- `corepack pnpm run format:check` → pass
- `corepack pnpm run lint` → pass
- `uv run --all-extras python -m mypy src/kicad_mcp/` → pass
- `uv run --all-extras python scripts/check_tool_contracts.py` → pass
- `corepack pnpm run docs:tools:check` → pass
- `uv run --all-extras python -m pytest tests/integration/test_tool_surface_snapshot.py -q` → pass
- `corepack pnpm run test:unit` → pass
- `uv run --all-extras python -m pytest tests/integration/test_verdict_reports.py tests/integration/test_emc_tools.py tests/integration/test_power_integrity_tools.py tests/integration/test_signal_integrity_extended.py tests/integration/test_dfm_tools.py -q` → pass
- `corepack pnpm run test` → pass, coverage 85.60% >= 83%
