### PR TITLE
feat(gate): add advisory schematic cosmetics quality gate

### DIFF
--- a/src/kicad_mcp/tools/fixers.py
+++ b/src/kicad_mcp/tools/fixers.py
@@ -155,6 +155,35 @@ GATE_FIXERS: dict[str, list[FixerAction]] = {
             description="Inspect footprint-parity details to identify mismatched refs.",
         ),
     ],
+    # Advisory only — cosmetic fixers mutate the schematic and default to a dry
+    # run, so they are surfaced as suggestions (never auto-applied in the loop)
+    # to respect the review-before-write workflow.
+    "Schematic cosmetics": [
+        FixerAction(
+            tool="sch_cosmetic_score",
+            description="Re-score cosmetics and read worst_category to pick the right fixer.",
+        ),
+        FixerAction(
+            tool="sch_align_to_grid",
+            description="Snap off-grid symbols/labels/wires to the grid (dry run, then apply).",
+        ),
+        FixerAction(
+            tool="sch_straighten_wires",
+            description="Flatten almost-orthogonal wires (dry run, then apply=true).",
+        ),
+        FixerAction(
+            tool="sch_resolve_label_overlaps",
+            description="De-conflict overlapping labels by flipping justify (dry run, then apply).",
+        ),
+        FixerAction(
+            tool="sch_normalize_power_orientation",
+            description="Upright sideways power symbols (dry run, then apply=true).",
+        ),
+        FixerAction(
+            tool="sch_normalize_text_sizes",
+            description="Normalise outlier fonts to the dominant size (dry run, then apply=true).",
+        ),
+    ],
 }
 
 # Gate names that, when failing, block *all* downstream gates.

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -1031,6 +1031,60 @@ def _empty_child_sheet_ids(top_file: Path) -> set[str]:
     return ignored
 
 
+# Sheets scoring below this are flagged (advisory only — cosmetic quality never
+# blocks release).
+_COSMETIC_GATE_THRESHOLD = 80.0
+
+
+def _evaluate_schematic_cosmetics_gate() -> GateOutcome:
+    """Advisory gate on schematic cosmetic quality (never blocks release).
+
+    Scores every sheet with the deterministic cosmetic engine and reports the
+    worst. Below the threshold it returns WARN with the worst category, so the
+    fix queue surfaces the cosmetic tools without gating manufacturing.
+    """
+    from ..models.visual_qa import run_cosmetic_qa
+    from .schematic import project_schematic_files
+
+    try:
+        sheets = project_schematic_files()
+    except Exception:
+        sheets = []
+    if not sheets:
+        return GateOutcome("Schematic cosmetics", "PASS", "No schematic sheets to score.")
+
+    worst_score = 100.0
+    worst_sheet = ""
+    worst_category = ""
+    details: list[str] = []
+    for sch in sheets:
+        try:
+            text = sch.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        report = run_cosmetic_qa(text)
+        score = float(cast(float, report["cosmetic_score"]))
+        category = str(report.get("worst_category") or "")
+        details.append(f"{sch.name}: score {score:.0f} (worst: {category or 'none'})")
+        if score < worst_score:
+            worst_score, worst_sheet, worst_category = score, sch.name, category
+
+    if worst_score >= _COSMETIC_GATE_THRESHOLD:
+        return GateOutcome(
+            "Schematic cosmetics",
+            "PASS",
+            f"Cosmetic score {worst_score:.0f}/100 across all sheets.",
+            details,
+        )
+    return GateOutcome(
+        "Schematic cosmetics",
+        "WARN",
+        f"Cosmetic score {worst_score:.0f}/100 on {worst_sheet} "
+        f"(worst category: {worst_category or 'none'}). Advisory — does not block release.",
+        details,
+    )
+
+
 def _evaluate_schematic_connectivity_gate() -> GateOutcome:
     from .schematic import _build_connectivity_groups, parse_schematic_file
 
