### PR TITLE
docs: add MCP Registry status page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ The docs are ordered from first setup to operations and maintenance.
 - [Client Config Generator](install/client-config-generator.md)
 - [Publishing](publishing.md)
 - [Public Listings](public-listing.md)
+- [MCP Registry Status](registry.md)
 
 ### Integrations
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,45 @@
+# MCP Registry status
+
+KiCad MCP Pro publishes registry metadata from the repository-level `server.json` manifest.
+
+## Canonical identity
+
+| Field | Value |
+| --- | --- |
+| Registry name | `io.github.oaslananka/kicad-mcp-pro` |
+| Repository | `https://github.com/oaslananka/kicad-mcp` |
+| Documentation | `https://oaslananka.github.io/kicad-mcp/` |
+| PyPI package | `kicad-mcp-pro` |
+| npm package | `kicad-mcp-pro` |
+| Current manifest version | `3.20.0` |
+
+## Source of truth
+
+- `server.json` is the registry manifest source of truth.
+- `pyproject.toml`, package metadata, and `server.json` must stay synchronized.
+- Registry publication should use the documented dry-run flow before any live publish.
+- Live publication requires maintainer review and should not run from a dirty tree.
+
+## Validation commands
+
+Run these before registry submission or release handoff:
+
+```bash
+corepack pnpm run mcp:manifest:check
+corepack pnpm run metadata:check
+corepack pnpm run publish:mcp:dry-run
+corepack pnpm run submission:check
+```
+
+The first two checks were verified locally while adding this page. The dry-run and submission checks remain the release operator's final gate because they may depend on network reachability and registry-side availability.
+
+## CI coverage
+
+`check:meta` includes `metadata:check` and `mcp:manifest:check`, so ordinary CI catches most metadata drift before release. Release readiness also runs `submission:check` through `check:release`.
+
+## Related docs
+
+- [OpenAI MCP Registry submission](submission/openai-mcp-registry.md)
+- [Public listings](public-listing.md)
+- [Release process](release-process.md)
+- [MCP transport](mcp/transport.md)


### PR DESCRIPTION
## Summary

- Add a dedicated MCP Registry status page for the canonical registry identity and manifest source of truth.
- Document validation commands for manifest, metadata, dry-run, and submission checks.
- Link the page from the documentation index.

## Validation

- corepack pnpm run mcp:manifest:check
- corepack pnpm run metadata:check
- uv run mkdocs build --strict