### PR TITLE
docs: add README demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ configuration is documented in
 [`docs/configuration.md`](docs/configuration.md#opentelemetry), and privacy rules
 are documented in [`docs/privacy.md`](docs/privacy.md).
 
+## See it in action
+
+![KiCad MCP Pro terminal demo](docs/assets/demo.gif)
+
+Run a health check, inspect doctor output, and start the MCP server before connecting Claude, Cursor, Copilot, or another MCP-capable agent. See the [demo notes](docs/demo.md) for the reproducible cast and replacement rules.
+
+```text
+Open the current KiCad project, inspect the schematic hierarchy, list ERC-relevant issues, render a schematic preview, and explain what changed without modifying files.
+```
+
 ## Scope and honesty
 
 KiCad MCP Pro is a **professional first-pass design and review assistant**, not an

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,30 @@
+# Demo
+
+This page collects the short demo media used by the README and release/reviewer flows.
+
+![KiCad MCP Pro terminal demo](assets/demo.gif)
+
+## What the demo shows
+
+The current bundled demo is a deterministic, redacted terminal capture. It shows a safe first-run posture for KiCad MCP Pro:
+
+1. run a health check;
+2. inspect doctor output;
+3. start the MCP server;
+4. confirm that the server is ready for an MCP-capable client.
+
+The demo is intentionally conservative. It does not claim fabrication readiness and does not include real project paths, hostnames, API tokens, or private design files.
+
+## Try a first agent prompt
+
+```text
+Open the current KiCad project, inspect the schematic hierarchy, list ERC-relevant issues, render a schematic preview, and explain what changed without modifying files.
+```
+
+For agent setup, see the [AI agent setup docs](agents/index.md). For a live-preview workflow that produces visual evidence after schematic edits, see [Safe live-preview workflow](workflows/live-preview.md).
+
+## Source files
+
+- GIF: [`assets/demo.gif`](assets/demo.gif)
+- Asciinema cast: [`assets/demo.cast`](assets/demo.cast)
+- Maintenance notes: [`demo-media.md`](demo-media.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ The docs are ordered from first setup to operations and maintenance.
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 - [Comparison](comparison.md)
+- [Demo](demo.md)
 
 ### Reference and status
 


### PR DESCRIPTION
## Summary

- Add a visible README "See it in action" demo section using the existing demo GIF.
- Add `docs/demo.md` with the reproducible demo context and first safe agent prompt.
- Link the demo page from the documentation index.

## Validation

- uv run mkdocs build --strict