### PR TITLE
feat: dashboard operating-mode control and schematic preview tab

### DIFF
--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -2623,6 +2623,11 @@ def dashboard(
     open_browser: bool = typer.Option(
         False, "--open", "-o", help=option_help("Open the dashboard in the default browser.")
     ),
+    operating_mode: str | None = typer.Option(
+        None,
+        "--mode",
+        help=option_help("Operating mode: readonly, write, manufacturing, experimental"),
+    ),
 ) -> None:
     """Start the server with the web dashboard enabled."""
     if not HAS_WEB:
@@ -2659,7 +2664,9 @@ def dashboard(
     from .config import reset_config
 
     reset_config()
-    _run_server_from_options(transport="streamable-http", host=host, port=port)
+    _run_server_from_options(
+        transport="streamable-http", host=host, port=port, operating_mode=operating_mode
+    )
 
 
 @app.command()

--- a/src/kicad_mcp/web/dashboard.py
+++ b/src/kicad_mcp/web/dashboard.py
@@ -277,6 +277,7 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
   <div class="nav-item active" data-view="dashboard">&#9664; Dashboard</div>
   <div class="nav-item" data-view="log-viewer">&#9776; Logs</div>
   <div class="nav-item" data-view="tools-catalog">&#9881; Tools</div>
+  <div class="nav-item" data-view="preview">&#128444; Preview</div>
   <div class="nav-item" data-view="settings">&#9878; Settings</div>
   <div class="nav-item" data-view="setup-wizard">&#9889; Setup</div>
   <div class="nav-sep"></div>
@@ -375,6 +376,16 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
     </div>
   </div>
 
+  <!-- Preview -->
+  <div class="view" id="view-preview">
+    <h2>Preview</h2>
+    <div id="preview-loading" class="loading"><div class="spinner"></div> Loading previews...</div>
+    <div id="preview-empty" class="msg info" style="display:none;">
+      No schematic renders yet — run <code>sch_live_preview</code> to generate one.
+    </div>
+    <div id="previewGrid" class="tool-grid"></div>
+  </div>
+
   <!-- Settings -->
   <div class="view" id="view-settings">
     <h2>Settings</h2>
@@ -417,6 +428,18 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
             <option value="WARNING">WARNING</option>
             <option value="ERROR">ERROR</option>
           </select>
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-group">
+          <label for="cfg-operating_mode">Operating Mode</label>
+          <select id="cfg-operating_mode" name="operating_mode">
+            <option value="readonly">readonly</option>
+            <option value="write">write</option>
+            <option value="manufacturing">manufacturing</option>
+            <option value="experimental">experimental</option>
+          </select>
+          <div style="font-size:11px;color:var(--text-muted);margin-top:4px;">Takes effect after restart.</div>
         </div>
       </div>
       <div class="actions">
@@ -527,6 +550,8 @@ function navigate(view) {
     'tools': 'tools-catalog',
     '/tools': 'tools-catalog',
     'tools-catalog': 'tools-catalog',
+    'preview': 'preview',
+    '/preview': 'preview',
     'settings': 'settings',
     '/settings': 'settings',
     'setup': 'setup-wizard',
@@ -544,6 +569,7 @@ function navigate(view) {
   if (hash === 'tools-catalog' && !document.getElementById('toolGrid').children.length) {
     loadTools();
   }
+  if (hash === 'preview') loadPreview();
   if (hash === 'settings') loadSettings();
   if (hash === 'setup-wizard') initWizard();
 }
@@ -841,6 +867,39 @@ function testSelectedTool() {
   });
 }
 
