### PR TITLE
chore: ignore local tool dirs and keep plugin manifest version in sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "kicad-pro",
-  "version": "3.19.0",
+  "version": "3.24.0",
   "description": "KiCad MCP Pro plugin for schematic review, PCB design assistance, DRC/ERC validation, DFM checks, and manufacturing release workflows.",
   "skills": [
     "./skills/kicad-design-review",

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ TEMP/
 # Tauri / Rust build artifacts
 src-tauri/target/
 src-tauri/Cargo.lock
+src-tauri/gen/
+
+# Serena local index cache
+.serena/

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,6 +52,11 @@
           "jsonpath": "$.version"
         },
         {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
           "type": "yaml",
           "path": "compatibility.yaml",
           "jsonpath": "$.products.kicad-mcp-pro.version"

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -214,3 +214,21 @@ def test_docs_workflow_uses_properdocs_to_avoid_mkdocs_2_warning() -> None:
 
     assert "uv run properdocs build -f mkdocs.yml --strict" in workflow
     assert "python -m mkdocs build" not in workflow
+
+
+def test_plugin_manifest_version_tracks_package_and_is_release_managed() -> None:
+    """The Claude plugin manifest version must match the package and be release-managed.
+
+    It drifted (3.19.0 vs 3.24.0) because release-please did not bump it; this locks
+    the version to pyproject and asserts the manifest is listed as a release extra-file
+    so future releases keep it in sync automatically.
+    """
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = pyproject["project"]["version"]
+    plugin = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    assert plugin["version"] == version
+
+    config = json.loads((ROOT / "release-please-config.json").read_text(encoding="utf-8"))
+    extra_files = config["packages"]["."]["extra-files"]
+    tracked = {(entry["path"], entry.get("jsonpath")) for entry in extra_files}
+    assert (".claude-plugin/plugin.json", "$.version") in tracked


### PR DESCRIPTION
## Summary

Two small housekeeping fixes surfaced during recent work.

- **`.gitignore`**: ignore `src-tauri/gen/` (generated Tauri schemas) and the local Serena index cache, which appeared as untracked noise in every `git status`.
- **Plugin manifest version drift**: the plugin manifest was pinned at `3.19.0` while the package is `3.24.0`, because release-please never bumped it. This syncs it to `3.24.0` and adds it to the release-please `extra-files` for the root package, so future releases bump it in lockstep with the package version. A test locks the manifest version to `pyproject.toml` and asserts it is release-managed, so the drift cannot recur.

## Type of change

- [x] Refactor / maintenance

## Validation

- [x] `git check-ignore` confirms both paths are now ignored; `git status` is clean of the noise
- [x] new test asserts manifest version == package version and that the manifest is in `extra-files`
- [x] release metadata/hardening/workflow tests green; `ruff format`/`check` clean; JSON valid

## Safety and compatibility

- [x] No runtime or tool-surface change; metadata and release config only.
- [x] Logs, fixtures, and generated artifacts do not contain secrets.

## Release notes

None (housekeeping).