### PR TITLE
feat(skill): add visual-excellence loop skill and workflow prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,8 @@
     "./skills/pcb-design",
     "./skills/drc-check",
     "./skills/fabrication-output",
-    "./skills/schematic-review"
+    "./skills/schematic-review",
+    "./skills/visual-excellence"
   ],
   "author": {
     "name": "oaslananka",

--- a/.opencode/skills/visual-excellence/SKILL.md
+++ b/.opencode/skills/visual-excellence/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: visual-excellence
+description: Drive a KiCad schematic to a professional, cosmetically clean state through a score → fix → render → verify loop using KiCad MCP Pro cosmetic tools.
+---
+
+# Visual Excellence Skill
+
+Use this skill when an AI agent is asked to make a KiCad schematic *look*
+professional — clean, readable, and conventionally drawn — not just electrically
+correct. It closes the loop between measuring cosmetic quality, applying safe
+fixes, and visually confirming the result.
+
+This skill is specific to `oaslananka/kicad-mcp-pro` and should be kept
+synchronized with `docs/tools-reference.generated.md`.
+
+## When to use
+
+- Post-capture cleanup before layout or review
+- Preparing a schematic for a datasheet, report, or customer hand-off
+- Whenever a sheet "works but looks rushed": off-grid parts, diagonal wires,
+  colliding labels, sideways power symbols, inconsistent fonts
+
+Do **not** use this skill to claim electrical correctness. Cosmetic fixes never
+substitute for ERC, connectivity review, or human engineering approval. Run
+`sch_visual_qa` / `run_erc` separately for correctness.
+
+## The invariant you can rely on
+
+Every cosmetic fixer treats **electrical connectivity as a hard invariant**. It
+computes a coordinate-independent connectivity signature before and after the
+change; a fixer that would alter any net is *refused* on apply and never writes.
+So you can apply fixes without fear of silently breaking a net — but always
+confirm with the render and the visual diff, and finish with an ERC pass.
+
+## Required context
+
+- Active project path and the schematic file(s)
+- The target cosmetic score (default: 80/100)
+- Whether you are allowed to modify the schematic (this skill mutates on
+  `apply=true`; it needs write operating mode)
+
+## Primary MCP tools
+
+### Measure
+
+- `sch_cosmetic_score` — 0–100 score with a per-category penalty breakdown and
+  the `worst_category` to fix first (`grid`, `wiring`, `typography`,
+  `orientation`, `layout_balance`, `readability`, `documentation`)
+- `sch_visual_qa` — readability findings (overlaps, off-sheet, dense fanout)
+
+### Fix (dry-run by default; pass `apply=true` to commit)
+
+- `sch_align_to_grid` — snap off-grid symbols, labels, wires, junctions
+- `sch_straighten_wires` — flatten almost-orthogonal wire segments
+- `sch_resolve_label_overlaps` — flip label justify so text stops colliding
+- `sch_normalize_power_orientation` — upright sideways power/ground symbols
+- `sch_normalize_text_sizes` — normalise outlier fonts onto the dominant size
+
+### See and verify
+
+- `sch_render_png` — render the sheet so you can visually evaluate it
+- `sch_render_visual_diff` — the exact before/after pixel delta of your last
+  mutation, plus the list of changed objects
+- `run_erc` — the electrical safety net after cosmetic edits
+
+## The loop
+
+Run this loop per sheet until the score meets the target or no fixer applies:
+
+1. **Measure.** Call `sch_cosmetic_score`. If `cosmetic_score` ≥ target, stop —
+   the sheet is clean. Otherwise read `worst_category`.
+2. **Plan (dry run).** Call the fixer matching `worst_category` with the default
+   `apply=false`. Read `connectivity_preserved` and the `changes` list.
+   - `grid` → `sch_align_to_grid`
+   - `wiring` → `sch_straighten_wires`
+   - `readability` (label overlaps) → `sch_resolve_label_overlaps`
+   - `orientation` → `sch_normalize_power_orientation`
+   - `typography` → `sch_normalize_text_sizes`
+3. **Decide.** If `connectivity_preserved` is `false`, do **not** apply — the fix
+   would change a net. Report it and hand back to the human (or fix the
+   underlying wiring first). If `true`, continue.
+4. **Apply.** Call the same fixer with `apply=true`. A `refused` status means the
+   invariant caught a connectivity change at commit time — treat it as step 3.
+5. **See.** Call `sch_render_png` and evaluate the image against the rubric
+   below. Call `sch_render_visual_diff` and confirm the red delta covers only the
+   objects you intended to move.
+6. **Re-measure.** Call `sch_cosmetic_score` again. Confirm the score rose and no
+   new category regressed. Return to step 1.
+7. **Guard.** After the loop, run `run_erc` to confirm the cosmetic pass left the
+   design electrically intact.
+
+Stop after a full pass where every applicable fixer reports `no_change`, even if
+the score is still below target — the remaining gap needs human layout judgment,
+not an automated fixer. Report what is left and why.
+
+## Rubric — what "professional" looks like
+
+When you evaluate a `sch_render_png`, check for:
+
+- **Grid** — parts and wires sit on a regular grid; nothing looks hand-nudged.
+- **Orthogonal wiring** — wires run horizontally/vertically; no diagonals.
+- **Legible labels** — net labels and reference designators do not overlap and
+  read cleanly against nearby text.
+- **Conventional symbols** — power up, ground down, no sideways power symbols.
+- **Consistent typography** — one dominant font size across the sheet.
+- **Balanced composition** — content spreads across the sheet rather than
+  crowding one corner.
+- **Complete title block** — title, revision, date, and company are filled in.
+
+Judge the rendered image, not just the score: the score is a fast proxy, but the
+render is the ground truth for readability.
+
+## Guardrails
+
+- Cosmetic ≠ correct. Never sign off electrical behavior from this skill.
+- Prefer dry runs first; only apply once `connectivity_preserved` is `true`.
+- If a fixer is refused, the underlying net topology needs a human — surface it,
+  do not force it.
+- End with `run_erc`; a clean cosmetic pass must also be a clean electrical one.

--- a/skills/visual-excellence/SKILL.md
+++ b/skills/visual-excellence/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: visual-excellence
+description: Drive a KiCad schematic to a professional, cosmetically clean state through a score → fix → render → verify loop using KiCad MCP Pro cosmetic tools.
+---
+
+# Visual Excellence Skill
+
+Use this skill when an AI agent is asked to make a KiCad schematic *look*
+professional — clean, readable, and conventionally drawn — not just electrically
+correct. It closes the loop between measuring cosmetic quality, applying safe
+fixes, and visually confirming the result.
+
+This skill is specific to `oaslananka/kicad-mcp-pro` and should be kept
+synchronized with `docs/tools-reference.generated.md`.
+
+## When to use
+
+- Post-capture cleanup before layout or review
+- Preparing a schematic for a datasheet, report, or customer hand-off
+- Whenever a sheet "works but looks rushed": off-grid parts, diagonal wires,
+  colliding labels, sideways power symbols, inconsistent fonts
+
+Do **not** use this skill to claim electrical correctness. Cosmetic fixes never
+substitute for ERC, connectivity review, or human engineering approval. Run
+`sch_visual_qa` / `run_erc` separately for correctness.
+
+## The invariant you can rely on
+
+Every cosmetic fixer treats **electrical connectivity as a hard invariant**. It
+computes a coordinate-independent connectivity signature before and after the
+change; a fixer that would alter any net is *refused* on apply and never writes.
+So you can apply fixes without fear of silently breaking a net — but always
+confirm with the render and the visual diff, and finish with an ERC pass.
+
+## Required context
+
+- Active project path and the schematic file(s)
+- The target cosmetic score (default: 80/100)
+- Whether you are allowed to modify the schematic (this skill mutates on
+  `apply=true`; it needs write operating mode)
+
+## Primary MCP tools
+
+### Measure
+
+- `sch_cosmetic_score` — 0–100 score with a per-category penalty breakdown and
+  the `worst_category` to fix first (`grid`, `wiring`, `typography`,
+  `orientation`, `layout_balance`, `readability`, `documentation`)
+- `sch_visual_qa` — readability findings (overlaps, off-sheet, dense fanout)
+
+### Fix (dry-run by default; pass `apply=true` to commit)
+
+- `sch_align_to_grid` — snap off-grid symbols, labels, wires, junctions
+- `sch_straighten_wires` — flatten almost-orthogonal wire segments
+- `sch_resolve_label_overlaps` — flip label justify so text stops colliding
+- `sch_normalize_power_orientation` — upright sideways power/ground symbols
+- `sch_normalize_text_sizes` — normalise outlier fonts onto the dominant size
+
+### See and verify
+
+- `sch_render_png` — render the sheet so you can visually evaluate it
+- `sch_render_visual_diff` — the exact before/after pixel delta of your last
+  mutation, plus the list of changed objects
+- `run_erc` — the electrical safety net after cosmetic edits
+
+## The loop
+
+Run this loop per sheet until the score meets the target or no fixer applies:
+
+1. **Measure.** Call `sch_cosmetic_score`. If `cosmetic_score` ≥ target, stop —
+   the sheet is clean. Otherwise read `worst_category`.
+2. **Plan (dry run).** Call the fixer matching `worst_category` with the default
+   `apply=false`. Read `connectivity_preserved` and the `changes` list.
+   - `grid` → `sch_align_to_grid`
+   - `wiring` → `sch_straighten_wires`
+   - `readability` (label overlaps) → `sch_resolve_label_overlaps`
+   - `orientation` → `sch_normalize_power_orientation`
+   - `typography` → `sch_normalize_text_sizes`
+3. **Decide.** If `connectivity_preserved` is `false`, do **not** apply — the fix
+   would change a net. Report it and hand back to the human (or fix the
+   underlying wiring first). If `true`, continue.
+4. **Apply.** Call the same fixer with `apply=true`. A `refused` status means the
+   invariant caught a connectivity change at commit time — treat it as step 3.
+5. **See.** Call `sch_render_png` and evaluate the image against the rubric
+   below. Call `sch_render_visual_diff` and confirm the red delta covers only the
+   objects you intended to move.
+6. **Re-measure.** Call `sch_cosmetic_score` again. Confirm the score rose and no
+   new category regressed. Return to step 1.
+7. **Guard.** After the loop, run `run_erc` to confirm the cosmetic pass left the
+   design electrically intact.
+
+Stop after a full pass where every applicable fixer reports `no_change`, even if
+the score is still below target — the remaining gap needs human layout judgment,
+not an automated fixer. Report what is left and why.
+
+## Rubric — what "professional" looks like
+
+When you evaluate a `sch_render_png`, check for:
+
+- **Grid** — parts and wires sit on a regular grid; nothing looks hand-nudged.
+- **Orthogonal wiring** — wires run horizontally/vertically; no diagonals.
+- **Legible labels** — net labels and reference designators do not overlap and
+  read cleanly against nearby text.
+- **Conventional symbols** — power up, ground down, no sideways power symbols.
+- **Consistent typography** — one dominant font size across the sheet.
+- **Balanced composition** — content spreads across the sheet rather than
+  crowding one corner.
+- **Complete title block** — title, revision, date, and company are filled in.
+
+Judge the rendered image, not just the score: the score is a fast proxy, but the
+render is the ground truth for readability.
+
+## Guardrails
+
+- Cosmetic ≠ correct. Never sign off electrical behavior from this skill.
+- Prefer dry runs first; only apply once `connectivity_preserved` is `true`.
+- If a fixer is refused, the underlying net topology needs a human — surface it,
+  do not force it.
+- End with `run_erc`; a clean cosmetic pass must also be a clean electrical one.

--- a/src/kicad_mcp/prompts/workflows.py
+++ b/src/kicad_mcp/prompts/workflows.py
@@ -197,6 +197,38 @@ Run a closed-loop design review instead of trusting a single build pass.
         return [TextContent(type="text", text=text)]
 
     @mcp.prompt()
+    def visual_excellence_loop() -> list[TextContent]:
+        """Score → fix → render → verify loop for professional schematic cosmetics."""
+        text = """
+Drive the schematic to a professional, cosmetically clean state with a measured
+loop. Cosmetic fixers keep electrical connectivity as a hard invariant, so apply
+them without fear — but verify the render and finish with ERC.
+
+Run this loop per sheet until the score meets the target (default 80/100) or no
+fixer applies:
+
+1. Measure with `sch_cosmetic_score()`. If the score is at target, stop. Else
+   read `worst_category`.
+2. Dry-run the matching fixer (default `apply=false`) and read
+   `connectivity_preserved`:
+   - `grid` -> `sch_align_to_grid()`
+   - `wiring` -> `sch_straighten_wires()`
+   - `readability` -> `sch_resolve_label_overlaps()`
+   - `orientation` -> `sch_normalize_power_orientation()`
+   - `typography` -> `sch_normalize_text_sizes()`
+3. If `connectivity_preserved` is false, do not apply — the fix would change a
+   net; surface it for a human. If true, apply with `apply=true`.
+4. See it: `sch_render_png()`, then `sch_render_visual_diff()` to confirm the
+   delta covers only the objects you intended to move.
+5. Re-measure with `sch_cosmetic_score()`; confirm the score rose. Repeat.
+6. When every applicable fixer reports `no_change`, stop even if below target —
+   the rest needs human layout judgment. Report what is left.
+7. Finish with `run_erc()`: a clean cosmetic pass must also be electrically
+   clean. Cosmetic checks never substitute for ERC or human approval.
+""".strip()
+        return [TextContent(type="text", text=text)]
+
+    @mcp.prompt()
     def fix_blocking_issues() -> list[TextContent]:
         """Prompt focused on consuming the fix queue and clearing blockers."""
         text = """

--- a/tests/integration/test_prompt_workflows.py
+++ b/tests/integration/test_prompt_workflows.py
@@ -20,6 +20,7 @@ async def test_workflow_prompts_expose_v3_canonical_sequences() -> None:
     post_route = await get_prompt_text(server, "post_placement_routing", {})
     manufacturing = await get_prompt_text(server, "manufacturing_export", {})
     review = await get_prompt_text(server, "design_review_loop", {})
+    visual = await get_prompt_text(server, "visual_excellence_loop", {})
     blocking = await get_prompt_text(server, "fix_blocking_issues", {})
     release = await get_prompt_text(server, "manufacturing_release_checklist", {})
     high_speed = await get_prompt_text(server, "high_speed_review_loop", {})
@@ -34,6 +35,8 @@ async def test_workflow_prompts_expose_v3_canonical_sequences() -> None:
     assert "post-placement routing loop" in post_route
     assert "export_manufacturing_package" in manufacturing
     assert "kicad://project/fix_queue" in review
+    assert "sch_cosmetic_score" in visual
+    assert "connectivity_preserved" in visual
     assert "project_get_next_action" in blocking
     assert "Treat manufacturing release as a gated handoff" in release
     assert "critical nets" in high_speed


### PR DESCRIPTION
## Summary

Phase C of the Visual Excellence Loop. Adds the skill and workflow prompt that turn the Phase A score (`sch_cosmetic_score`, #378) and the Phase B fixers (#380) into a repeatable procedure an agent can follow to drive a schematic to a professional, cosmetically clean state.

- `skills/visual-excellence/SKILL.md` (mirrored to `.opencode/skills/` for OpenCode-native loading) — the **score → fix → render → verify** loop: measure with `sch_cosmetic_score`, dry-run the fixer matching `worst_category`, apply only when `connectivity_preserved` is true, confirm with `sch_render_png` + `sch_render_visual_diff`, re-score, and finish with `run_erc`. Includes a rubric for judging the rendered sheet and guardrails that cosmetic fixes never substitute for electrical review.
- registers the skill in the plugin manifest.
- adds the `visual_excellence_loop` workflow prompt with the same sequence.

## Type of change

- [x] Documentation / skill / prompt

## Validation

- [x] `test_prompt_workflows` extended to assert the new prompt renders with the loop's key signals
- [x] prompt registers on the server; plugin manifest is valid JSON with the new skill
- [x] `ruff format`/`check` clean; no generated-file or tool-surface drift (no new tools)
- [x] strict prompt-count tests (`test_reviewer_prompts`, `test_server`) unaffected

## Safety and compatibility

- [x] Public tool contracts, generated docs, metadata, and compatibility matrices are updated when needed. (skill/prompt only; no tool surface change)
- [x] The skill insists cosmetic fixes are gated by the connectivity invariant, verified by render, and followed by ERC — it never claims electrical sign-off.
- [x] Logs, fixtures, screenshots, and generated artifacts do not contain secrets or private board data.
- [x] Approximate / heuristic behavior is described honestly (the score is a proxy; the render is ground truth).

## Release notes

Adds a visual-excellence skill and `visual_excellence_loop` workflow prompt that drive schematic cosmetic cleanup through a score → fix → render → verify loop.