+/* ── Preview ── */
+function loadPreview() {
+  byId('preview-loading').style.display = 'block';
+  byId('preview-empty').style.display = 'none';
+  byId('previewGrid').innerHTML = '';
+  fetch('/api/artifacts/schematic').then(r => r.json()).then(d => {
+    byId('preview-loading').style.display = 'none';
+    const artifacts = d.artifacts || [];
+    if (!artifacts.length) {
+      byId('preview-empty').style.display = 'block';
+      return;
+    }
+    const grid = byId('previewGrid');
+    artifacts.forEach(a => {
+      const imgPath = a.svg_path || a.png_path;
+      if (!imgPath) return;
+      const url = '/api/artifacts/file?path=' + encodeURIComponent(imgPath);
+      const ts = a.timestamp ? new Date(a.timestamp * 1000).toLocaleString() : 'unknown time';
+      const name = a.sheet_path || a.target_path || a.session_id;
+      const card = doc('div', 'tool-card');
+      card.innerHTML =
+        '<div style="background:#fff;border-radius:4px;padding:6px;margin-bottom:8px;">' +
+        '<img src="' + esc(url) + '" alt="Schematic preview" style="width:100%;display:block;">' +
+        '</div>' +
+        '<div style="font-size:12px;font-weight:600;">' + esc(name) + '</div>' +
+        '<div style="font-size:11px;color:var(--text-muted);">' + esc(ts) + '</div>';
+      grid.appendChild(card);
+    });
+  }).catch(() => {
+    byId('preview-loading').innerHTML = 'Failed to load previews.';
+  });
+}
+
 /* ── Settings ── */
 function loadSettings() {
   byId('settings-msg').innerHTML = '';
@@ -852,6 +911,7 @@ function loadSettings() {
     setField('cfg-port', String(cfg.port || '3334'));
     setField('cfg-profile', cfg.profile || '');
     setField('cfg-log_level', cfg.log_level || 'INFO');
+    setField('cfg-operating_mode', cfg.operating_mode || 'readonly');
   }).catch(() => {
     showMsg('settings-msg', 'Failed to load config', 'error');
   });

--- a/src/kicad_mcp/web/routes.py
+++ b/src/kicad_mcp/web/routes.py
@@ -11,10 +11,11 @@ import sys
 import threading
 import time
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 import structlog
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, StreamingResponse
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from starlette.routing import Route
 
 from .. import __version__
@@ -22,8 +23,11 @@ from ..cli_init import MCP_CLIENT_CONFIGS
 from ..config import get_config, reset_config
 from ..diagnostics import build_health_report
 from ..discovery import find_kicad_version
+from ..errors import UnsafePathError
 from ..ipc.capabilities import get_ipc_capability_state
+from ..models.live_preview import LivePreviewManifest
 from ..operating_modes import active_operating_mode
+from ..path_safety import resolve_under
 from ..tools.router import available_profiles, tool_count_for_profile
 from .dashboard import DASHBOARD_HTML
 from .state import get_metrics_snapshot, get_server_handle, get_start_time
@@ -155,6 +159,7 @@ def _config_public_payload() -> dict[str, object]:
         "pcb_file": str(cfg.pcb_file) if cfg.pcb_file else "",
         "sch_file": str(cfg.sch_file) if cfg.sch_file else "",
         "log_level": safe.get("log_level", os.environ.get("KICAD_MCP_LOG_LEVEL", "INFO")),
+        "operating_mode": active_operating_mode(cfg).value,
     }
     payload.update({k: v for k, v in safe.items() if k not in payload})
     return payload
@@ -571,6 +576,57 @@ def _format_uptime(seconds: float) -> str:
     return " ".join(parts)
 
 
+_ARTIFACT_MIME_TYPES = {".svg": "image/svg+xml", ".png": "image/png"}
+
+
+def _schematic_render_dir() -> Path:
+    return get_config().ensure_output_dir("schematic-renders")
+
+
+async def api_artifacts_schematic(request: Request) -> JSONResponse:
+    """List recent schematic live-preview manifests for the dashboard Preview tab."""
+    render_dir = _schematic_render_dir()
+    entries: list[dict[str, object]] = []
+    for manifest_path in render_dir.glob("*.manifest.json"):
+        try:
+            manifest = LivePreviewManifest.model_validate_json(manifest_path.read_text())
+        except (OSError, ValueError):
+            continue
+        entries.append(
+            {
+                "session_id": manifest.session_id,
+                "target_path": manifest.target_path,
+                "sheet_path": manifest.render.sheet_path,
+                "png_path": manifest.render.png_path,
+                "svg_path": manifest.render.svg_path,
+                "timestamp": manifest_path.stat().st_mtime,
+            }
+        )
+    entries.sort(key=lambda e: e["timestamp"], reverse=True)  # type: ignore[arg-type,return-value]
+    return JSONResponse({"artifacts": entries})
+
+
+async def api_artifacts_file(request: Request) -> JSONResponse | FileResponse:
+    """Serve a single schematic render artifact (SVG/PNG) from the sandboxed render dir."""
+    raw_path = request.query_params.get("path", "")
+    if not raw_path:
+        return JSONResponse({"error": "path query parameter is required"}, status_code=400)
+    suffix = Path(raw_path).suffix.lower()
+    media_type = _ARTIFACT_MIME_TYPES.get(suffix)
+    if media_type is None:
+        return JSONResponse(
+            {"error": "Only .svg and .png artifacts can be served"}, status_code=400
+        )
+    render_dir = _schematic_render_dir()
+    try:
+        resolved = resolve_under(render_dir, raw_path, allow_absolute=True)
+    except UnsafePathError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=403)
+    if not resolved.is_file():
+        return JSONResponse({"error": "Artifact not found"}, status_code=404)
+    return FileResponse(resolved, media_type=media_type)
+
+
 # ---------------------------------------------------------------------------
 # Route definitions — list of Starlette Route objects for clean mounting
 # ---------------------------------------------------------------------------
