### PR TITLE
fix: default schematic snap grid to 50 mil

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,19 @@ interop aliases for launchers and editors:
 Diagnostics only report whether tokens are configured. Token values are never
 printed.
 
+
+## Schematic Grid Defaults
+
+Schematic write tools keep snapping enabled by default and use a 1.27 mm / 50 mil grid. This matches common KiCad library symbols, including `Device:R`, whose pins may not land cleanly on a 2.54 mm / 100 mil grid when the symbol body is centered. Agents should prefer the default snapped behavior instead of disabling snap globally.
+
+Set `KICAD_MCP_SCHEMATIC_GRID_MM` before server startup to override the schematic snap grid for a project or launcher:
+
+```bash
+KICAD_MCP_SCHEMATIC_GRID_MM=1.27
+```
+
+Invalid, zero, negative, or unreasonably large values fall back to the built-in 1.27 mm default. PCB placement grid defaults are independent and are not changed by this setting.
+
 ## KiCad IPC Capability Discovery
 
 `kicad_get_server_info` reports the live IPC state that MCP clients use to gate

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -5480,7 +5480,7 @@ def register(mcp: FastMCP) -> None:
     ) -> str:
         """Add a schematic symbol at an absolute coordinate.
 
-        Coordinates snap to the 2.54 mm schematic grid by default; set
+        Coordinates snap to the 1.27 mm / 50 mil schematic grid by default; set
         snap_to_grid=False only when an exact off-grid coordinate is intentional.
         """
         payload = AddSymbolInput(
@@ -5598,7 +5598,7 @@ def register(mcp: FastMCP) -> None:
         sheet: str | None = None,
         sheet_file: str | None = None,
     ) -> str:
-        """Add a schematic wire, snapping endpoints to the 2.54 mm grid by default."""
+        """Add a schematic wire, snapping endpoints to the 1.27 mm / 50 mil grid by default."""
         payload = AddWireInput(
             x1_mm=x1_mm,
             y1_mm=y1_mm,
@@ -5639,7 +5639,7 @@ def register(mcp: FastMCP) -> None:
         sheet: str | None = None,
         sheet_file: str | None = None,
     ) -> str:
-        """Add a schematic label, snapping its anchor to the 2.54 mm grid by default."""
+        """Add a schematic label, snapping its anchor to the 1.27 mm / 50 mil grid by default."""
         label_text = name or text
         if not label_text:
             raise ValueError("Either name or text parameter is required.")
@@ -5855,7 +5855,7 @@ def register(mcp: FastMCP) -> None:
         sheet: str | None = None,
         sheet_file: str | None = None,
     ) -> str:
-        """Add a power symbol, snapping its anchor to the 2.54 mm grid by default."""
+        """Add a power symbol, snapping its anchor to the 1.27 mm / 50 mil grid by default."""
         placed_x, placed_y = _snap_point(x_mm, y_mm, snap_to_grid)
         result = str(
             sch_add_symbol(
@@ -5886,7 +5886,7 @@ def register(mcp: FastMCP) -> None:
         sheet: str | None = None,
         sheet_file: str | None = None,
     ) -> str:
-        """Add a schematic bus, snapping endpoints to the 2.54 mm grid by default."""
+        """Add a schematic bus, snapping endpoints to the 1.27 mm / 50 mil grid by default."""
         payload = AddBusInput(
             x1_mm=x1_mm,
             y1_mm=y1_mm,
@@ -5925,7 +5925,10 @@ def register(mcp: FastMCP) -> None:
         sheet: str | None = None,
         sheet_file: str | None = None,
     ) -> str:
-        """Add a bus wire entry marker, snapping its anchor to the 2.54 mm grid by default."""
+        """Add a bus wire entry marker.
+
+        Snaps its anchor to the 1.27 mm / 50 mil grid by default.
+        """
         payload = AddBusWireEntryInput(
             x_mm=x_mm,
             y_mm=y_mm,
@@ -5953,7 +5956,7 @@ def register(mcp: FastMCP) -> None:
         sheet: str | None = None,
         sheet_file: str | None = None,
     ) -> str:
-        """Add a no-connect marker, snapping it to the 2.54 mm grid by default."""
+        """Add a no-connect marker, snapping it to the 1.27 mm / 50 mil grid by default."""
         payload = AddNoConnectInput(x_mm=x_mm, y_mm=y_mm, snap_to_grid=snap_to_grid)
         target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
         marker_x, marker_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
@@ -6336,7 +6339,7 @@ def register(mcp: FastMCP) -> None:
         given coordinate. Use sch_get_labels() to find exact names/positions."""
         tol = 0.05
         removed = 0
-        # sch_add_label snaps to the 2.54 mm grid by default, so a label placed at
+        # sch_add_label snaps to the schematic grid by default, so a label placed at
         # (50, 50) actually lands at (50.8, 50.8). Match against both the raw query
         # point and its grid-snapped position so the obvious add/delete round trip
         # works, while still deleting labels that were placed off-grid.
@@ -6516,7 +6519,7 @@ def register(mcp: FastMCP) -> None:
         schematic without erasing it use ``sch_add_symbol`` / ``sch_add_wire`` /
         ``sch_add_label`` instead.
 
-        Coordinates are snapped to the 2.54 mm grid by default.  When no coordinates
+        Coordinates are snapped to the 1.27 mm / 50 mil grid by default.  When no coordinates
         are provided for a symbol, set ``auto_layout=True`` so the placement engine
         assigns non-overlapping positions automatically.
 

--- a/src/kicad_mcp/tools/schematic_constants.py
+++ b/src/kicad_mcp/tools/schematic_constants.py
@@ -5,16 +5,34 @@ have a single, import-light source of truth for grid sizes, paper dimensions,
 auto-layout spacing, power-net naming and the public tool-name list. Keeping these
 here lets future domain submodules and the router share them without importing the
 heavy registration module. This is the first incremental slice of the #161 split;
-behaviour and values are unchanged.
+behaviour is kept centralized and safe defaults may evolve here.
 """
 
 from __future__ import annotations
+
+import os
 
 # ---------------------------------------------------------------------------
 # Grid / snap
 # ---------------------------------------------------------------------------
 
-SCHEMATIC_GRID_MM = 2.54
+DEFAULT_SCHEMATIC_GRID_MM = 1.27
+
+
+def _schematic_grid_from_env() -> float:
+    raw = os.getenv("KICAD_MCP_SCHEMATIC_GRID_MM")
+    if raw is None or raw.strip() == "":
+        return DEFAULT_SCHEMATIC_GRID_MM
+    try:
+        grid_mm = float(raw)
+    except ValueError:
+        return DEFAULT_SCHEMATIC_GRID_MM
+    if grid_mm <= 0.0 or grid_mm > 25.4:
+        return DEFAULT_SCHEMATIC_GRID_MM
+    return round(grid_mm, 4)
+
+
+SCHEMATIC_GRID_MM = _schematic_grid_from_env()
 SNAP_TOLERANCE_MM = 1e-6
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_schematic_grid.py
+++ b/tests/unit/test_schematic_grid.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+
+import kicad_mcp.tools.schematic_constants as schematic_constants
+from kicad_mcp.tools import schematic
+
+
+def test_schematic_default_grid_is_50_mil() -> None:
+    assert schematic_constants.DEFAULT_SCHEMATIC_GRID_MM == 1.27
+    assert schematic_constants.SCHEMATIC_GRID_MM == 1.27
+    assert schematic._snap_schematic_coord(2.0) == 2.54
+    assert schematic._snap_schematic_coord(3.2) == 3.81
+
+
+def test_schematic_grid_override(monkeypatch) -> None:
+    monkeypatch.setenv("KICAD_MCP_SCHEMATIC_GRID_MM", "0.635")
+    reloaded = importlib.reload(schematic_constants)
+    try:
+        assert reloaded.SCHEMATIC_GRID_MM == 0.635
+    finally:
+        monkeypatch.delenv("KICAD_MCP_SCHEMATIC_GRID_MM", raising=False)
+        importlib.reload(schematic_constants)
+
+
+def test_schematic_grid_invalid_values_fall_back(monkeypatch) -> None:
+    for value in ["", "nope", "-1", "0", "100"]:
+        monkeypatch.setenv("KICAD_MCP_SCHEMATIC_GRID_MM", value)
+        reloaded = importlib.reload(schematic_constants)
+        assert reloaded.SCHEMATIC_GRID_MM == 1.27
+    monkeypatch.delenv("KICAD_MCP_SCHEMATIC_GRID_MM", raising=False)
+    importlib.reload(schematic_constants)

--- a/tests/unit/test_sexpr.py
+++ b/tests/unit/test_sexpr.py
@@ -372,15 +372,16 @@ def test_schematic_routing_endpoint_helpers_cover_fallbacks() -> None:
 
 
 def test_terminal_stub_length_scales_with_net_name() -> None:
-    from kicad_mcp.tools.schematic import _terminal_stub_length
+    from kicad_mcp.tools.schematic import SCHEMATIC_GRID_MM, _terminal_stub_length
 
     # Short names keep the historical 5.08 mm stub; long names are pushed out so
-    # the global-label text clears the symbol body, snapped to the 2.54 mm grid.
+    # the global-label text clears the symbol body, snapped to the configured
+    # schematic grid. The default grid is 50 mil, but deployments may override it.
     assert _terminal_stub_length("GND") == 5.08
     assert _terminal_stub_length("3V3") == 5.08
     long_stub = _terminal_stub_length("VBUS_5V")
     assert long_stub > 5.08
-    assert abs(long_stub / 2.54 - round(long_stub / 2.54)) < 1e-6  # grid-aligned
+    assert abs(long_stub / SCHEMATIC_GRID_MM - round(long_stub / SCHEMATIC_GRID_MM)) < 1e-6
 
 
 def test_pin_alias_resolves_diff_pair_and_duplicate_contacts() -> None:


### PR DESCRIPTION
## Summary

- Change schematic snap-grid default from 2.54 mm / 100 mil to 1.27 mm / 50 mil.
- Keep snapping enabled by default so agents do not need `snap_to_grid=False` for common KiCad library symbols.
- Add `KICAD_MCP_SCHEMATIC_GRID_MM` as a startup-time override with safe fallback for invalid values.
- Document the default and override in configuration docs.
- Add unit tests for the default grid, env override, and invalid override fallback.

## Validation

- `python3 -m py_compile src/kicad_mcp/tools/schematic_constants.py src/kicad_mcp/tools/schematic.py tests/unit/test_schematic_grid.py`
- `uv run --all-extras ruff check src/kicad_mcp/tools/schematic_constants.py src/kicad_mcp/tools/schematic.py tests/unit/test_schematic_grid.py`
- `uv run --all-extras python -m pytest tests/unit/test_schematic_grid.py -q`
- `uv run --all-extras python -m pytest tests/integration/test_schematic_tools.py -q`
- `uv run mkdocs build --strict`

Closes #349
Refs #314