### PR TITLE
fix(schematic): resolve child sheets for read tools

### DIFF
--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -610,7 +610,7 @@ def _resolve_schematic_target(
     sheet: str | None = None,
     sheet_file: str | None = None,
 ) -> _SchematicTarget:
-    """Resolve an optional child-sheet target for file-backed write tools."""
+    """Resolve an optional child-sheet target for file-backed tools."""
     if sheet and sheet_file:
         raise ValueError("Use only one of sheet or sheet_file.")
 
@@ -5225,9 +5225,13 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool()
     @ttl_cache(ttl_seconds=5)
-    def sch_get_symbols() -> str:
-        """List all schematic symbols."""
-        sch_file = _get_schematic_file()
+    def sch_get_symbols(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """List all schematic symbols, optionally from a child sheet."""
+        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
+        sch_file = target.path
         data = parse_schematic_file(sch_file)
         symbols = data["symbols"] + data["power_symbols"]
         if not symbols:
@@ -5254,9 +5258,13 @@ def register(mcp: FastMCP) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
-    def sch_get_wires() -> str:
-        """List all wires in the schematic."""
-        sch_file = _get_schematic_file()
+    def sch_get_wires(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """List all wires in the schematic, optionally from a child sheet."""
+        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
+        sch_file = target.path
         wires = parse_schematic_file(sch_file)["wires"]
         if not wires:
             return _with_schematic_diagnostics(
@@ -5272,9 +5280,13 @@ def register(mcp: FastMCP) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
-    def sch_get_labels() -> str:
-        """List all labels in the schematic."""
-        sch_file = _get_schematic_file()
+    def sch_get_labels(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """List all labels in the schematic, optionally from a child sheet."""
+        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
+        sch_file = target.path
         labels = parse_schematic_file(sch_file)["labels"]
         if not labels:
             return _with_schematic_diagnostics(
@@ -5289,9 +5301,13 @@ def register(mcp: FastMCP) -> None:
         return "\n".join(lines)
 
     @mcp.tool()
-    def sch_get_net_names() -> str:
-        """List unique net names derived from labels."""
-        sch_file = _get_schematic_file()
+    def sch_get_net_names(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """List unique net names derived from labels, optionally from a child sheet."""
+        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
+        sch_file = target.path
         labels = parse_schematic_file(sch_file)["labels"]
         names = sorted({label["name"] for label in labels})
         if not names:

--- a/tests/integration/test_schematic_tools.py
+++ b/tests/integration/test_schematic_tools.py
@@ -1244,6 +1244,39 @@ async def test_schematic_create_and_inspect_child_sheets(sample_project, mock_ki
 
 
 @pytest.mark.anyio
+async def test_schematic_read_tools_resolve_child_sheet_labels(
+    sample_project,
+    mock_kicad,
+) -> None:
+    server = build_server("schematic")
+
+    await call_tool_text(
+        server,
+        "sch_create_sheet",
+        {"name": "Sub", "filename": "sub.kicad_sch", "x_mm": 40.64, "y_mm": 50.8},
+    )
+    await call_tool_text(
+        server,
+        "sch_add_hierarchical_label",
+        {
+            "text": "OUT",
+            "x_mm": 30.48,
+            "y_mm": 30.48,
+            "shape": "output",
+            "sheet": "Sub",
+        },
+    )
+
+    root_labels = await call_tool_text(server, "sch_get_labels", {})
+    child_labels = await call_tool_text(server, "sch_get_labels", {"sheet": "Sub"})
+    child_nets = await call_tool_text(server, "sch_get_net_names", {"sheet": "Sub"})
+
+    assert "OUT" not in root_labels
+    assert "OUT" in child_labels
+    assert "- OUT" in child_nets
+
+
+@pytest.mark.anyio
 async def test_schematic_global_and_hierarchical_labels_preserve_shape(
     sample_project,
     mock_kicad,


### PR DESCRIPTION
## Summary
- resolve optional `sheet` / `sheet_file` targets for schematic read tools
- fix `sch_get_labels(sheet=...)` reading the active/root schematic instead of the requested child sheet
- add a regression test for child-sheet hierarchical labels and net names

## Tests
- `uv run --all-extras ruff check src/kicad_mcp/tools/schematic.py tests/integration/test_schematic_tools.py`
- `uv run --all-extras ruff format --check src/kicad_mcp/tools/schematic.py tests/integration/test_schematic_tools.py`
- `uv run --all-extras pytest tests/integration/test_schematic_tools.py -k 'read_tools_resolve_child_sheet_labels or create_and_inspect_child_sheets or add_label' -q`

Closes #307