### PR TITLE
docs: add llms.txt for AI discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
   <a href="docs/installation.md">Installation</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="docs/tools-reference.generated.md">Tool Reference</a> ·
-  <a href="https://oaslananka.github.io/kicad-mcp/agents/">AI Agent Setup</a>
+  <a href="https://oaslananka.github.io/kicad-mcp/agents/">AI Agent Setup</a> ·
+  <a href="docs/llms.txt">AI discovery</a>
 </p>
 
 <p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ The docs are ordered from first setup to operations and maintenance.
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 - [Comparison](comparison.md)
+- [AI Discovery](llms.txt)
 
 ### Reference and status
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,37 @@
+# KiCad MCP Pro
+
+> AI-ready Model Context Protocol server for KiCad EDA workflows. It lets MCP-capable agents inspect, automate, validate, and review KiCad schematic, PCB, ERC, DRC, DFM, BOM, and manufacturing export workflows.
+
+## Canonical links
+
+- GitHub: https://github.com/oaslananka/kicad-mcp
+- Documentation: https://oaslananka.github.io/kicad-mcp/
+- PyPI: https://pypi.org/project/kicad-mcp-pro/
+- npm: https://www.npmjs.com/package/kicad-mcp-pro
+- MCP Registry name: io.github.oaslananka/kicad-mcp-pro
+
+## Core docs
+
+- Installation: https://oaslananka.github.io/kicad-mcp/installation/
+- Client configuration: https://oaslananka.github.io/kicad-mcp/client-configuration/
+- Tool reference: https://oaslananka.github.io/kicad-mcp/tools-reference/
+- AI agent setup: https://oaslananka.github.io/kicad-mcp/agents/
+- API stability: https://oaslananka.github.io/kicad-mcp/api-stability/
+- Security and privacy: https://oaslananka.github.io/kicad-mcp/security/threat-model/
+- Safe live-preview workflow: https://oaslananka.github.io/kicad-mcp/workflows/live-preview/
+
+## Scope and safety
+
+KiCad MCP Pro is a professional first-pass design and review assistant. It does not replace human engineering sign-off, fabrication review, or formal safety validation. Agents should use structured tool output, rendered evidence, ERC/DRC/DFM checks, and human review before release or manufacturing decisions.
+
+## Recommended first agent workflow
+
+1. Inspect the current KiCad project and schematic hierarchy.
+2. Summarize ERC/DRC-relevant issues without modifying files.
+3. Render a schematic preview and inspect visual evidence.
+4. Plan changes before using write tools.
+5. Re-run preview, ERC/DRC, DFM, and export checks after modifications.
+
+## Keywords
+
+KiCad MCP, KiCad automation, AI PCB design, EDA automation, Model Context Protocol, Claude MCP, Cursor MCP, GitHub Copilot MCP, schematic automation, PCB automation, ERC, DRC, DFM, BOM, manufacturing export, live preview, visual evidence, MCP server, Python, PyPI, npm.


### PR DESCRIPTION
## Summary

- Add `docs/llms.txt` for AI and answer-engine discovery.
- Link the discovery file from the README top navigation.
- Link the discovery file from the documentation index.

## Validation

- uv run mkdocs build --strict

Refs #314