### PR TITLE
fix: honor experimental operating mode in tool status

### DIFF
--- a/src/kicad_mcp/tools/pcb.py
+++ b/src/kicad_mcp/tools/pcb.py
@@ -62,6 +62,7 @@ from ..models.pcb import (
 )
 from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.verdict import Finding, SuggestedFix, VerdictReport, stable_finding_id
+from ..operating_modes import OperatingMode, active_operating_mode
 from ..utils import telemetry as otel
 from ..utils.cache import clear_ttl_cache, ttl_cache
 from ..utils.impedance import TraceType, copper_thickness_mm, trace_impedance
@@ -3525,7 +3526,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool()
     def pcb_highlight_net(net_name: str) -> str:
         """Attempt to highlight a net in the GUI when supported."""
-        if not get_config().enable_experimental_tools:
+        if active_operating_mode(get_config()) is not OperatingMode.EXPERIMENTAL:
             return "Net highlighting is experimental. Enable experimental tools to try it."
         return (
             "Net highlighting is not exposed as a stable KiCad 10.x IPC operation. "
@@ -3536,7 +3537,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool()
     def pcb_set_net_class(net_name: str, class_name: str) -> str:
         """Assign a net class when the runtime supports it."""
-        if not get_config().enable_experimental_tools:
+        if active_operating_mode(get_config()) is not OperatingMode.EXPERIMENTAL:
             return "Net class assignment is experimental. Enable experimental tools to try it."
         return (
             "Direct net class assignment is not exposed as a stable KiCad 10.x IPC operation. "

--- a/src/kicad_mcp/tools/project.py
+++ b/src/kicad_mcp/tools/project.py
@@ -34,6 +34,7 @@ from ..models.state import (
     WorkflowRole,
 )
 from ..models.verdict import Finding, SuggestedFix, Verdict, stable_finding_id
+from ..operating_modes import OperatingMode, active_operating_mode
 from ..path_safety import assert_within
 from ..prompts.workflows import render_professional_circuit_design_prompt
 from ..utils.cache import clear_ttl_cache, ttl_cache
@@ -323,6 +324,8 @@ def _render_design_workflow(state: DesignWorkflowState) -> str:
 def _render_project_info() -> str:
     cfg = get_config()
     cli_status = "found" if cfg.kicad_cli.exists() else "missing"
+    operating_mode = active_operating_mode(cfg)
+    experimental_enabled = operating_mode is OperatingMode.EXPERIMENTAL
     return "\n".join(
         [
             "Current project configuration:",
@@ -334,7 +337,7 @@ def _render_project_info() -> str:
             f"- Output directory: {cfg.output_dir or '(not set)'}",
             f"- KiCad CLI: {cfg.kicad_cli} ({cli_status})",
             f"- Server profile: {cfg.profile}",
-            f"- Experimental tools: {cfg.enable_experimental_tools}",
+            f"- Experimental tools: {experimental_enabled}",
         ]
     )
 

--- a/tests/unit/test_operating_modes.py
+++ b/tests/unit/test_operating_modes.py
@@ -12,6 +12,7 @@ from kicad_mcp.operating_modes import (
     tool_required_mode,
 )
 from kicad_mcp.server import KiCadFastMCP, _apply_cli_env, build_server
+from tests.conftest import call_tool_text
 
 
 def _tool_names_for_mode(mode: str, *, profile: str = "full") -> set[str]:
@@ -115,6 +116,35 @@ def test_experimental_mode_requires_explicit_opt_in_for_routing_and_unstable_too
         "route_tune_length",
         "sch_swap_pins",
     } <= tool_names
+
+
+@pytest.mark.anyio
+async def test_project_info_reports_effective_experimental_mode(
+    monkeypatch,
+    sample_project,
+) -> None:
+    monkeypatch.setenv("KICAD_MCP_OPERATING_MODE", "experimental")
+    monkeypatch.delenv("KICAD_MCP_ENABLE_EXPERIMENTAL_TOOLS", raising=False)
+    reset_config()
+    server = build_server("full")
+
+    text = await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    expected = "- " + "Experimental tools: True"
+    assert expected in text
+
+
+@pytest.mark.anyio
+async def test_experimental_mode_enables_legacy_experimental_pcb_guards(monkeypatch) -> None:
+    monkeypatch.setenv("KICAD_MCP_OPERATING_MODE", "experimental")
+    monkeypatch.delenv("KICAD_MCP_ENABLE_EXPERIMENTAL_TOOLS", raising=False)
+    reset_config()
+    server = build_server("full")
+
+    text = await call_tool_text(server, "pcb_highlight_net", {"net_name": "GND"})
+
+    assert "Enable experimental tools" not in text
+    assert "Net highlighting is not exposed as a stable" in text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #369.

Summary:
- Report experimental tools from the effective operating mode instead of the legacy flag.
- Make PCB experimental guards respect --mode experimental.
- Add regression coverage for project status and PCB guard behavior.

Validation:
- uv run pytest tests/unit/test_operating_modes.py -q