### PR TITLE
Add native agent runtime config for KiCad

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,96 +1,17 @@
 {
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "kicad-pro",
   "version": "3.19.0",
-  "description": "KiCad MCP Pro agent plugin for schematic review, PCB design assistance, DRC/ERC validation, DFM checks, and manufacturing release workflows.",
+  "description": "KiCad MCP Pro plugin for schematic review, PCB design assistance, DRC/ERC validation, DFM checks, and manufacturing release workflows.",
+  "skills": [
+    "./skills/kicad-design-review",
+    "./skills/pcb-design",
+    "./skills/drc-check",
+    "./skills/fabrication-output",
+    "./skills/schematic-review"
+  ],
   "author": {
     "name": "oaslananka",
     "url": "https://github.com/oaslananka"
-  },
-  "source": {
-    "source": "github",
-    "repo": "oaslananka/kicad-mcp"
-  },
-  "category": "engineering",
-  "tags": [
-    "kicad",
-    "pcb",
-    "eda",
-    "mcp",
-    "hardware",
-    "electronics",
-    "drc",
-    "erc",
-    "manufacturing"
-  ],
-  "mcp_servers": [
-    {
-      "name": "io.github.oaslananka/kicad-mcp-pro",
-      "title": "KiCad MCP Pro",
-      "description": "Production-grade MCP server for KiCad EDA automation.",
-      "package": {
-        "pypi": "kicad-mcp-pro",
-        "npm": "kicad-mcp-pro",
-        "oci": "ghcr.io/oaslananka/kicad-mcp-pro:3.19.0"
-      },
-      "transports": [
-        "stdio",
-        "streamable-http"
-      ],
-      "launch_examples": [
-        "uvx kicad-mcp-pro --transport stdio",
-        "uvx kicad-mcp-pro --transport streamable-http --host 127.0.0.1 --port 3334",
-        "npx kicad-mcp-pro --help"
-      ],
-      "registry_manifest": "server.json",
-      "tool_reference": "docs/tools-reference.generated.md",
-      "minimum_requirements": [
-        "Python 3.13+ when using the PyPI/uvx package.",
-        "Node.js 24.11+ and pnpm 11+ for source checkout development flows.",
-        "KiCad CLI 8.x, 9.x, or 10.x on PATH for file-backed DRC, ERC, and export tools."
-      ]
-    }
-  ],
-  "skills": [
-    {
-      "name": "kicad-design-review",
-      "path": "skills/kicad-design-review/SKILL.md",
-      "description": "Comprehensive KiCad design review workflow covering schematic, PCB, DFM, manufacturing, high-speed, and simulation checks."
-    },
-    {
-      "name": "pcb-design",
-      "path": "skills/pcb-design/SKILL.md",
-      "description": "Safe PCB design assistance workflow using KiCad MCP board, placement, routing, stackup, and quality-gate tools."
-    },
-    {
-      "name": "drc-check",
-      "path": "skills/drc-check/SKILL.md",
-      "description": "DRC/ERC execution, triage, waiver, and revalidation workflow for KiCad projects."
-    },
-    {
-      "name": "fabrication-output",
-      "path": "skills/fabrication-output/SKILL.md",
-      "description": "Manufacturing release workflow for Gerbers, drill files, BOM, pick-and-place, 3D, DFM, and release evidence."
-    },
-    {
-      "name": "schematic-review",
-      "path": "skills/schematic-review/SKILL.md",
-      "description": "Schematic inspection and review workflow using ERC, connectivity, symbol, net, and visual QA tools."
-    }
-  ],
-  "documentation": {
-    "readme": "README.md",
-    "installation": "docs/installation.md",
-    "client_configuration": "docs/client-configuration.md",
-    "tool_reference": "docs/tools-reference.generated.md",
-    "agent_plugin": "README.md#agent-plugin-and-skills"
-  },
-  "safety": {
-    "human_review_required": true,
-    "notes": [
-      "KiCad MCP Pro is an engineering assistant, not an autonomous sign-off authority.",
-      "Manufacturing output must be reviewed by a qualified human before fabrication or assembly.",
-      "ERC, DRC, DFM, export artifacts, and known waivers must be reported separately from assumptions."
-    ]
-  },
-  "status": "ready-for-catalog-validation"
+  }
 }

