### PR TITLE
Add KiCad agent plugin manifest and workflow skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,96 @@
+{
+  "name": "kicad-pro",
+  "version": "3.19.0",
+  "description": "KiCad MCP Pro agent plugin for schematic review, PCB design assistance, DRC/ERC validation, DFM checks, and manufacturing release workflows.",
+  "author": {
+    "name": "oaslananka",
+    "url": "https://github.com/oaslananka"
+  },
+  "source": {
+    "source": "github",
+    "repo": "oaslananka/kicad-mcp"
+  },
+  "category": "engineering",
+  "tags": [
+    "kicad",
+    "pcb",
+    "eda",
+    "mcp",
+    "hardware",
+    "electronics",
+    "drc",
+    "erc",
+    "manufacturing"
+  ],
+  "mcp_servers": [
+    {
+      "name": "io.github.oaslananka/kicad-mcp-pro",
+      "title": "KiCad MCP Pro",
+      "description": "Production-grade MCP server for KiCad EDA automation.",
+      "package": {
+        "pypi": "kicad-mcp-pro",
+        "npm": "kicad-mcp-pro",
+        "oci": "ghcr.io/oaslananka/kicad-mcp-pro:3.19.0"
+      },
+      "transports": [
+        "stdio",
+        "streamable-http"
+      ],
+      "launch_examples": [
+        "uvx kicad-mcp-pro --transport stdio",
+        "uvx kicad-mcp-pro --transport streamable-http --host 127.0.0.1 --port 3334",
+        "npx kicad-mcp-pro --help"
+      ],
+      "registry_manifest": "server.json",
+      "tool_reference": "docs/tools-reference.generated.md",
+      "minimum_requirements": [
+        "Python 3.13+ when using the PyPI/uvx package.",
+        "Node.js 24.11+ and pnpm 11+ for source checkout development flows.",
+        "KiCad CLI 8.x, 9.x, or 10.x on PATH for file-backed DRC, ERC, and export tools."
+      ]
+    }
+  ],
+  "skills": [
+    {
+      "name": "kicad-design-review",
+      "path": "skills/kicad-design-review/SKILL.md",
+      "description": "Comprehensive KiCad design review workflow covering schematic, PCB, DFM, manufacturing, high-speed, and simulation checks."
+    },
+    {
+      "name": "pcb-design",
+      "path": "skills/pcb-design/SKILL.md",
+      "description": "Safe PCB design assistance workflow using KiCad MCP board, placement, routing, stackup, and quality-gate tools."
+    },
+    {
+      "name": "drc-check",
+      "path": "skills/drc-check/SKILL.md",
+      "description": "DRC/ERC execution, triage, waiver, and revalidation workflow for KiCad projects."
+    },
+    {
+      "name": "fabrication-output",
+      "path": "skills/fabrication-output/SKILL.md",
+      "description": "Manufacturing release workflow for Gerbers, drill files, BOM, pick-and-place, 3D, DFM, and release evidence."
+    },
+    {
+      "name": "schematic-review",
+      "path": "skills/schematic-review/SKILL.md",
+      "description": "Schematic inspection and review workflow using ERC, connectivity, symbol, net, and visual QA tools."
+    }
+  ],
+  "documentation": {
+    "readme": "README.md",
+    "installation": "docs/installation.md",
+    "client_configuration": "docs/client-configuration.md",
+    "tool_reference": "docs/tools-reference.generated.md",
+    "agent_plugin": "README.md#agent-plugin-and-skills"
+  },
+  "safety": {
+    "human_review_required": true,
+    "notes": [
+      "KiCad MCP Pro is an engineering assistant, not an autonomous sign-off authority.",
+      "Manufacturing output must be reviewed by a qualified human before fabrication or assembly.",
+      "ERC, DRC, DFM, export artifacts, and known waivers must be reported separately from assumptions."
+    ]
+  },
+  "status": "ready-for-catalog-validation"
+}

