### PR TITLE
docs: close live preview onboarding gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
     steps:
       - name: Skip heavy CI for docs-only PR
         if: needs.changes.outputs.docs_only == 'true'
+        working-directory: ${{ github.workspace }}
         run: |
           echo "::notice::Skipping mcp-npm CI — docs-only PR detected"
           echo "skip_ci=true" >> "$GITHUB_ENV"

--- a/docs/agents/cursor.md
+++ b/docs/agents/cursor.md
@@ -29,6 +29,13 @@ Or manually:
 2. Copy Cursor Rule: `integrations/cursor/rules/kicad.mdc` → `.cursor/rules/kicad.mdc`
 3. (Optional) Copy Skill: `integrations/cursor/skills/kicad-pcb-review/` → `.cursor/skills/`
 
+
+## Quickstart screenshot
+
+![Cursor MCP quickstart screenshot](../assets/cursor-mcp-quickstart.svg)
+
+This sanitized screenshot shows the expected project-scoped `.cursor/mcp.json` shape and the important onboarding posture: the `kicad` server is present and `KICAD_MCP_OPERATING_MODE` starts in `readonly` mode. It intentionally uses no private project path, token, or user-specific workspace name.
+
 ## Verification
 
 In Cursor Agent mode, ask:

--- a/docs/assets/cursor-mcp-quickstart.svg
+++ b/docs/assets/cursor-mcp-quickstart.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Cursor MCP quickstart configuration screenshot</title>
+  <desc id="desc">Sanitized example of a project-scoped Cursor MCP configuration for KiCad MCP Pro.</desc>
+  <rect width="960" height="540" rx="18" fill="#111827"/>
+  <rect x="32" y="32" width="896" height="476" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="64" y="78" fill="#e5e7eb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22">.cursor/mcp.json</text>
+  <text x="64" y="122" fill="#a7f3d0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">{</text>
+  <text x="88" y="154" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">"mcpServers": {</text>
+  <text x="112" y="186" fill="#fde68a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">"kicad": {</text>
+  <text x="136" y="218" fill="#e5e7eb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">"command": "uvx",</text>
+  <text x="136" y="250" fill="#e5e7eb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">"args": ["kicad-mcp-pro", "--mode", "readonly"],</text>
+  <text x="136" y="282" fill="#e5e7eb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">"env": {</text>
+  <text x="160" y="314" fill="#fca5a5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">"KICAD_MCP_OPERATING_MODE": "readonly"</text>
+  <text x="136" y="346" fill="#e5e7eb" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">}</text>
+  <text x="112" y="378" fill="#fde68a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">}</text>
+  <text x="88" y="410" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">}</text>
+  <text x="64" y="442" fill="#a7f3d0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">}</text>
+  <rect x="610" y="118" width="260" height="210" rx="12" fill="#172554" stroke="#2563eb"/>
+  <text x="634" y="162" fill="#bfdbfe" font-family="Arial, sans-serif" font-size="19" font-weight="700">Quick verification</text>
+  <text x="634" y="200" fill="#dbeafe" font-family="Arial, sans-serif" font-size="16">Server name: kicad</text>
+  <text x="634" y="232" fill="#dbeafe" font-family="Arial, sans-serif" font-size="16">Default mode: readonly</text>
+  <text x="634" y="264" fill="#dbeafe" font-family="Arial, sans-serif" font-size="16">No tokens or private paths</text>
+  <text x="634" y="296" fill="#dbeafe" font-family="Arial, sans-serif" font-size="16">Project scoped config</text>
+</svg>

--- a/docs/development/contributing-fixtures.md
+++ b/docs/development/contributing-fixtures.md
@@ -20,3 +20,31 @@ Benchmark and regression fixtures live under `tests/fixtures/benchmark_projects/
 ## Test Placement
 
 Use unit tests for pure helpers, integration tests for file-backed tool behavior, and e2e tests for workflow-level regressions.
+
+## Live-preview fixture guidance
+
+Live-preview tests should use the smallest KiCad hierarchy that proves the behavior under test. A useful fixture has:
+
+- one root schematic, usually `demo.kicad_sch`;
+- one child sheet, for example `power.kicad_sch`;
+- a matching `demo.kicad_pro` project file;
+- a minimal board file only when the test also needs PCB context.
+
+The hierarchy fixture `tests/fixtures/benchmark_projects/fail_sismosmart_like_hierarchy/` is a good example of a root sheet plus child sheet layout. Live-preview tests can use this shape to verify that child-sheet edits are detected even when the root sheet itself is unchanged.
+
+## Adding a live-preview fixture
+
+1. Start from a minimal public KiCad project.
+2. Keep the root sheet and one child sheet unless the regression specifically needs more hierarchy.
+3. Use synthetic references and net names such as `R1`, `U1`, `GND`, `READY`, or `CHILD_LIVE`.
+4. Avoid vendor-specific or customer-specific identifiers unless they are public examples.
+5. Add a test that documents which file should appear in `changed_files`.
+6. Prefer rendered evidence or manifest assertions over brittle timestamp-only checks.
+
+## Review checklist
+
+- The fixture contains no private project names, hostnames, paths, or component sourcing credentials.
+- The fixture is small enough to inspect in a pull request.
+- The test explains whether it is checking root-sheet watch behavior, child-sheet discovery, debounce behavior, or fallback rendering.
+- The fixture does not require a graphical KiCad session unless the test is explicitly marked as GUI-only.
+

--- a/docs/workflows/live-preview.md
+++ b/docs/workflows/live-preview.md
@@ -77,6 +77,51 @@ Agent code should read structured fields instead of parsing human-readable messa
 
 Agents should ignore unknown fields for forward compatibility.
 
+
+## Manifest example
+
+A live-preview manifest should be durable, sanitized, and useful to both humans and agents. Prefer relative project paths where possible:
+
+```json
+{
+  "schema_version": "live-preview.manifest.v1",
+  "session_id": "lp-20260707-001",
+  "target_path": "hardware/demo.kicad_sch",
+  "watch": {
+    "include_child_sheets": true,
+    "files": ["hardware/demo.kicad_sch", "hardware/power.kicad_sch"],
+    "changed_files": ["hardware/power.kicad_sch"]
+  },
+  "debounce": {
+    "requested_ms": 750,
+    "state": "settled"
+  },
+  "render": {
+    "status": "ok",
+    "sheet_path": "hardware/power.kicad_sch",
+    "png_path": "artifacts/live-preview/lp-20260707-001.png",
+    "svg_path": "artifacts/live-preview/lp-20260707-001.svg",
+    "dpi": 200,
+    "include_title_block": true
+  },
+  "artifacts": [
+    {
+      "kind": "png",
+      "path": "artifacts/live-preview/lp-20260707-001.png",
+      "role": "rendered-preview",
+      "mime_type": "image/png"
+    }
+  ],
+  "warnings": [],
+  "safety": {
+    "uses_relative_paths": true,
+    "redacted_private_paths": true
+  }
+}
+```
+
+Do not expose private absolute workstation paths in public CI artifacts, screenshots, or issue comments.
+
 ## Troubleshooting
 
 If no preview appears, first check whether the response is `initialized` or `pending_debounce`. These are normal states. Call again after a schematic mutation or after the debounce window.


### PR DESCRIPTION
Closes #332.
Closes #335.
Closes #336.

Consolidates the remaining small onboarding docs tasks and keeps #314 open as the parent epic.

Also fixes the docs-only mcp-npm skip step so docs-only PRs do not fail before checkout.