### PR TITLE
docs: define live preview UX and stability contract

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -21,3 +21,26 @@ Security fixes may bypass the full deprecation window when preserving behavior w
 ## Breaking Changes
 
 Breaking changes require a PR label, changelog entry, migration note, and, for major public workflow changes, an RFC.
+
+## Live-preview workflow stability
+
+`sch_live_preview()` is a documented agent workflow surface, but clients must
+separate stable workflow semantics from evolving implementation metadata.
+
+Stable for client use:
+
+- baseline, no-change, debounce-pending, changed, and rendered status concepts;
+- watched-file and changed-file evidence;
+- rendered PNG artifact evidence when rendering succeeds;
+- child-sheet inclusion as the default watch behavior;
+- artifact-first safety guidance for companion-plugin and agent flows.
+
+Evolving metadata:
+
+- richer manifest files;
+- additional visual-evidence artifact indexes;
+- more detailed debounce timing fields;
+- GUI-facing confirmation and session-consent metadata.
+
+Clients should ignore unknown fields in live-preview responses and should not
+parse human-readable messages when a structured field is available.

--- a/docs/integration/companion-plugin.md
+++ b/docs/integration/companion-plugin.md
@@ -79,7 +79,7 @@ the dependency-free helpers are covered by `tests/unit/test_companion_context.py
 
 The companion plugin must keep live-preview feedback artifact-first by default.
 A plugin button or agent command may request `sch_live_preview(render=true)` to
-produce a preview image, but it must not silently force the user's open KiCad GUI
+produce a preview image, but it must not silently change the user's open KiCad GUI
 state to update.
 
 Recommended UX contract:

--- a/docs/integration/companion-plugin.md
+++ b/docs/integration/companion-plugin.md
@@ -74,3 +74,27 @@ the dependency-free helpers are covered by `tests/unit/test_companion_context.py
 - It does not request filesystem or network permissions beyond the loopback POST.
 - Mutating operations are listed in `SAFE_APPLY_ACTIONS` and always require an
   explicit confirmation via `confirm_safe_apply`.
+
+## Live-preview opt-in refresh UX
+
+The companion plugin must keep live-preview feedback artifact-first by default.
+A plugin button or agent command may request `sch_live_preview(render=true)` to
+produce a preview image, but it must not silently force the user's open KiCad GUI
+state to update.
+
+Recommended UX contract:
+
+1. Show a clear action label such as **Refresh preview evidence** for ordinary
+   artifact generation.
+2. Use a separate, explicit action label such as **Refresh open KiCad view** for
+   GUI-facing behavior.
+3. Before any GUI-facing refresh, show a confirmation dialog explaining that the
+   MCP server cannot prove whether the editor has unsaved human changes.
+4. Remember consent only for the current plugin session; do not persist it across
+   KiCad restarts.
+5. Surface the resulting status in the dialog or status pane, including whether
+   the operation produced a PNG artifact, skipped because no change was detected,
+   or failed with a renderer diagnostic.
+
+Agents should treat preview PNGs, visual diffs, and visual QA results as evidence
+for review, not as proof that a human user's editor tab has been updated.


### PR DESCRIPTION
## Summary

- Define companion-plugin live-preview opt-in UX.
- Document live-preview workflow stability expectations in API stability guidance.
- Clarify stable response concepts and evolving metadata.

## Validation

- uv run mkdocs build --strict

Closes #320
Closes #321
Refs #314