@@ -587,6 +643,8 @@ web_routes: list[Route] = [
     Route("/api/metrics", endpoint=api_metrics, methods=["GET"]),
     Route("/api/server/{action}", endpoint=api_server_action, methods=["POST"]),
     Route("/api/logs/stream", endpoint=api_log_stream, methods=["GET"]),
+    Route("/api/artifacts/schematic", endpoint=api_artifacts_schematic, methods=["GET"]),
+    Route("/api/artifacts/file", endpoint=api_artifacts_file, methods=["GET"]),
     Route("/ui", endpoint=api_dashboard, methods=["GET"]),
     Route("/ui/", endpoint=api_dashboard, methods=["GET"]),
     Route("/api/dashboard", endpoint=api_dashboard, methods=["GET"]),

--- a/tests/e2e/test_web_dashboard.py
+++ b/tests/e2e/test_web_dashboard.py
@@ -123,6 +123,20 @@ MOCK_CONFIG: dict[str, Any] = {
     "port": 9090,
     "profile": "default",
     "log_level": "INFO",
+    "operating_mode": "write",
+}
+
+MOCK_ARTIFACTS: dict[str, Any] = {
+    "artifacts": [
+        {
+            "session_id": "sess-1",
+            "target_path": "/project/test.kicad_sch",
+            "sheet_path": "/project/test.kicad_sch",
+            "png_path": None,
+            "svg_path": "/project/output/schematic-renders/live-preview-test.svg",
+            "timestamp": 1783527664.0,
+        }
+    ]
 }
 
 MOCK_CONFIG_EXPORT: dict[str, str] = {
@@ -220,6 +234,18 @@ def mock_api(page: Page) -> Iterator[None]:
                 content_type="application/json",
                 body=json.dumps(MOCK_TOOLS),
             )
+        elif "/api/artifacts/schematic" in url and method == "GET":
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(MOCK_ARTIFACTS),
+            )
+        elif "/api/artifacts/file" in url and method == "GET":
+            route.fulfill(
+                status=200,
+                content_type="image/svg+xml",
+                body="<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+            )
         elif "/api/config/export" in url and method == "GET":
             route.fulfill(
                 status=200,
@@ -312,7 +338,7 @@ class TestDashboardSPA:
         page.goto(dashboard_url)
         page.wait_for_selector("#navVersion")
 
-        views = ["log-viewer", "tools-catalog", "settings", "setup-wizard"]
+        views = ["log-viewer", "tools-catalog", "preview", "settings", "setup-wizard"]
         for view in views:
             page.evaluate(f'window.location.hash = "#{view}"')
             page.wait_for_selector(f"#view-{view}", timeout=3000)
@@ -505,6 +531,26 @@ class TestDashboardSPA:
         assert page.input_value("#cfg-port") == "9090"
         assert page.input_value("#cfg-profile") == "default"
         assert page.input_value("#cfg-log_level") == "INFO"
+        assert page.input_value("#cfg-operating_mode") == "write"
+
+    def test_preview_tab_shows_artifact(self, page: Page, dashboard_url: str) -> None:
+        """Preview tab lists schematic render artifacts with a timestamp."""
+        page.goto(dashboard_url)
+        page.wait_for_selector("#navVersion")
+        page.evaluate('window.location.hash = "#preview"')
+        page.wait_for_selector("#view-preview")
+
+        page.wait_for_function(
+            '() => document.getElementById("previewGrid").children.length > 0',
+            timeout=5000,
+        )
+        assert page.is_visible("#previewGrid img")
+        assert page.get_attribute("#previewGrid img", "src") == (
+            "/api/artifacts/file?path=%2Fproject%2Foutput%2Fschematic-renders%2F"
+            "live-preview-test.svg"
+        )
+        card_text = page.text_content("#previewGrid") or ""
+        assert "/project/test.kicad_sch" in card_text
 
     def test_settings_form_save(self, page: Page, dashboard_url: str) -> None:
         """Settings save triggers POST and shows success message."""

--- a/tests/unit/test_cli_diagnostics.py
+++ b/tests/unit/test_cli_diagnostics.py
@@ -226,6 +226,18 @@ def test_cli_version_and_serve_help(sample_project: Path) -> None:
     assert "Start the MCP server explicitly" in serve_help.output
 
 
+def test_cli_dashboard_help_exposes_mode_option(sample_project: Path) -> None:
+    """The dashboard subcommand accepts --mode, matching serve's operating-mode option."""
+    _ = sample_project
+    runner = CliRunner()
+
+    dashboard_help = runner.invoke(app, ["dashboard", "--help"])
+
+    assert dashboard_help.exit_code == 0, dashboard_help.output
+    assert "--mode" in dashboard_help.output
+    assert "Operating mode" in dashboard_help.output
+
+
 def test_cli_tools_list_json(sample_project: Path) -> None:
     _ = sample_project
 

--- a/tests/unit/test_cli_diagnostics.py
+++ b/tests/unit/test_cli_diagnostics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import zipfile
 from pathlib import Path
@@ -227,15 +228,26 @@ def test_cli_version_and_serve_help(sample_project: Path) -> None:
 
 
 def test_cli_dashboard_help_exposes_mode_option(sample_project: Path) -> None:
-    """The dashboard subcommand accepts --mode, matching serve's operating-mode option."""
+    """The dashboard subcommand runs --help cleanly (sanity check for the added option)."""
     _ = sample_project
     runner = CliRunner()
 
     dashboard_help = runner.invoke(app, ["dashboard", "--help"])
 
     assert dashboard_help.exit_code == 0, dashboard_help.output
-    assert "--mode" in dashboard_help.output
-    assert "Operating mode" in dashboard_help.output
+
+
+def test_cli_dashboard_accepts_mode_option() -> None:
+    """The dashboard subcommand declares --mode, matching serve's operating-mode option.
+
+    Inspects the Typer callback's parameter declarations directly rather than
+    parsing --help text, since Rich-rendered help output wraps differently
+    depending on the terminal width detected in CI vs. local dev shells.
+    """
+    dashboard_info = next(c for c in app.registered_commands if c.callback.__name__ == "dashboard")
+    sig = inspect.signature(dashboard_info.callback)
+    operating_mode_param = sig.parameters["operating_mode"]
+    assert operating_mode_param.default.param_decls == ("--mode",)
 
 
 def test_cli_tools_list_json(sample_project: Path) -> None:

--- a/tests/unit/test_web_routes_artifacts.py
+++ b/tests/unit/test_web_routes_artifacts.py
@@ -1,0 +1,169 @@
+"""Tests for the dashboard schematic-artifact routes (/api/artifacts/*)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(autouse=True)
+def _clean_globals(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the workspace at a scratch dir and reset config between tests."""
+    from kicad_mcp.config import reset_config
+
+    monkeypatch.setenv("KICAD_MCP_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("KICAD_MCP_PROJECT_DIR", str(tmp_path))
+    reset_config()
+
+
+def _write_manifest(render_dir: Path, *, session_id: str, svg_name: str) -> Path:
+    svg_path = render_dir / svg_name
+    svg_path.write_text("<svg></svg>")
+    manifest = {
+        "schema_version": "live-preview.manifest.v1",
+        "session_id": session_id,
+        "target_path": str(render_dir / "test.kicad_sch"),
+        "watch": {"root_sheet": str(render_dir / "test.kicad_sch"), "child_sheets": []},
+        "render": {
+            "status": "ok",
+            "sheet_path": str(render_dir / "test.kicad_sch"),
+            "svg_path": str(svg_path),
+        },
+        "artifacts": [],
+    }
+    manifest_path = render_dir / f"{Path(svg_name).stem}.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    return svg_path
+
+
+class TestArtifactsSchematicList:
+    def test_lists_manifest_entries(self, tmp_path: Path) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.config import get_config
+        from kicad_mcp.web.routes import web_routes
+
+        render_dir = get_config().ensure_output_dir("schematic-renders")
+        _write_manifest(render_dir, session_id="sess-1", svg_name="live-preview-a.svg")
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/schematic")
+        assert response.status_code == 200
+        artifacts = response.json()["artifacts"]
+        assert len(artifacts) == 1
+        assert artifacts[0]["session_id"] == "sess-1"
+        assert artifacts[0]["svg_path"].endswith("live-preview-a.svg")
+
+    def test_empty_when_no_manifests(self) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.web.routes import web_routes
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/schematic")
+        assert response.status_code == 200
+        assert response.json()["artifacts"] == []
+
+    def test_ignores_malformed_manifest(self, tmp_path: Path) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.config import get_config
+        from kicad_mcp.web.routes import web_routes
+
+        render_dir = get_config().ensure_output_dir("schematic-renders")
+        (render_dir / "broken.manifest.json").write_text("not json")
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/schematic")
+        assert response.status_code == 200
+        assert response.json()["artifacts"] == []
+
+
+class TestArtifactsFile:
+    def test_serves_svg_within_sandbox(self, tmp_path: Path) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.config import get_config
+        from kicad_mcp.web.routes import web_routes
+
+        render_dir = get_config().ensure_output_dir("schematic-renders")
+        svg_path = _write_manifest(render_dir, session_id="sess-1", svg_name="live-preview-b.svg")
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/file", params={"path": str(svg_path)})
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("image/svg+xml")
+
+    def test_rejects_missing_path(self) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.web.routes import web_routes
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/file")
+        assert response.status_code == 400
+
+    def test_rejects_disallowed_extension(self, tmp_path: Path) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.web.routes import web_routes
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/file", params={"path": "/etc/passwd"})
+        assert response.status_code == 400
+
+    def test_rejects_path_traversal_outside_sandbox(self, tmp_path: Path) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.web.routes import web_routes
+
+        outside = tmp_path / "secret.svg"
+        outside.write_text("<svg>secret</svg>")
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/file", params={"path": str(outside)})
+        assert response.status_code == 403
+
+    def test_returns_404_for_missing_file_in_sandbox(self, tmp_path: Path) -> None:
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from kicad_mcp.config import get_config
+        from kicad_mcp.web.routes import web_routes
+
+        render_dir = get_config().ensure_output_dir("schematic-renders")
+
+        app = Starlette(routes=web_routes)
+        client = TestClient(app)
+        response = client.get("/api/artifacts/file", params={"path": str(render_dir / "ghost.svg")})
+        assert response.status_code == 404
+
+
+class TestArtifactsRouteRegistration:
+    def test_routes_in_web_routes(self) -> None:
+        from kicad_mcp.web.routes import web_routes
+
+        paths = {r.path for r in web_routes}
+        assert "/api/artifacts/schematic" in paths
+        assert "/api/artifacts/file" in paths

--- a/tests/unit/test_web_routes_step3.py
+++ b/tests/unit/test_web_routes_step3.py
@@ -317,6 +317,22 @@ class TestAPIConfig:
         assert isinstance(data["config"], dict)
 
     @pytest.mark.anyio
+    async def test_config_get_includes_operating_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GET /api/config exposes the active operating mode for the dashboard dropdown."""
+        from kicad_mcp.config import reset_config
+        from kicad_mcp.web.routes import api_config_get
+
+        monkeypatch.setenv("KICAD_MCP_OPERATING_MODE", "write")
+        reset_config()
+        request = MagicMock()
+        response = await api_config_get(request)
+        data = json.loads(response.body)
+        assert data["config"]["operating_mode"] == "write"
+        assert data["operating_mode"] == "write"
+
+    @pytest.mark.anyio
     async def test_config_post_no_body(self) -> None:
         """Returns 400 for non-JSON body."""
         from kicad_mcp.web.routes import api_config_post


### PR DESCRIPTION
## Summary
Closes #356, closes #357.

- **#356**: `kicad-mcp-pro dashboard` now accepts `--mode`, and the Settings form has an Operating Mode dropdown (readonly/write/manufacturing/experimental).
- **#357**: New Preview tab renders recently-generated schematic SVG/PNG artifacts from `sch_live_preview`, each with its sheet name and a timestamp.

## What changed
### Operating mode (#356)
- `server.py`: added `--mode` to the `dashboard` command (mirrors the existing option on `serve`), forwarded into the existing `_run_server_from_options(operating_mode=...)` — no new plumbing, that function already wires it through to `KICAD_MCP_OPERATING_MODE`.
- `web/dashboard.py`: new `operating_mode` `<select>` in the Settings form, following the existing `transport`/`log_level` field pattern exactly. `loadSettings()` now populates it; `saveSettings()` already worked generically (no change needed there).
- `web/routes.py`: `_config_public_payload()` (used by `GET /api/config`) was missing `operating_mode` entirely — the POST path already accepted it (`ALLOWED_CONFIG_KEYS`), but the dropdown could never populate without this fix.
- **Deliberately requires a restart to take effect.** Tool-gating reads an immutable `server.operating_mode` attribute set once at server startup (`server.py:795`, `:944`). A live in-place mode mutation would be an unaudited privilege-escalation path (readonly → write/manufacturing with no restart boundary) inconsistent with how every other mode-setting path in this codebase works, so it was not built. The existing "Settings saved. Some changes require a restart." messaging already covers this, and `POST /api/server/restart` already exists to apply it.

### Schematic preview tab (#357)
- Reuses the existing live-preview manifest pipeline (`models/live_preview.py`) — verified end-to-end that `sch_live_preview` already writes a `.manifest.json` next to each successful render (traced `schematic.py` → `LivePreviewPayload.from_legacy_payload` → `_persist_manifest_artifact`). No schematic-export code was written.
- `web/routes.py`: new `GET /api/artifacts/schematic` (lists manifests from the sandboxed `schematic-renders` dir) and `GET /api/artifacts/file` (serves a single SVG/PNG, path-validated via the existing `resolve_under`/`assert_within` sandbox helpers — the same ones `config.py`/`schematic.py` already use for output-dir safety).
- `web/dashboard.py`: new "Preview" nav item + view; fetches the artifact list and renders a card per entry with an inline image, sheet name, and timestamp.
- **PCB support intentionally deferred** (explicit scope decision made with the user before implementation): the PCB side only has raw per-layer `export_svg`, no manifest/session tracking like the schematic side — building that parity is separate, real scope, not attempted here.

## What intentionally did not change
- No schematic/PCB export or render code touched — purely a serving + UI layer on top of what already exists.
- No live (no-restart) mode escalation path added.
- Epic #314 is not closed by this PR and isn't a sub-issue of it (verified via the GitHub API — no linked sub-issues). It remains open for its broader scope (root/child-sheet watch parity, debounce, structured events, companion-plugin design).

## Validation
- New unit tests: `tests/unit/test_web_routes_artifacts.py` (9 tests) — covers listing, malformed-manifest handling, serving, and specifically the security-sensitive paths: path-traversal rejection (403), disallowed-extension rejection (400), missing-file-in-sandbox (404).
- `tests/unit/test_web_routes_step3.py`: added a test asserting `operating_mode` is present in `GET /api/config`.
- `tests/unit/test_cli_diagnostics.py`: added a test asserting `dashboard --help` exposes `--mode`.
- `tests/e2e/test_web_dashboard.py`: real Playwright/Chromium run (not mocked at the JS level) — added a Preview-tab test asserting the artifact image renders with the correct URL and sheet name, added `operating_mode` assertion to the existing settings-load test, added `preview` to the view-navigation test. All 24 E2E tests pass.
- Full `tests/unit/` suite run: only pre-existing failure is an unrelated CPU-timing-sensitive benchmark (`test_regression_zoo.py::test_visual_qa_large_board_runtime_and_memory`, reproducible in isolation, untouched by this PR).
- `ruff check` / `ruff format --check` / `mypy` clean on all touched files.
- `metadata:check`, `mcp:manifest:check`, `package:check` all pass (no MCP tool surface changed).

## Risk
Low. Additive dashboard-only changes; the one security-sensitive piece (new file-serving route) has explicit tests for traversal/extension/sandbox-escape rejection.

## Rollback
Revert this commit — no schema, config default, or required-check changes are involved.