### PR TITLE
ci: add manual token fallback for PyPI/TestPyPI publishing

### DIFF
--- a/.github/workflows/publish-python-token.yml
+++ b/.github/workflows/publish-python-token.yml
@@ -1,0 +1,100 @@
+name: Publish Python (token fallback)
+
+# Manual, token-authenticated fallback for publishing to PyPI / TestPyPI.
+#
+# The PRIMARY publish path is trusted publishing (OIDC) in publish-python.yml.
+# Use this workflow ONLY when OIDC is unavailable — for example right after a
+# repository rename, before the PyPI/TestPyPI trusted-publisher configuration is
+# updated to the new repository name. It is manual-only (workflow_dispatch) and
+# never runs on release, so it cannot fire automatically.
+#
+# Token publishing does NOT produce PEP 740 attestations (those require OIDC), so
+# prefer fixing the trusted publisher and returning to publish-python.yml.
+#
+# Setup: create the gated environments `pypi-token` and `testpypi-token` (add
+# required reviewers), and add an environment secret named PYPI_PUBLISH_TOKEN to
+# each — the real PyPI token on `pypi-token`, the TestPyPI token on
+# `testpypi-token`. The workflow selects the environment (and therefore the
+# correct token) from the chosen target.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which index to publish to
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+permissions:
+  contents: read
+
+jobs:
+  publish-token:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    runs-on: ubuntu-24.04
+    environment:
+      name: ${{ inputs.target == 'pypi' && 'pypi-token' || 'testpypi-token' }}
+      url: ${{ inputs.target == 'pypi' && 'https://pypi.org/p/kicad-mcp-pro' || 'https://test.pypi.org/p/kicad-mcp-pro' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: false
+          version-file: uv.toml
+      - run: uv sync --all-extras --frozen
+      - run: uv build
+      - name: Generate and verify local checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --all-extras python scripts/generate_release_evidence.py generate \
+            --dist-dir dist \
+            --output release-evidence
+          uv run --all-extras python scripts/generate_release_evidence.py verify-local \
+            --checksums release-evidence/SHA256SUMS.txt \
+            --artifacts dist
+          (cd dist && sha256sum --check ../release-evidence/SHA256SUMS.txt)
+      - name: Check if version already published
+        id: check-published
+        env:
+          TARGET: ${{ inputs.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(uv run --frozen python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          if [ "$TARGET" = "pypi" ]; then
+            base="https://pypi.org"
+          else
+            base="https://test.pypi.org"
+          fi
+          if curl -fsS "${base}/pypi/kicad-mcp-pro/${version}/json" >/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish with API token
+        if: steps.check-published.outputs.already_published != 'true'
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          packages-dir: dist
+          repository-url: ${{ inputs.target == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          password: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+          # Token auth cannot mint OIDC attestations; keep this false.
+          attestations: false
+      - name: Verify published digests
+        env:
+          TARGET: ${{ inputs.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(uv run --frozen python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          uv run --frozen python scripts/generate_release_evidence.py verify-pypi \
+            --repository "$TARGET" \
+            --package kicad-mcp-pro \
+            --version "$version" \
+            --checksums release-evidence/SHA256SUMS.txt

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -19,6 +19,27 @@ The release workflow uses PyPI Trusted Publishing through GitHub Actions OIDC.
 Long-lived package-index token secrets should not be needed once the PyPI
 trusted publisher is configured.
 
+### Token fallback (manual, OIDC unavailable)
+
+`.github/workflows/publish-python-token.yml` is a manual-only
+(`workflow_dispatch`) fallback for when trusted publishing cannot run — most
+commonly right after a repository rename, before the PyPI/TestPyPI
+trusted-publisher configuration is updated to the new repository name (the OIDC
+claim carries the new name while PyPI still expects the old one, so the primary
+path fails).
+
+The preferred fix is to update the trusted publisher's repository name on PyPI
+and TestPyPI and return to the OIDC path. The token fallback exists only to
+unblock a publish in the meantime. Note that token authentication cannot mint
+PEP 740 attestations.
+
+To use it: create the gated environments `pypi-token` and `testpypi-token` (add
+required reviewers), then add an environment secret named `PYPI_PUBLISH_TOKEN`
+to each — the real PyPI project token on `pypi-token`, the TestPyPI project
+token on `testpypi-token`. Run the workflow and pick the `target`; the chosen
+environment supplies the matching token. Use project-scoped tokens, not
+account-wide ones.
+
 ## GitHub Releases
 
 GitHub Release artifacts are produced by `.github/workflows/release-please.yml`.

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -27,6 +27,24 @@ def test_protocol_schema_release_contract_matches_existing_release_history() -> 
     assert "startsWith(github.event.release.tag_name, 'protocol-schemas-v')" in workflow
 
 
+def test_python_token_fallback_is_manual_only_and_tokenized() -> None:
+    workflow = _read(".github/workflows/publish-python-token.yml")
+
+    # Manual-only: it must never run on release (that path stays OIDC).
+    assert "workflow_dispatch:" in workflow
+    assert "\n  release:" not in workflow
+    # Token auth, not OIDC — and token cannot mint attestations.
+    assert "password: ${{ secrets.PYPI_PUBLISH_TOKEN }}" in workflow
+    assert "attestations: false" in workflow
+    # Same supply-chain guards as the primary publish path.
+    assert "Check if version already published" in workflow
+    assert "steps.check-published.outputs.already_published != 'true'" in workflow
+    assert "github.repository_owner == 'oaslananka'" in workflow
+    assert "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in workflow
+    # It must not request id-token (that is the OIDC path's privilege).
+    assert "id-token: write" not in workflow
+
+
 def test_publish_workflows_are_idempotent_for_existing_versions() -> None:
     python_workflow = _read(".github/workflows/publish-python.yml")
     npm_workflow = _read(".github/workflows/publish-npm.yml")


### PR DESCRIPTION
## Summary

Adds a manual, token-authenticated fallback for publishing to PyPI / TestPyPI, without touching the primary trusted-publishing (OIDC) path in `publish-python.yml`.

**Why:** after the repository rename (`kicad-mcp` → `kicad-mcp-pro`), the PyPI/TestPyPI trusted-publisher config still references the old repository name, so the OIDC claim no longer matches and the primary publish path fails until the trusted publisher is updated. This workflow unblocks a publish in the meantime.

- `publish-python-token.yml` — `workflow_dispatch` **only** (never runs on release), with a `target` choice (`testpypi` / `pypi`). It is gated behind per-target environments (`pypi-token` / `testpypi-token`) so a token secret and required reviewers can be attached, and it keeps the same supply-chain guards as the primary path: checksum verify before and after, version-already-published idempotency, owner guard, and pinned action SHAs. `attestations: false` and no `id-token` are requested, because token auth cannot mint PEP 740 attestations.
- `docs/publishing.md` documents the fallback and its setup, and states the preferred fix is to update the trusted publisher and return to OIDC.

## Setup (one-time, needs PyPI login)

Create the gated environments `pypi-token` and `testpypi-token` (add required reviewers), then add an environment secret `PYPI_PUBLISH_TOKEN` to each — the real PyPI project token on `pypi-token`, the TestPyPI project token on `testpypi-token`. The workflow selects the environment (and matching token) from the chosen target. Use project-scoped tokens, not account-wide ones.

## Type of change

- [x] Release / packaging / supply chain

## Validation

- [x] `zizmor --min-severity high` clean on the new file and across all workflows
- [x] test asserts manual-only (no `release:` trigger), token auth, `attestations: false`, no `id-token`, and the shared guards
- [x] release/security workflow tests (`test_release_workflows`, `test_release_hardening`, `test_release_preflight_guard`, `test_ruleset_consistency`) green
- [x] `ruff format`/`check` clean

## Safety and compatibility

- [x] Primary OIDC path in `publish-python.yml` is byte-for-byte unchanged.
- [x] Token path is manual-only, environment-gated, and idempotent; it disables attestations honestly rather than pretending to sign.
- [x] Logs, fixtures, and generated artifacts do not contain secrets.
- [x] Approximate / heuristic behavior is described honestly (docs state the token path loses attestations and OIDC is preferred).

## Release notes

Adds a manual token-based PyPI/TestPyPI publish fallback for use when trusted publishing (OIDC) is unavailable.