--- a/README.md
+++ b/README.md
@@ -180,6 +180,58 @@ Use `kicad-mcp-pro --help` to inspect CLI commands and
 MCP client. The generated tool catalog is available in
 [`docs/tools-reference.generated.md`](docs/tools-reference.generated.md).
 
+
+## Agent plugin and skills
+
+This repository owns the product-level agent plugin and KiCad-specific skills for
+KiCad MCP Pro. The central [`agent-tools`](https://github.com/oaslananka/agent-tools)
+repository should catalog this plugin, but the manifest and workflow instructions live
+here so they stay synchronized with the actual MCP server tools.
+
+| File | Purpose |
+| --- | --- |
+| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) | Product-level plugin manifest for compatible agent runtimes and marketplace catalogs. |
+| [`skills/kicad-design-review/SKILL.md`](skills/kicad-design-review/SKILL.md) | Comprehensive KiCad design review skill. |
+| [`skills/pcb-design/SKILL.md`](skills/pcb-design/SKILL.md) | PCB design, layout inspection, placement, routing, stackup, and board-quality workflow. |
+| [`skills/drc-check/SKILL.md`](skills/drc-check/SKILL.md) | ERC/DRC execution, triage, waiver review, and revalidation workflow. |
+| [`skills/fabrication-output/SKILL.md`](skills/fabrication-output/SKILL.md) | Manufacturing export, DFM, release evidence, and fabrication-package workflow. |
+| [`skills/schematic-review/SKILL.md`](skills/schematic-review/SKILL.md) | Schematic inspection, ERC, connectivity, power, symbol, and readability workflow. |
+
+### Agent setup
+
+KiCad MCP Pro can be launched with the published Python package, npm wrapper, or the
+container metadata declared in [`server.json`](server.json). Common local starts are:
+
+```bash
+uvx kicad-mcp-pro --transport stdio
+uvx kicad-mcp-pro --transport streamable-http --host 127.0.0.1 --port 3334
+npx kicad-mcp-pro --help
+```
+
+For source checkouts, run the normal repository validation path before publishing plugin
+changes:
+
+```bash
+corepack pnpm run metadata:check
+python3 -m json.tool .claude-plugin/plugin.json >/dev/null
+```
+
+### Validation workflow
+
+Before listing this plugin as active from `agent-tools`, verify at least one compatible
+agent runtime can:
+
+1. Discover `.claude-plugin/plugin.json`.
+2. Launch or connect to `kicad-mcp-pro` over `stdio` or Streamable HTTP.
+3. Call `kicad_get_server_info` or `kicad_get_project_info`.
+4. Load a skill from `skills/` and follow the workflow without referencing missing tools.
+5. Report ERC, DRC, DFM, export artifacts, assumptions, and human-review requirements
+   separately.
+
+KiCad MCP Pro is an engineering assistant, not an autonomous manufacturing sign-off
+authority. Generated PCB and fabrication outputs require qualified human review before
+fabrication or assembly.
+
 ## Development
 
 New contributors should start with [`ARCHITECTURE.md`](ARCHITECTURE.md), which maps

