### PR TITLE
fix(gate-history): store gate history in the canonical .kicad-mcp state dir

### DIFF
--- a/src/kicad_mcp/resources/gate_history.py
+++ b/src/kicad_mcp/resources/gate_history.py
@@ -40,7 +40,9 @@ class GateHistory:
     @classmethod
     def for_active_project(cls) -> GateHistory:
         root = get_config().project_root
-        state_dir = root / ".kicad_mcp"
+        # Canonical MCP state dir is ".kicad-mcp" (hyphen) everywhere else; keep
+        # gate history in the same place rather than a second ".kicad_mcp" dir.
+        state_dir = root / ".kicad-mcp"
         state_dir.mkdir(parents=True, exist_ok=True)
         history = cls(state_dir / "gate_history.db")
         history._init()

--- a/tests/unit/test_gate_history.py
+++ b/tests/unit/test_gate_history.py
@@ -4,6 +4,7 @@ import sqlite3
 from contextlib import closing
 from pathlib import Path
 
+import kicad_mcp.resources.gate_history as gate_history_module
 from kicad_mcp.resources.gate_history import GateHistory
 from kicad_mcp.tools.validation import GateOutcome
 
@@ -48,3 +49,20 @@ def test_gate_history_schema_migration_sets_user_version(tmp_path: Path) -> None
         user_version = db.execute("PRAGMA user_version").fetchone()[0]
 
     assert user_version == 1
+
+
+def test_for_active_project_uses_canonical_state_dir(tmp_path: Path, monkeypatch) -> None:
+    """Gate history must live in the canonical ".kicad-mcp" state dir (hyphen),
+    not a second ".kicad_mcp" directory that diverges from the rest of the tools.
+    """
+
+    class _Cfg:
+        project_root = tmp_path
+
+    monkeypatch.setattr(gate_history_module, "get_config", lambda: _Cfg())
+
+    history = GateHistory.for_active_project()
+
+    assert history.db_path == tmp_path / ".kicad-mcp" / "gate_history.db"
+    assert (tmp_path / ".kicad-mcp").is_dir()
+    assert not (tmp_path / ".kicad_mcp").exists()


### PR DESCRIPTION
## Bug

`GateHistory.for_active_project()` wrote its SQLite DB to `<project>/.kicad_mcp/`
(underscore), but every other tool uses `.kicad-mcp` (hyphen — 21 references in
`src/`). Gate history therefore persisted to a **separate directory** from all
other MCP state (checkpoints, plans, visual baselines, …).

## Fix

Unify on the canonical `.kicad-mcp` (hyphen) directory. One-line change plus a
regression test that locks the path and asserts the old `.kicad_mcp` directory is
not created.

Note: `.gitignore` already ignores `.kicad-mcp/` (added recently), so this also
means gate history is now git-ignored by the same rule as the rest of the state.
