### PR TITLE
fix: clarify live preview reload request contract

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -33,14 +33,18 @@ Stable for client use:
 - watched-file and changed-file evidence;
 - rendered PNG artifact evidence when rendering succeeds;
 - child-sheet inclusion as the default watch behavior;
-- artifact-first safety guidance for companion-plugin and agent flows.
+- artifact-first safety guidance for companion-plugin and agent flows;
+- the distinction between a GUI reload request and a confirmed GUI document reload.
 
 Evolving metadata:
 
 - richer manifest files;
 - additional visual-evidence artifact indexes;
 - more detailed debounce timing fields;
-- GUI-facing confirmation and session-consent metadata.
+- GUI-facing confirmation and session-consent metadata;
+- upstream KiCad issue links that explain reload limitations.
+
+For schematic GUI refresh, `reload_attempted=true` means the MCP server made a best-effort GUI-facing request. It does not imply that the already-open KiCad schematic document was confirmed to reload from disk. Clients must prefer `render_artifacts`, `manifest_path`, and structured visual evidence as authoritative review data.
 
 Clients should ignore unknown fields in live-preview responses and should not
 parse human-readable messages when a structured field is available.

--- a/docs/workflows/live-preview-runtime-contract-status.md
+++ b/docs/workflows/live-preview-runtime-contract-status.md
@@ -5,10 +5,14 @@ This branch wires the typed live-preview payload model into the existing `sch_li
 ## Implemented
 
 - The legacy live-preview response is normalized through the typed contract model before it is returned.
-- Agent-facing fields are now available from the structured response contract: `schema_version`, `tool`, `session_id`, `project_path`, `project_ref`, `watched_files`, `changed_files`, `debounce_ms`, `outcome`, `reload_attempted`, `reload_outcome`, `render_artifacts`, `warnings`, `unsafe_state`, and `next_actions`.
-- The contract model distinguishes rendered, reloaded, skipped, pending, fallback, and error-like outcomes.
+- Agent-facing fields are now available from the structured response contract: `schema_version`, `tool`, `session_id`, `project_path`, `project_ref`, `watched_files`, `changed_files`, `debounce_ms`, `outcome`, `reload_attempted`, `reload_outcome`, `reload_confirmed`, `reload_mode`, `upstream_blockers`, `render_artifacts`, `warnings`, `unsafe_state`, and `next_actions`.
+- The contract model distinguishes rendered, reload-requested, confirmed-reloaded, skipped, pending, fallback, and error-like outcomes.
 - The manifest model can produce a `live-preview.manifest.v1` JSON shape from the normalized payload.
-- Unit contract tests cover rendered output, reload distinction, render failure, manifest artifact indexing, and debounce bounds.
+- Unit contract tests cover rendered output, best-effort GUI reload requests, render failure, manifest artifact indexing, and debounce bounds.
+
+## Reload semantics
+
+`reload_attempted=true` records a best-effort GUI-facing request. It does not prove that the already-open KiCad schematic document reloaded from disk. Until KiCad exposes a confirmed silent schematic `RevertDocument` IPC path, clients must treat rendered artifacts and manifests as the authoritative review evidence. The upstream blocker is <https://gitlab.com/kicad/code/kicad/-/work_items/24803>.
 
 ## Still pending
 
@@ -20,4 +24,4 @@ Runtime manifest file emission from `sch_live_preview()` is not yet enabled in t
 - `uv run --all-extras ruff format src/kicad_mcp/models/live_preview.py src/kicad_mcp/tools/schematic.py tests/unit/test_live_preview_contract.py`
 - `uv run --all-extras ruff check src/kicad_mcp/models/live_preview.py src/kicad_mcp/tools/schematic.py tests/unit/test_live_preview_contract.py`
 
-The local pytest invocation for `tests/unit/test_live_preview_contract.py` was attempted but the remote execution safety filter blocked the command output in this environment.
+`uv run --all-extras python -m pytest tests/unit/test_live_preview_contract.py -q`

--- a/docs/workflows/live-preview.md
+++ b/docs/workflows/live-preview.md
@@ -20,7 +20,7 @@ The safe default is artifact-based feedback. The tool should prefer rendered PNG
 
 The MCP process cannot reliably prove that a human has no unsaved KiCad GUI edits. For that reason, GUI refresh behavior must remain explicit and operator-approved. Agents must not treat a rendered PNG as proof that the KiCad GUI has refreshed its open editor tab.
 
-`reload=true` is a best-effort GUI-facing request, not a guarantee that KiCad will reload the already-open schematic document from disk. KiCad `View -> Refresh` may redraw the viewport without re-reading the schematic file. Agent workflows must therefore treat `render`, `render_artifacts`, and the live-preview manifest as the authoritative review evidence.
+`reload=true` is a best-effort GUI-facing request, not a guarantee that KiCad will reload the already-open schematic document from disk. KiCad `View -> Refresh` may redraw the viewport without re-reading the schematic file. In KiCad 10, the schematic editor does not expose a confirmed silent `RevertDocument` IPC path equivalent to PCB, so live-preview responses distinguish `reload_attempted` from `reload_confirmed`. Track the upstream blocker at <https://gitlab.com/kicad/code/kicad/-/work_items/24803>. Agent workflows must therefore treat `render`, `render_artifacts`, and the live-preview manifest as the authoritative review evidence.
 
 ## Recommended agent sequence
 
@@ -40,7 +40,7 @@ The MCP process cannot reliably prove that a human has no unsaved KiCad GUI edit
 - `sch_render_png()` renders one selected schematic sheet to a PNG artifact.
 - `sch_render_visual_diff()` compares schematic visual state before and after changes.
 - `sch_visual_qa()` checks visual readability and schematic presentation defects.
-- `sch_reload()` is a separate GUI-facing operation and should be treated as best-effort. It should not be used blindly in automated flows.
+- `sch_reload()` is a separate GUI-facing operation and should be treated as best-effort. It means a reload was requested, not that the GUI document was confirmed to have reloaded from disk. It should not be used blindly in automated flows.
 
 ## Child sheets
 
@@ -69,7 +69,11 @@ Agent code should read structured fields instead of parsing human-readable messa
 - `signature`: per-file size, mtime, and digest evidence;
 - `render`: generated image artifact metadata when rendering succeeds or fails;
 - `render_artifacts`: PNG, SVG, and manifest evidence artifacts associated with the preview;
-- `manifest_path`: durable JSON manifest path when manifest persistence succeeds.
+- `manifest_path`: durable JSON manifest path when manifest persistence succeeds;
+- `reload_attempted`: whether a GUI-facing reload request was sent;
+- `reload_confirmed`: whether the workflow can prove the GUI document reloaded from disk. This is normally `false` for schematic reload requests on KiCad 10;
+- `reload_outcome`: `requested` for best-effort GUI reload requests, not a confirmation of disk reload;
+- `upstream_blockers`: upstream KiCad issues that limit stronger GUI reload guarantees.
 
 Agents should ignore unknown fields for forward compatibility.
 

--- a/src/kicad_mcp/models/live_preview.py
+++ b/src/kicad_mcp/models/live_preview.py
@@ -26,12 +26,24 @@ LivePreviewOutcome = Literal[
     "pending",
     "changed",
     "rendered",
+    "reload_requested",
     "reloaded",
     "error",
     "fallback",
 ]
 ArtifactKind = Literal["png", "svg", "json", "junit", "environment"]
 RenderStatus = Literal["ok", "failed", "empty_sheet", "skipped"]
+
+SCHEMATIC_GUI_RELOAD_BEST_EFFORT_WARNING = (
+    "KiCad schematic GUI reload is best-effort only; treat rendered artifacts "
+    "and the manifest as authoritative review evidence."
+)
+SCHEMATIC_GUI_RELOAD_UNCONFIRMED_WARNING = (
+    "Schematic GUI disk reload was requested but not confirmed. KiCad 10 does "
+    "not expose a confirmed silent schematic RevertDocument IPC path equivalent "
+    "to PCB."
+)
+SCHEMATIC_GUI_RELOAD_UPSTREAM_BLOCKER_URL = "https://gitlab.com/kicad/code/kicad/-/work_items/24803"
 
 
 class LivePreviewArtifact(BaseModel):
@@ -129,6 +141,13 @@ class LivePreviewPayload(BaseModel):
     debounce_ms: int = Field(default=750, ge=0, le=60_000)
     reload_attempted: bool = False
     reload_outcome: str = "skipped"
+    reload_confirmed: bool = False
+    reload_mode: Literal[
+        "skipped",
+        "best_effort_gui_request",
+        "confirmed_gui_reload",
+    ] = "skipped"
+    upstream_blockers: list[str] = Field(default_factory=list)
     render_artifacts: list[LivePreviewArtifact] = Field(default_factory=list)
     unsafe_state: dict[str, Any] = Field(default_factory=dict)
     next_actions: list[str] = Field(default_factory=list)
@@ -150,12 +169,13 @@ class LivePreviewPayload(BaseModel):
         watch_files = [str(item) for item in payload.get("watch_files", [])]
         render_payload = payload.get("render") or {}
         render_status = str(render_payload.get("status", "skipped"))
+        reload_confirmed = bool(payload.get("reload_confirmed", False))
         if status == "pending_debounce":
             outcome: LivePreviewOutcome = "pending"
         elif render_status == "ok" or status.endswith("_rendered"):
             outcome = "rendered"
         elif status.endswith("_reloaded"):
-            outcome = "reloaded"
+            outcome = "reloaded" if reload_confirmed else "reload_requested"
         elif render_status == "failed" or status == "error":
             outcome = "error"
         elif status == "fallback":
@@ -182,12 +202,24 @@ class LivePreviewPayload(BaseModel):
         )
         reload_result = payload.get("reload_result")
         reload_attempted = bool(payload.get("reload_attempted") or reload_result)
-        if reload_attempted and reload_result:
-            reload_outcome = str(payload.get("reload_outcome") or "ok")
-        elif reload_attempted:
-            reload_outcome = str(payload.get("reload_outcome") or "attempted")
+        if reload_attempted and not reload_confirmed:
+            # A successful IPC send means the GUI-facing request was attempted; it
+            # does not prove that the open Eeschema document reloaded from disk.
+            reload_outcome = "requested"
+        elif reload_attempted and reload_confirmed:
+            reload_outcome = "confirmed"
         else:
             reload_outcome = str(payload.get("reload_outcome") or "skipped")
+        reload_mode = (
+            "confirmed_gui_reload"
+            if reload_confirmed
+            else "best_effort_gui_request"
+            if reload_attempted
+            else "skipped"
+        )
+        upstream_blockers = [str(item) for item in payload.get("upstream_blockers", [])]
+        if reload_attempted and not reload_confirmed:
+            upstream_blockers.append(SCHEMATIC_GUI_RELOAD_UPSTREAM_BLOCKER_URL)
         render_artifacts: list[LivePreviewArtifact] = []
         if render.png_path:
             render_artifacts.append(
@@ -208,8 +240,12 @@ class LivePreviewPayload(BaseModel):
                 )
             )
         warnings = [str(item) for item in payload.get("warnings", [])]
+        if reload_attempted and not reload_confirmed:
+            warnings.append(SCHEMATIC_GUI_RELOAD_BEST_EFFORT_WARNING)
+            warnings.append(SCHEMATIC_GUI_RELOAD_UNCONFIRMED_WARNING)
         if reload_attempted and not payload.get("dirty_state_verified", False):
             warnings.append("GUI dirty state could not be verified before reload request.")
+        warnings = list(dict.fromkeys(warnings))
         unsafe_state = dict(payload.get("unsafe_state") or {})
         dirty_state_verified = bool(payload.get("dirty_state_verified", False))
         unsafe_state.setdefault("dirty_state_verified", dirty_state_verified)
@@ -219,6 +255,12 @@ class LivePreviewPayload(BaseModel):
         elif outcome == "rendered":
             next_actions = [
                 "Inspect render_artifacts before continuing.",
+                "Run ERC/DRC checks after schematic changes.",
+            ]
+        elif outcome == "reload_requested":
+            next_actions = [
+                "Inspect render_artifacts when available before continuing.",
+                "Do not assume the KiCad GUI document reloaded from disk.",
                 "Run ERC/DRC checks after schematic changes.",
             ]
         elif outcome == "reloaded":
@@ -250,6 +292,9 @@ class LivePreviewPayload(BaseModel):
             debounce_ms=debounce_ms,
             reload_attempted=reload_attempted,
             reload_outcome=reload_outcome,
+            reload_confirmed=reload_confirmed,
+            reload_mode=reload_mode,
+            upstream_blockers=upstream_blockers,
             render_artifacts=render_artifacts,
             unsafe_state=unsafe_state,
             next_actions=next_actions,
@@ -258,6 +303,11 @@ class LivePreviewPayload(BaseModel):
             signature=dict(payload.get("signature") or {}),
             debounce=debounce,
             render=render,
+            safety=LivePreviewSafety(
+                dirty_state_verified=dirty_state_verified,
+                status=reload_mode if reload_attempted else "safe_artifact_preview",
+                warnings=warnings,
+            ),
             message=payload.get("message"),
         )
         return _persist_manifest_artifact(normalized) if render_artifacts else normalized

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -5351,7 +5351,10 @@ def _reload_schematic_via_ipc() -> str:
         command = editor_commands_pb2.RevertDocument()
         command.document.CopyFrom(documents[0])
         kicad._client.send(command, type(None).__mro__[0])
-        return "The schematic was updated and KiCad was asked to reload it."
+        return (
+            "The schematic was updated and a best-effort KiCad GUI reload request was sent. "
+            "Schematic disk reload in the open GUI document is not confirmed."
+        )
     except Exception as exc:
         logger.debug("schematic_reload_failed", error=str(exc))
         return "The schematic was updated. Reload it manually in KiCad if needed."
@@ -7723,8 +7726,8 @@ def register(mcp: FastMCP) -> None:
             reload_result=reload_result,
             render_metadata=render_metadata,
             message=(
-                "KiCad reload was requested by opt-in reload=True; dirty GUI state "
-                "could not be verified."
+                "A best-effort KiCad GUI reload was requested by opt-in reload=True; "
+                "schematic disk reload in the open GUI document is not confirmed."
                 if reload
                 else "Preview refreshed without forcing a KiCad GUI reload."
             ),

--- a/tests/unit/test_live_preview_contract.py
+++ b/tests/unit/test_live_preview_contract.py
@@ -62,7 +62,7 @@ def test_live_preview_payload_normalizes_current_tool_shape() -> None:
     ]
 
 
-def test_live_preview_payload_distinguishes_gui_reload() -> None:
+def test_live_preview_payload_distinguishes_best_effort_gui_reload_request() -> None:
     payload = LivePreviewPayload.from_legacy_payload(
         {
             "status": "changed_reloaded",
@@ -76,12 +76,22 @@ def test_live_preview_payload_distinguishes_gui_reload() -> None:
         }
     )
 
-    assert payload.outcome == "reloaded"
+    assert payload.outcome == "reload_requested"
     assert payload.reload_attempted is True
-    assert payload.reload_outcome == "ok"
+    assert payload.reload_outcome == "requested"
+    assert payload.reload_confirmed is False
+    assert payload.reload_mode == "best_effort_gui_request"
+    assert payload.upstream_blockers == ["https://gitlab.com/kicad/code/kicad/-/work_items/24803"]
     assert payload.unsafe_state == {"dirty_state_verified": False, "unsafe": False}
-    assert "GUI dirty state could not be verified" in payload.warnings[0]
-    assert payload.next_actions == ["Verify the GUI-visible sheet and run ERC/DRC checks."]
+    assert any("best-effort only" in warning for warning in payload.warnings)
+    assert any("not confirmed" in warning for warning in payload.warnings)
+    assert any("GUI dirty state could not be verified" in warning for warning in payload.warnings)
+    assert payload.safety.status == "best_effort_gui_request"
+    assert payload.next_actions == [
+        "Inspect render_artifacts when available before continuing.",
+        "Do not assume the KiCad GUI document reloaded from disk.",
+        "Run ERC/DRC checks after schematic changes.",
+    ]
 
 
 def test_live_preview_payload_surfaces_render_failure_as_error() -> None:


### PR DESCRIPTION
Summary: clarify live-preview reload request semantics. Adds explicit reload_confirmed and reload_mode contract fields, safer warnings, docs updates, and tests. Refs issue 314. Validation passed: ruff, mypy, unit test, integration fallback test, metadata script, mkdocs strict build.