--- a/skills/drc-check/SKILL.md
+++ b/skills/drc-check/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: drc-check
+description: KiCad MCP workflow for ERC/DRC execution, issue triage, waiver review, and revalidation.
+---
+
+# DRC Check Skill
+
+Use this skill when an AI agent is asked to run, interpret, triage, or revalidate KiCad ERC/DRC results through KiCad MCP Pro.
+
+This skill is specific to `oaslananka/kicad-mcp` and should be kept synchronized with `docs/tools-reference.generated.md`.
+
+## When to use
+
+Use this skill for:
+
+- Schematic ERC review
+- PCB DRC review
+- DRC rule inspection and custom rule checks
+- Unconnected net triage
+- Courtyard and silk-to-pad violation triage
+- Waiver/exclusion review
+- Revalidation after an edit
+
+Do not use this skill to hide, auto-waive, or normalize violations without explicit engineering rationale.
+
+## Required context
+
+Collect:
+
+- Active project path and KiCad version from `kicad_get_project_info`
+- Board and schematic files
+- Target gate: ERC, DRC, project gate, release gate, or revalidation loop
+- Manufacturer or design-rule constraints, if relevant
+- Existing waivers/exclusions, if any
+
+## Primary MCP tools
+
+### Setup and discovery
+
+- `kicad_get_project_info`
+- `kicad_get_version`
+- `kicad_help`
+- `kicad_get_tools_in_category`
+
+### ERC and schematic checks
+
+- `run_erc`
+- `erc_list_rules`
+- `schematic_quality_gate`
+- `schematic_connectivity_gate`
+- `schematic_design_rule_check`
+- `sch_check_power_flags`
+- `sch_get_net_names`
+- `sch_get_symbols`
+
+### DRC and board checks
+
+- `run_drc`
+- `drc_list_rules`
+- `drc_check_rule_conflicts`
+- `drc_list_exclusions`
+- `drc_validate_exclusions`
+- `get_unconnected_nets`
+- `get_courtyard_violations`
+- `get_silk_to_pad_violations`
+- `pcb_quality_gate`
+- `pcb_transfer_quality_gate`
+- `pcb_stackup_consistency_gate`
+
+### Controlled rule/exclusion operations
+
+Use these only when explicitly requested and when the rationale is documented.
+
+- `drc_add_exclusion`
+- `drc_remove_exclusion`
+- `drc_rule_create`
+- `drc_rule_delete`
+- `drc_rule_enable`
+- `drc_export_rules`
+- `erc_set_rule_severity`
+- `erc_reset_rules`
+
+### Project-level validation
+
+- `project_quality_gate`
+- `project_quality_gate_report`
+- `project_full_validation_loop`
+- `project_revalidate_after_edit`
+- `project_gate_trend`
+
+## Workflow
+
+1. Confirm active project and KiCad capability with `kicad_get_project_info` and `kicad_get_version`.
+2. Run ERC with `run_erc` when schematic validation is in scope.
+3. Run DRC with `run_drc` when PCB validation is in scope.
+4. Run targeted issue extractors: `get_unconnected_nets`, `get_courtyard_violations`, and `get_silk_to_pad_violations`.
+5. Inspect rule configuration with `drc_list_rules`, `erc_list_rules`, and `drc_check_rule_conflicts` when violations are unclear.
+6. Check exclusions with `drc_list_exclusions` and `drc_validate_exclusions`.
+7. Run the relevant quality gates.
+8. Group findings by severity, rule, object/reference, location, and likely fix.
+9. If edits are performed by another workflow, re-run the targeted gates and compare before/after results.
+10. Report remaining violations, accepted waivers, and unverified assumptions separately.
+
+## Waiver policy
+
+A DRC/ERC issue may be marked as waived only when the response documents:
+
+- Rule name or violation ID
+- Location/object/reference
+- Expected requirement
+- Actual deviation
+- Engineering rationale
+- Human approval requirement
+
+Do not add DRC exclusions automatically just to make a gate pass.
+
+## Quality checks
+
+A complete DRC/ERC report must include:
+
+- Tool versions or project context
+- ERC result summary
+- DRC result summary
+- Issue counts by severity
+- Critical blockers
+- Waivers/exclusions status
+- Recommended fixes
+- Revalidation result after any changes
+
+## Failure modes
+
+Stop and report clearly when:
+
+- KiCad CLI is unavailable for file-backed checks
+- Project paths are ambiguous
+- DRC/ERC output cannot be produced
+- Rule files are missing or conflicting
+- Exclusions are stale or cannot be validated
+- The user asks to suppress violations without an engineering reason
+
+## Output format
+
+Return:
+
+- Project context
+- ERC summary
+- DRC summary
+- Rule/exclusion status
+- Findings by severity
+- Recommended fixes
+- Revalidation evidence
+- Human-review notes