--- a/.codex/config.example.toml
+++ b/.codex/config.example.toml
@@ -1,0 +1,10 @@
+# Example Codex MCP configuration for KiCad MCP Pro.
+# Copy the [[mcp_servers]] block into your Codex config.toml and adjust paths/env if needed.
+
+[[mcp_servers]]
+name = "kicad-mcp-pro"
+command = "uvx"
+args = ["kicad-mcp-pro", "--transport", "stdio"]
+
+[mcp_servers.env]
+KICAD_MCP_TRANSPORT = "stdio"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "kicad-mcp-pro": {
+      "command": "uvx",
+      "args": [
+        "kicad-mcp-pro",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "KICAD_MCP_TRANSPORT": "stdio"
+      }
+    }
+  }
+}

--- a/.vscode/mcp.example.json
+++ b/.vscode/mcp.example.json
@@ -1,0 +1,16 @@
+{
+  "servers": {
+    "kicad-mcp-pro": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "kicad-mcp-pro",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "KICAD_MCP_TRANSPORT": "stdio"
+      }
+    }
+  }
+}

--- a/docs/agent-runtime-config.md
+++ b/docs/agent-runtime-config.md
@@ -1,0 +1,50 @@
+# Agent Runtime Configuration
+
+This document gives copyable configuration examples for running KiCad MCP Pro from popular MCP-capable agent runtimes.
+
+## Claude Code
+
+The repository includes both:
+
+- `.claude-plugin/plugin.json` with a native `mcpServers` entry.
+- `.mcp.json` with the same MCP server definition for project-local Claude Code usage.
+
+Validate the plugin locally:
+
+```bash
+claude plugin validate .
+```
+
+Run Claude Code with this plugin directory for one session:
+
+```bash
+claude --plugin-dir .
+```
+
+## Codex CLI
+
+Use `.codex/config.example.toml` as a starting point. Copy the `[[mcp_servers]]` block into your Codex config file and adjust command arguments if needed.
+
+## VS Code / GitHub Copilot
+
+Use `.vscode/mcp.example.json` as a workspace MCP configuration example. If your VS Code profile already has MCP servers configured globally, copy only the `kicad-mcp-pro` server block.
+
+## Cursor and other MCP clients
+
+Most MCP-compatible clients can use the same stdio launch command:
+
+```bash
+uvx kicad-mcp-pro --transport stdio
+```
+
+## Validation checklist
+
+1. Confirm the command starts: `uvx kicad-mcp-pro --help`.
+2. Validate plugin metadata: `claude plugin validate .`.
+3. Start an MCP-capable client with the configured server.
+4. Call a safe read-only diagnostic tool such as `kicad_get_server_info` or `kicad_get_project_info`.
+5. Use the KiCad skills only after the active project path and required KiCad installation state are clear.
+
+## Safety
+
+KiCad MCP Pro is an engineering assistant, not a manufacturing sign-off authority. ERC, DRC, DFM, fabrication exports, and all generated design changes require human engineering review.


### PR DESCRIPTION
## Summary

Hardens the KiCad agent/plugin packaging for popular MCP-capable agent runtimes.

## Changes

- Convert `.claude-plugin/plugin.json` to a Claude Code-valid plugin manifest.
- Add `.mcp.json` for project-local Claude Code MCP discovery.
- Add `.codex/config.example.toml` for Codex MCP configuration.
- Add `.vscode/mcp.example.json` for VS Code / GitHub Copilot-style workspace MCP configuration.
- Add `docs/agent-runtime-config.md` with Claude Code, Codex, VS Code/Copilot, Cursor/generic MCP setup notes and validation checklist.

## Validation performed

- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .mcp.json >/dev/null`
- `python3 -m json.tool .vscode/mcp.example.json >/dev/null`
- `claude plugin validate .`
- `git diff --check`

## Notes

The product-specific source repository remains the source of truth for KiCad skills and MCP runtime configuration. Marketplace/catalog metadata stays in `oaslananka/agent-tools`.