@@ -2165,6 +2219,7 @@ def _evaluate_project_gate(
         ("schematic", _evaluate_schematic_gate),
         ("connectivity", _evaluate_schematic_connectivity_gate),
         ("connectivity", _evaluate_pre_sync_gate),
+        ("schematic", _evaluate_schematic_cosmetics_gate),
         ("pcb", _evaluate_pcb_gate),
         ("pcb", _evaluate_pcb_placement_gate),
         ("pcb", _evaluate_pcb_transfer_gate),

--- a/tests/unit/test_cosmetics_gate.py
+++ b/tests/unit/test_cosmetics_gate.py
@@ -1,0 +1,86 @@
+"""Unit tests for the advisory schematic-cosmetics quality gate (Phase E)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.tools.fixers import BLOCKING_GATES, GATE_FIXERS, fixers_for_gate
+
+_CLEAN_SCH = """(kicad_sch (paper "A4")
+  (title_block (title "Clean") (rev "A") (date "2026-01-01") (company "Acme"))
+  (wire (pts (xy 50.8 50.8) (xy 63.5 50.8)))
+  (label "NET_A" (at 50.8 40.64 0) (effects (font (size 1.27 1.27))))
+)"""
+
+_UGLY_SCH = """(kicad_sch (paper "A4")
+  (wire (pts (xy 50.7 40.0) (xy 63.4 40.3)))
+  (label "NET_A" (at 50.7 40.0 0) (effects (font (size 2.54 2.54))))
+  (label "NET_B" (at 63.4 40.3 0) (effects (font (size 1.27 1.27))))
+  (junction (at 50.7 40.0))
+)"""
+
+
+def test_cosmetics_gate_is_advisory_and_suggest_only() -> None:
+    # The gate must never block release, and its fixers are suggestions only.
+    assert "Schematic cosmetics" not in BLOCKING_GATES
+    fixers = fixers_for_gate("Schematic cosmetics")
+    assert fixers, "cosmetics gate should have fixer suggestions"
+    assert all(not fixer.auto_applicable for fixer in fixers)
+    tools = {fixer.tool for fixer in fixers}
+    assert "sch_align_to_grid" in tools
+    assert "sch_cosmetic_score" in tools
+
+
+def test_cosmetics_gate_fixers_have_no_broken_callables() -> None:
+    from kicad_mcp.tools.fixers import validate_callable_imports
+
+    assert validate_callable_imports(GATE_FIXERS) == []
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_cosmetics_gate_passes_on_clean_sheet(sample_project: Path) -> None:
+    from kicad_mcp.server import build_server
+    from kicad_mcp.tools.validation import _evaluate_schematic_cosmetics_gate
+    from tests.conftest import call_tool_text
+
+    (sample_project / "demo.kicad_sch").write_text(_CLEAN_SCH, encoding="utf-8")
+    server = build_server("schematic")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    outcome = _evaluate_schematic_cosmetics_gate()
+    assert outcome.name == "Schematic cosmetics"
+    assert outcome.status == "PASS"
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_cosmetics_gate_warns_on_ugly_sheet(sample_project: Path) -> None:
+    from kicad_mcp.server import build_server
+    from kicad_mcp.tools.validation import _evaluate_schematic_cosmetics_gate
+    from tests.conftest import call_tool_text
+
+    (sample_project / "demo.kicad_sch").write_text(_UGLY_SCH, encoding="utf-8")
+    server = build_server("schematic")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    outcome = _evaluate_schematic_cosmetics_gate()
+    assert outcome.status == "WARN"
+    assert "does not block release" in outcome.summary
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_cosmetics_gate_included_in_project_gate(sample_project: Path) -> None:
+    from kicad_mcp.server import build_server
+    from kicad_mcp.tools.validation import _evaluate_project_gate
+    from tests.conftest import call_tool_text
+
+    (sample_project / "demo.kicad_sch").write_text(_CLEAN_SCH, encoding="utf-8")
+    server = build_server("schematic")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    names = {outcome.name for outcome in _evaluate_project_gate()}
+    assert "Schematic cosmetics" in names


### PR DESCRIPTION
## Summary

Phase E (final) of the Visual Excellence Loop. Wires the cosmetic score (#378) into the project quality gate and fix queue, so cosmetic quality is tracked alongside the electrical gates — **without ever blocking a release**.

- `_evaluate_schematic_cosmetics_gate` scores every sheet and returns `PASS` at/above the threshold (80/100), else `WARN` naming the worst sheet and category. `WARN` is advisory: sign-off treats it as "passed with advisories" and manufacturing export never blocks on it (its `blocking` set is fed by specific electrical criteria, not the project-gate roll-up).
- registered in the project gate evaluators under the `schematic` category, after the electrical schematic gates so real blockers come first.
- adds a `Schematic cosmetics` list to the gate fixer registry, **suggestion-only** (never auto-applied): the cosmetic fixers mutate the schematic and default to a dry run, so the loop surfaces them as recommended tools rather than applying them automatically — respecting the review-before-write workflow and avoiding a non-converging loop.

## Design notes

- Not in `BLOCKING_GATES`; adds no auto-fixer callables → the validation loop cannot spin on it or mutate a schematic without review.
- Threshold 80; the benchmark pass-fixtures score 96, so they stay `PASS` (no gate flips).

## Type of change

- [x] Feature

## Validation

- [x] gate `PASS` on a clean sheet, `WARN` on an ugly one, and present in `_evaluate_project_gate()`
- [x] `validate_callable_imports(GATE_FIXERS)` still clean; gate is suggest-only and not blocking
- [x] broad gate/validation/project/e2e regression tests green (no existing gate behavior changed)
- [x] full `tests/unit` suite green; `ruff format`/`check`/`mypy` clean; no tool-surface change

## Safety and compatibility

- [x] Public tool contracts, generated docs, metadata, and compatibility matrices are updated when needed. (no new tools; internal gate only)
- [x] Cosmetic quality is advisory — it never blocks manufacturing or claims electrical sign-off.
- [x] Logs, fixtures, screenshots, and generated artifacts do not contain secrets or private board data.
- [x] Approximate / heuristic behavior is described honestly (the score is a proxy; the gate is advisory).

## Release notes

Adds an advisory "Schematic cosmetics" quality gate that surfaces cosmetic score in the project gate and fix queue without blocking release.