--- a/skills/fabrication-output/SKILL.md
+++ b/skills/fabrication-output/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: fabrication-output
+description: KiCad MCP manufacturing release workflow for Gerbers, drill files, BOM, pick-and-place, DFM, release evidence, and final human review.
+---
+
+# Fabrication Output Skill
+
+Use this skill when an AI agent is asked to prepare, validate, or package KiCad manufacturing outputs through KiCad MCP Pro.
+
+This skill is specific to `oaslananka/kicad-mcp` and should be kept synchronized with `docs/tools-reference.generated.md`.
+
+## When to use
+
+Use this skill for:
+
+- Gerber and drill export
+- BOM and pick-and-place export
+- STEP/3D/PDF fabrication documentation
+- DFM review
+- Manufacturing quality gate review
+- Release evidence and manifest generation
+- Final manufacturing handoff preparation
+
+Do not use this skill before ERC/DRC/DFM status is known.
+
+## Required context
+
+Collect:
+
+- Active KiCad project path
+- Target manufacturer or generic fabrication constraints
+- Board stackup and layer count
+- Assembly requirement: PCB only, SMT assembly, through-hole, mixed assembly, or prototype
+- Required output directory
+- Whether variants/DNP/population options apply
+- Human approval status for unresolved violations and waivers
+
+## Primary MCP tools
+
+### Pre-release gates
+
+- `kicad_get_project_info`
+- `project_quality_gate`
+- `project_quality_gate_report`
+- `project_professional_release_gate`
+- `project_release_readiness`
+- `project_signoff_report`
+- `run_erc`
+- `run_drc`
+- `check_design_for_manufacture`
+- `manufacturing_quality_gate`
+
+### Manufacturing and DFM tools
+
+- `dfm_load_manufacturer_profile`
+- `dfm_run_manufacturer_check`
+- `dfm_calculate_manufacturing_cost`
+- `mfg_generate_test_plan`
+- `mfg_create_release_evidence`
+- `mfg_generate_release_manifest`
+- `mfg_correct_cpl_rotations`
+- `pcb_check_creepage_clearance`
+- `pcb_check_test_coverage`
+
+### Export tools
+
+- `export_manufacturing_package`
+- `export_gerber`
+- `export_drill`
+- `export_bom`
+- `export_pick_and_place`
+- `export_netlist`
+- `export_pcb_pdf`
+- `export_sch_pdf`
+- `export_step`
+- `export_3d_render`
+- `export_ipc2581`
+- `export_odb`
+- `export_ipc_d356`
+- `jobset_list_templates`
+- `jobset_validate`
+- `jobset_export`
+- `variant_export_manufacturing_package`
+
+## Workflow
+
+1. Confirm active project with `kicad_get_project_info`.
+2. Run or retrieve project validation state using `project_quality_gate` or `project_quality_gate_report`.
+3. Run `run_erc` and `run_drc` unless the user provides recent validated evidence.
+4. Run DFM/manufacturing checks using `check_design_for_manufacture` and `manufacturing_quality_gate`.
+5. If a manufacturer is specified, load and run the relevant DFM profile with `dfm_load_manufacturer_profile` and `dfm_run_manufacturer_check`.
+6. Block release if there are unresolved critical ERC, DRC, DFM, stackup, or manufacturing-gate failures.
+7. Export required artifacts with the smallest complete export set for the user's target.
+8. Prefer `export_manufacturing_package` when a gated package is requested and supported.
+9. Generate evidence and manifests with `mfg_create_release_evidence` and `mfg_generate_release_manifest` when available.
+10. Report exact artifact types, output paths, gate results, known waivers, and human-review requirements.
+
+## Minimum artifact set
+
+For a typical PCB fabrication handoff:
+
+- Gerber files from `export_gerber`
+- Drill files from `export_drill`
+- Board PDF or fabrication drawing from `export_pcb_pdf`
+- Schematic PDF from `export_sch_pdf`
+- BOM from `export_bom`
+- Pick-and-place file from `export_pick_and_place` when assembly is required
+- STEP model from `export_step` when mechanical review is required
+- Release evidence/manifest when a formal release package is requested
+
+## Quality checks
+
+A manufacturing package response must include:
+
+- ERC status
+- DRC status
+- DFM/manufacturing gate status
+- Exported artifact list
+- Output location
+- Missing artifacts, if any
+- Waivers and exclusions
+- Human-review checklist
+
+## Failure modes
+
+Stop and report clearly when:
+
+- ERC/DRC has unresolved critical failures
+- DFM constraints are missing for a manufacturer-specific release
+- Export tools fail or output paths are not writable
+- BOM or pick-and-place data is incomplete
+- Variants/DNP requirements are ambiguous
+- The user asks to fabricate without validation evidence
+
+## Output format
+
+Return:
+
+- Release target
+- Gate status
+- Artifact inventory
+- Waivers/exclusions
+- Blockers
+- Human-review checklist
+- Final verdict: `blocked`, `draft package`, or `candidate package after human review`
+
+## Safety rule
+
+Never represent generated fabrication files as production-approved. Use `candidate package after human review` unless a qualified human explicitly approves the release outside the agent workflow.

