### PR TITLE
ci: scope dependency and code scanning workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,16 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Dockerfile"
+      - "renovate.json"
+      - "packages/mcp-npm/package.json"
+      - "packages/mcp-npm/package-lock.json"
+      - ".github/workflows/dependency-review.yml"
   workflow_dispatch:
 
 permissions:

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+# Honored by SonarQube Cloud Automatic Analysis (not the sonar-project.properties
+# format used by CI-based scans). Must live on the default branch to take effect.
+# Only classifies test source directories; does not exclude or silence any rule.
+sonar.tests=tests,packages/protocol-schemas/test,packages/kicad-fixtures/test


### PR DESCRIPTION
## Summary
Scope Dependency Review to actual dependency changes and classify test-code paths for SonarQube Cloud, reducing noise without weakening security coverage. Stacked on `ci/docs-only-skip` (#361).

## What changed
### dependency-review.yml
- Added `on.pull_request.paths` filter matching the same `dependencies` category `ci.yml`'s `changes` job already tracks (`package.json`, `pnpm-lock.yaml`, `pyproject.toml`, `uv.lock`, `Dockerfile`, `renovate.json`, `packages/mcp-npm/package.json`, `packages/mcp-npm/package-lock.json`, plus the workflow file itself)
- This is **not** a required status check in the branch ruleset, so a no-op run when the path filter doesn't match is safe — no pending-check risk

### .sonarcloud.properties (new)
- SonarQube Cloud's Automatic Analysis mode reads `.sonarcloud.properties` from the default branch — a different file from `sonar-project.properties` used by CI-based scans, and this repo has no Sonar CI workflow, confirming it runs in Automatic Analysis mode
- Sets `sonar.tests` to `tests`, `packages/protocol-schemas/test`, `packages/kicad-fixtures/test` so these are classified as test code
- Confirmed against the live SonarCloud project (`oaslananka_kicad-mcp`) that several open findings — hardcoded-looking IPs/credentials/HTTP literals in `tests/unit/test_release_hardening.py`, `test_connection_session.py`, `test_logging.py`, `test_server_info_contract.py`, `test_telemetry.py` — are test fixtures, not production code
- **Correction**: classifying these paths as tests does not by itself fix the project's currently-failing `new_security_rating` quality gate condition. That gate is also driven by several BLOCKER-severity `S2083` ("path constructed from user-controlled data") findings in production source (`src/kicad_mcp/tools/validation.py`, `pcb.py`, `embedded_files.py`, `three_d_models.py`, `variants.py`, `routing_rules.py`, `cli_init.py`, `schematic_roundtrip.py`), which `sonar.tests` classification has no effect on. This PR only removes test-code false-positive noise; it does not claim to turn the quality gate green, and Sonar is not a required check either way

## What intentionally did not change
- No rule severities or Quality Profiles changed — that requires SonarCloud UI access (org/project admin), not a repo file, and isn't something I can verify or set safely from here
- No files excluded from Sonar analysis — `sonar.tests` only classifies paths, it does not add `sonar.exclusions` or `sonar.test.exclusions`, so nothing stops being scanned
- Gitleaks unchanged — still runs on every PR
- CodeQL unchanged — its own `changes`/docs-only skip already exists from #361
- No required check names changed

## Validation
- `actionlint` clean (only pre-existing, unrelated shellcheck style notices in `ci.yml`/`kicad-live-e2e.yml` predating this branch)
- Verified via SonarQube MCP tooling against the live project that the referenced test files and quality-gate condition are real, not hypothetical

## Risk
Low — Dependency Review is non-required, so the path filter cannot cause a pending-required-check block. `.sonarcloud.properties` only reclassifies paths already inside the repo; Sonar itself is not a required check either.

## Rollback plan
Remove the `paths:` block from `dependency-review.yml` to restore always-on behavior. Delete `.sonarcloud.properties` to fall back to SonarCloud's automatic path detection.
