### PR TITLE
ci: skip heavy CI for docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
                 "${{ steps.filter.outputs.npm }}" == 'false' && \
                 "${{ steps.filter.outputs.schemas }}" == 'false' && \
                 "${{ steps.filter.outputs.workflows }}" == 'false' && \
+                "${{ steps.filter.outputs.dependencies }}" == 'false' && \
                 "${{ steps.filter.outputs.docs }}" == 'true' ]]; then
             echo 'docs_only=true' >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,159 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      docs_only: ${{ steps.check.outputs.docs_only }}
+      python: ${{ steps.filter.outputs.python }}
+      npm: ${{ steps.filter.outputs.npm }}
+      schemas: ${{ steps.filter.outputs.schemas }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      dependencies: ${{ steps.filter.outputs.dependencies }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'uv.toml'
+              - 'scripts/**'
+              - 'conftest.py'
+              - 'pyrightconfig.json'
+              - '.python-version'
+              - 'performance/**'
+              - 'evals/**'
+            npm:
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.node-version'
+              - '.npmrc'
+              - 'commitlint.config.cjs'
+              - '.commitlintrc.json'
+            schemas:
+              - 'packages/protocol-schemas/**'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            dependencies:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Dockerfile'
+              - 'renovate.json'
+            docs:
+              - 'docs/**'
+              - 'README.md'
+              - 'CONTRIBUTING.md'
+              - 'CHANGELOG.md'
+              - 'CODE_OF_CONDUCT.md'
+              - 'GOVERNANCE.md'
+              - 'MAINTAINERS.md'
+              - 'ROADMAP.md'
+              - 'SECURITY.md'
+              - 'SUPPORT.md'
+              - 'ARCHITECTURE.md'
+              - 'CITATION.cff'
+              - 'LICENSE'
+              - 'mkdocs.yml'
+              - 'assets/**'
+      - name: Compute docs_only flag
+        id: check
+        shell: bash
+        run: |
+          if [[ "${{ steps.filter.outputs.python }}" == 'false' && \
+                "${{ steps.filter.outputs.npm }}" == 'false' && \
+                "${{ steps.filter.outputs.schemas }}" == 'false' && \
+                "${{ steps.filter.outputs.workflows }}" == 'false' && \
+                "${{ steps.filter.outputs.docs }}" == 'true' ]]; then
+            echo 'docs_only=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+          fi
+      - name: Summarize detected changes
+        run: |
+          echo '## Change Detection Summary' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '| Category | Changed |' >> "$GITHUB_STEP_SUMMARY"
+          echo '|----------|---------|' >> "$GITHUB_STEP_SUMMARY"
+          echo '| python | ${{ steps.filter.outputs.python }} |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| npm | ${{ steps.filter.outputs.npm }} |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| schemas | ${{ steps.filter.outputs.schemas }} |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| workflows | ${{ steps.filter.outputs.workflows }} |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| dependencies | ${{ steps.filter.outputs.dependencies }} |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| docs | ${{ steps.filter.outputs.docs }} |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| **docs_only** | **${{ steps.check.outputs.docs_only }}** |' >> "$GITHUB_STEP_SUMMARY"
+
   mcp-server:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2025, macos-15]
     steps:
+      - name: Skip heavy CI for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: |
+          echo "::notice::Skipping mcp-server CI — docs-only PR detected"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        if: env.skip_ci != 'true'
         with:
           node-version-file: .node-version
           package-manager-cache: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        if: env.skip_ci != 'true'
         with:
           enable-cache: true
           version-file: uv.toml
       - run: corepack enable
+        if: env.skip_ci != 'true'
       - run: corepack pnpm install --frozen-lockfile
+        if: env.skip_ci != 'true'
       - run: uv sync --all-extras --frozen
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run format:check
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run lint
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run typecheck
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run test:unit
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run metadata:check
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run mcp:manifest:check
+        if: env.skip_ci != 'true'
       - run: corepack pnpm run package:check
+        if: env.skip_ci != 'true'
 
   mcp-npm:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -55,46 +176,82 @@ jobs:
       run:
         working-directory: packages/mcp-npm
     steps:
+      - name: Skip heavy CI for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: |
+          echo "::notice::Skipping mcp-npm CI — docs-only PR detected"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        if: env.skip_ci != 'true'
         with:
           node-version-file: .node-version
           package-manager-cache: false
       - run: npm ci --ignore-scripts=false
+        if: env.skip_ci != 'true'
       - run: npm pack --dry-run
+        if: env.skip_ci != 'true'
       - run: npm run build
+        if: env.skip_ci != 'true'
 
   protocol-schemas:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
     runs-on: ubuntu-24.04
     steps:
+      - name: Skip heavy CI for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: |
+          echo "::notice::Skipping protocol-schemas CI — docs-only PR detected"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        if: env.skip_ci != 'true'
         with:
           node-version-file: .node-version
           package-manager-cache: false
       - run: corepack enable
+        if: env.skip_ci != 'true'
       - run: corepack pnpm install --frozen-lockfile
+        if: env.skip_ci != 'true'
       - run: corepack pnpm --filter @oaslananka/kicad-protocol-schemas run format:check
+        if: env.skip_ci != 'true'
       - run: corepack pnpm --filter @oaslananka/kicad-protocol-schemas run lint
+        if: env.skip_ci != 'true'
       - run: corepack pnpm --filter @oaslananka/kicad-protocol-schemas run typecheck
+        if: env.skip_ci != 'true'
       - run: corepack pnpm --filter @oaslananka/kicad-protocol-schemas run test
+        if: env.skip_ci != 'true'
 
   security:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write
     steps:
+      - name: Skip Trivy scan for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: |
+          echo "::notice::Skipping Trivy filesystem scan — docs-only PR detected"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
         with:
           persist-credentials: false
       - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        if: env.skip_ci != 'true'
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,8 +16,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'packages/**'
+              - 'fuzz/**'
+              - 'evals/**'
+              - 'performance/**'
+              - '*.py'
+              - '*.js'
+              - '*.ts'
+              - '*.mjs'
+              - '*.cjs'
+      - name: Compute docs_only flag
+        id: check
+        shell: bash
+        run: |
+          if [[ "${{ steps.filter.outputs.code }}" == 'false' ]]; then
+            echo 'docs_only=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'docs_only=false' >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
     name: analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
     permissions:
@@ -34,11 +75,19 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
+      - name: Skip CodeQL for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: |
+          echo "::notice::Skipping CodeQL analysis — docs-only PR detected (no code changes)"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
         with:
           persist-credentials: false
       - uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463
+        if: env.skip_ci != 'true'
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463
+        if: env.skip_ci != 'true'


### PR DESCRIPTION
## Summary
Skip expensive CI jobs (full OS matrix, CodeQL, Trivy) on docs-only PRs while maintaining all required status check compatibility.

## What changed
### ci.yml
- Added `changes` job using `dorny/paths-filter` (SHA-pinned) to detect file categories
- All 4 existing jobs (`mcp-server`, `mcp-npm`, `protocol-schemas`, `security`) now `needs: [changes]` with `if: always()` so they always run
- Each job has a first step that sets `skip_ci=true` when `docs_only=true`
- All subsequent steps have `if: env.skip_ci != 'true'`
- On docs-only PR: jobs start, print "Skipping..." notice, and exit successfully in seconds
- On push/dispatch/code PR: `changes` job is skipped (PR-only), outputs are empty, `skip_ci` is never set → full CI runs

### codeql.yml
- Added `changes` job to detect if only docs changed
- `analyze` job uses same step-level no-op pattern
- Scheduled weekly scan and push-to-main continue to run full analysis

## What intentionally did not change
- **Job names are identical** — `mcp-server`, `mcp-npm`, `protocol-schemas`, `security`, `analyze` 
- **All 10 required status checks still report a status on every PR**
- Push to main behavior unchanged
- Scheduled CodeQL unchanged
- Gitleaks (`scan`) in separate workflow — unchanged, still runs on every PR
- No publish/release workflow changes
- No branch protection changes needed

## Step-level no-op pattern
```
Job starts → first step checks docs_only → sets skip_ci env var → remaining steps skipped
```
This ensures GitHub receives a ✅ status for the required check even on docs-only PRs.

## Validation
- YAML syntax verified
- All job names preserved for branch protection
- `needs: [changes]` + `if: always()` ensures jobs run even when changes job is skipped (push/dispatch)
- Action SHA-pinned: `dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36`

## Risk
⚠️ Low — job names preserved, required checks continue to report

## Rollback plan
Revert ci.yml and codeql.yml to their previous versions. All jobs will run unconditionally again. No branch protection changes needed.