--- a/skills/pcb-design/SKILL.md
+++ b/skills/pcb-design/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: pcb-design
+description: Safe KiCad PCB design assistance workflow using KiCad MCP board inspection, placement, routing, stackup, and quality-gate tools.
+---
+
+# PCB Design Skill
+
+Use this skill when an AI agent is asked to inspect, plan, improve, or safely assist with a KiCad PCB layout through KiCad MCP Pro.
+
+This skill is specific to `oaslananka/kicad-mcp` and should be kept synchronized with `docs/tools-reference.generated.md`.
+
+## When to use
+
+Use this skill for:
+
+- PCB layout review
+- Board outline, stackup, and design-rule planning
+- Component placement assistance
+- Routing-quality review
+- Schematic-to-PCB synchronization review
+- First-pass power, signal, EMC, and manufacturability sanity checks
+
+Do not use this skill to claim that a board is production-ready. Production readiness requires ERC, DRC, DFM, release package review, and human engineering approval.
+
+## Required context
+
+Collect or establish:
+
+- Active project path with `kicad_set_project` or current state from `kicad_get_project_info`
+- Board file and schematic file presence
+- Design intent from `project_get_design_intent` or `project_set_design_intent`
+- Board constraints: layer count, stackup, clearances, current, voltage, impedance, and manufacturer limits
+- User permission before any write/destructive board operation
+
+## Primary MCP tools
+
+### Project and intent
+
+- `kicad_get_project_info`
+- `kicad_set_project`
+- `project_get_design_intent`
+- `project_set_design_intent`
+- `project_design_workflow`
+- `project_get_next_action`
+
+### Read-only PCB inspection
+
+- `pcb_get_board_summary`
+- `pcb_get_layers`
+- `pcb_get_stackup`
+- `pcb_get_design_rules`
+- `pcb_get_footprints`
+- `pcb_get_nets`
+- `pcb_get_net_statistics`
+- `pcb_get_tracks`
+- `pcb_get_vias`
+- `pcb_get_zones`
+- `pcb_get_ratsnest`
+- `pcb_net_inspector`
+
+### PCB modification tools
+
+Use only after explaining the planned change and confirming that the workflow is allowed to modify files.
+
+- `pcb_set_board_outline`
+- `pcb_set_stackup`
+- `pcb_set_design_rules`
+- `pcb_sync_from_schematic`
+- `pcb_auto_place_by_schematic`
+- `pcb_auto_place_force_directed`
+- `pcb_move_footprint`
+- `pcb_place_component`
+- `pcb_place_decoupling_caps`
+- `pcb_add_track`
+- `pcb_add_tracks_bulk`
+- `pcb_add_via`
+- `pcb_add_zone`
+- `pcb_refill_zones`
+- `pcb_save`
+
+### Quality gates and specialist checks
+
+- `pcb_quality_gate`
+- `pcb_placement_quality_gate`
+- `pcb_transfer_quality_gate`
+- `pcb_stackup_consistency_gate`
+- `pcb_route_corner_style_gate`
+- `pcb_visual_qa`
+- `run_drc`
+- `check_design_for_manufacture`
+- `manufacturing_quality_gate`
+- `project_quality_gate`
+- `project_revalidate_after_edit`
+
+## Workflow
+
+1. Inspect project state with `kicad_get_project_info`.
+2. If needed, set the active project with `kicad_set_project`.
+3. Load or define design intent with `project_get_design_intent` or `project_set_design_intent`.
+4. Inspect board structure with `pcb_get_board_summary`, `pcb_get_layers`, `pcb_get_stackup`, and `pcb_get_design_rules`.
+5. Inspect physical implementation with `pcb_get_footprints`, `pcb_get_nets`, `pcb_get_tracks`, `pcb_get_vias`, and `pcb_get_zones`.
+6. For placement tasks, use `pcb_critique_placement`, `pcb_score_placement`, and `pcb_placement_quality_gate` before proposing edits.
+7. For routing tasks, inspect ratsnest, tracks, vias, net classes, stackup, and constraints before proposing route changes.
+8. Apply write operations only when the requested workflow explicitly allows file changes.
+9. Re-run targeted gates after every meaningful edit: `run_drc`, `pcb_quality_gate`, `pcb_transfer_quality_gate`, and `project_revalidate_after_edit`.
+10. Produce a report that separates verified tool output, assumptions, changes made, and remaining risks.
+
+## Quality checks
+
+A useful PCB design response must include:
+
+- Active project and board file summary
+- Constraints and assumptions used
+- Read-only observations before any mutation
+- List of write operations, if any
+- DRC and quality-gate result summary
+- Remaining warnings, unknowns, and required human checks
+
+## Failure modes
+
+Stop and report clearly when:
+
+- No KiCad project is active
+- The board file is missing or not parseable
+- Required KiCad CLI/IPC capability is unavailable
+- The user requested write operations but no safe project context exists
+- DRC or quality-gate output is missing after a layout-changing operation
+- The board depends on manufacturer constraints that were not provided
+
+## Output format
+
+Return:
+
+- Project context
+- Tools used
+- Findings by severity
+- Changes made or proposed
+- Validation results
+- Manufacturing readiness status: `not assessed`, `blocked`, `needs review`, or `candidate after human review`
+- Next actions
+
+## Safety rule
+
+Never state that a PCB is ready for fabrication solely because edits were applied. Fabrication output requires the fabrication-output workflow and qualified human review.

