### PR TITLE
feat: persist live preview manifest artifacts

### DIFF
--- a/src/kicad_mcp/models/live_preview.py
+++ b/src/kicad_mcp/models/live_preview.py
@@ -317,9 +317,7 @@ def _persist_manifest_artifact(payload: LivePreviewPayload) -> LivePreviewPayloa
         mime_type="application/json",
     )
     manifest = payload.to_manifest()
-    manifest = manifest.model_copy(
-        update={"artifacts": [*manifest.artifacts, manifest_artifact]}
-    )
+    manifest = manifest.model_copy(update={"artifacts": [*manifest.artifacts, manifest_artifact]})
     update: dict[str, Any] = {
         "manifest": manifest,
         "manifest_path": str(manifest_path),

--- a/src/kicad_mcp/models/live_preview.py
+++ b/src/kicad_mcp/models/live_preview.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Literal, get_args
 from uuid import uuid4
 
@@ -237,7 +238,7 @@ class LivePreviewPayload(BaseModel):
             state=debounce_state,
             pending_observed_at_ns=payload.get("pending_observed_at_ns"),
         )
-        return cls(
+        normalized = cls(
             status=status if status in get_args(LivePreviewStatus) else "changed",
             outcome=outcome,
             target=str(payload.get("target", "schematic")),
@@ -259,6 +260,7 @@ class LivePreviewPayload(BaseModel):
             render=render,
             message=payload.get("message"),
         )
+        return _persist_manifest_artifact(normalized) if render_artifacts else normalized
 
     def to_manifest(self) -> LivePreviewManifest:
         """Create a manifest from the normalized payload."""
@@ -289,3 +291,45 @@ class LivePreviewPayload(BaseModel):
             render=self.render,
             artifacts=artifacts,
         )
+
+
+def _manifest_artifact_path(payload: LivePreviewPayload) -> Path | None:
+    if payload.render.png_path:
+        png_path = Path(payload.render.png_path)
+        return png_path.with_name(f"{png_path.stem}.manifest.json")
+    if payload.render.svg_path:
+        svg_path = Path(payload.render.svg_path)
+        return svg_path.with_name(f"{svg_path.stem}.manifest.json")
+    if payload.target_path:
+        target_path = Path(payload.target_path)
+        return target_path.with_name(f"{target_path.stem}.live-preview.manifest.json")
+    return None
+
+
+def _persist_manifest_artifact(payload: LivePreviewPayload) -> LivePreviewPayload:
+    manifest_path = _manifest_artifact_path(payload)
+    if manifest_path is None:
+        return payload
+    manifest_artifact = LivePreviewArtifact(
+        kind="json",
+        path=str(manifest_path),
+        role="session-manifest",
+        mime_type="application/json",
+    )
+    manifest = payload.to_manifest()
+    manifest = manifest.model_copy(
+        update={"artifacts": [*manifest.artifacts, manifest_artifact]}
+    )
+    update: dict[str, Any] = {
+        "manifest": manifest,
+        "manifest_path": str(manifest_path),
+    }
+    if not manifest_path.parent.exists():
+        return payload.model_copy(update=update)
+    try:
+        manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+    except OSError as exc:
+        update["warnings"] = [*payload.warnings, f"Unable to write live-preview manifest: {exc}"]
+        return payload.model_copy(update=update)
+    update["render_artifacts"] = [*payload.render_artifacts, manifest_artifact]
+    return payload.model_copy(update=update)

--- a/tests/unit/test_live_preview_contract.py
+++ b/tests/unit/test_live_preview_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -132,6 +133,42 @@ def test_live_preview_manifest_indexes_visual_artifacts() -> None:
         ("svg", "source-render", SVG_PATH),
     ]
     json.loads(manifest.model_dump_json())
+
+
+def test_live_preview_payload_persists_manifest_json_with_visual_artifacts(
+    tmp_path: Path,
+) -> None:
+    root_sch = tmp_path / "demo.kicad_sch"
+    child_sch = tmp_path / "sub.kicad_sch"
+    png_path = tmp_path / "live.png"
+    svg_path = tmp_path / "live.svg"
+
+    payload = LivePreviewPayload.from_legacy_payload(
+        {
+            "status": "changed_rendered",
+            "target": "root schematic",
+            "target_path": str(root_sch),
+            "watch_files": [str(root_sch), str(child_sch)],
+            "changed_files": [str(child_sch)],
+            "render": {
+                "status": "ok",
+                "sheet_path": str(child_sch),
+                "png_path": str(png_path),
+                "svg_path": str(svg_path),
+            },
+        }
+    )
+
+    assert payload.manifest_path == str(tmp_path / "live.manifest.json")
+    assert payload.manifest is not None
+    manifest_path = Path(payload.manifest_path)
+    assert manifest_path.exists()
+    persisted = json.loads(manifest_path.read_text())
+    assert persisted["schema_version"] == "live-preview.manifest.v1"
+    assert persisted["session_id"] == payload.session_id
+    assert [item["kind"] for item in persisted["artifacts"]] == ["png", "svg", "json"]
+    assert payload.render_artifacts[-1].kind == "json"
+    assert payload.render_artifacts[-1].role == "session-manifest"
 
 
 def test_live_preview_debounce_bounds_are_schema_validated() -> None:


### PR DESCRIPTION
## Summary

- Persist a `live-preview.manifest.v1` JSON manifest when a normalized live-preview payload includes visual render artifacts.
- Store the manifest next to the rendered preview artifact as `<render-name>.manifest.json`.
- Add the manifest JSON artifact to `render_artifacts` with `role=session-manifest` and `mime_type=application/json`.
- Add unit coverage that asserts the manifest file is written and indexes PNG, SVG, and JSON artifacts.

## Validation

- `python3 -m py_compile src/kicad_mcp/models/live_preview.py tests/unit/test_live_preview_contract.py`
- `uv run --all-extras ruff format src/kicad_mcp/models/live_preview.py tests/unit/test_live_preview_contract.py`
- `uv run --all-extras ruff check src/kicad_mcp/models/live_preview.py tests/unit/test_live_preview_contract.py`

The targeted pytest command was attempted, but the remote execution safety filter blocked its output in this environment.

Closes #318
Refs #314