--- a/skills/schematic-review/SKILL.md
+++ b/skills/schematic-review/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: schematic-review
+description: KiCad MCP schematic inspection and review workflow using ERC, connectivity, symbol, net, power, readability, and quality-gate tools.
+---
+
+# Schematic Review Skill
+
+Use this skill when an AI agent is asked to inspect, review, or safely improve a KiCad schematic through KiCad MCP Pro.
+
+This skill is specific to `oaslananka/kicad-mcp` and should be kept synchronized with `docs/tools-reference.generated.md`.
+
+## When to use
+
+Use this skill for:
+
+- Pre-layout schematic review
+- ERC review
+- Net connectivity review
+- Power flag and no-connect review
+- Symbol, footprint, and component-property inspection
+- Readability and visual QA
+- Conservative schematic edits when explicitly requested
+
+Do not use this skill to claim electrical correctness without ERC, design-rule review, datasheet review, and human engineering approval.
+
+## Required context
+
+Collect:
+
+- Active project path and schematic file
+- Design intent and functional requirements
+- Expected power rails, interfaces, and critical nets
+- Component sourcing assumptions
+- Whether the task is read-only review or allowed to modify the schematic
+
+## Primary MCP tools
+
+### Project and intent
+
+- `kicad_get_project_info`
+- `project_get_design_intent`
+- `project_set_design_intent`
+- `project_get_design_spec`
+- `project_import_design_spec`
+- `project_design_report`
+
+### Read-only schematic inspection
+
+- `sch_get_symbols`
+- `sch_get_net_names`
+- `sch_get_labels`
+- `sch_get_wires`
+- `sch_get_connectivity_graph`
+- `sch_get_circuit_ir`
+- `sch_trace_net`
+- `sch_check_power_flags`
+- `sch_get_population_status`
+- `lib_get_symbol_info`
+- `lib_get_footprint_info`
+- `lib_verify_component_contract`
+
+### ERC, quality, and visual checks
+
+- `run_erc`
+- `schematic_quality_gate`
+- `schematic_connectivity_gate`
+- `schematic_design_rule_check`
+- `sch_visual_qa`
+- `sch_render_png`
+- `project_quality_gate`
+
+### Controlled schematic edit tools
+
+Use only when explicitly requested and when the workflow is allowed to modify files.
+
+- `sch_add_symbol`
+- `sch_add_component`
+- `sch_add_wire`
+- `sch_add_label`
+- `sch_add_global_label`
+- `sch_add_power_symbol`
+- `sch_add_no_connect`
+- `sch_add_missing_junctions`
+- `sch_modify_property`
+- `sch_update_properties`
+- `sch_move_symbol`
+- `sch_delete_symbol`
+- `sch_plan_from_spec`
+- `sch_preview_plan`
+- `sch_apply_plan`
+- `sch_verify_plan`
+- `sch_rollback_plan`
+- `sch_reload`
+
+## Workflow
+
+1. Confirm active project and schematic state with `kicad_get_project_info`.
+2. Retrieve design intent with `project_get_design_intent`; if absent and the user supplied requirements, store them with `project_set_design_intent` only when appropriate.
+3. Inspect symbols, nets, labels, wires, and connectivity graph.
+4. Run ERC with `run_erc`.
+5. Run `schematic_quality_gate`, `schematic_connectivity_gate`, and `schematic_design_rule_check`.
+6. Check power-rail intent using `sch_check_power_flags` and net tracing for critical rails/interfaces.
+7. Check component metadata and footprint bindings with library tools when part correctness is in scope.
+8. For readability review, use `sch_visual_qa` and optionally `sch_render_png`.
+9. If edits are requested, prefer plan/preview/apply/verify/rollback tools over direct mutation when possible.
+10. Re-run ERC and schematic quality gates after any schematic-changing operation.
+
+## Quality checks
+
+A schematic review response must include:
+
+- Project and schematic context
+- ERC summary
+- Connectivity findings
+- Power-flag/no-connect findings
+- Symbol/footprint/property findings
+- Readability findings
+- Required fixes and open questions
+- Human-review notes
+
+## Failure modes
+
+Stop and report clearly when:
+
+- No KiCad project is active
+- Schematic files are missing or unsupported
+- ERC cannot run
+- The design intent is too ambiguous to judge correctness
+- Component datasheets or footprint requirements are unavailable
+- The user requests edits without permission to modify files
+
+## Output format
+
+Return:
+
+- Schematic context
+- Tools used
+- Findings by severity
+- ERC and quality-gate status
+- Proposed or applied fixes
+- Remaining assumptions
+- Next validation steps
+
+## Safety rule
+
+A clean ERC result is necessary but not sufficient for design approval. Always report datasheet, footprint, power-budget, signal-integrity, and human-review gaps separately.


### PR DESCRIPTION
## Summary

Adds the product-level KiCad agent plugin manifest and modular KiCad-specific workflow skills so `oaslananka/agent-tools` can later activate `kicad-pro` without pointing to a missing manifest.

## Changes

- Add `.claude-plugin/plugin.json` for the `kicad-pro` plugin.
- Add `skills/pcb-design/SKILL.md`.
- Add `skills/drc-check/SKILL.md`.
- Add `skills/fabrication-output/SKILL.md`.
- Add `skills/schematic-review/SKILL.md`.
- Update `README.md` with an Agent plugin and skills section, setup commands, and activation validation workflow.

## Validation performed

- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- Verified MCP tool references in the new skill files against `docs/tools-reference.generated.md`.
- `git diff --check`

## Related issues

Refs #298
Refs #299
Refs #300

## Notes

This PR does not activate the central `agent-tools` marketplace entry yet. The central catalog should move `kicad-pro` from `planned_plugins` to `plugins` only after this PR is merged and at least one compatible agent installation path is validated.