### PR TITLE
docs: fix stale kicad-mcp repo references left by the rename

### DIFF
--- a/docs/repo-maturity-report.md
+++ b/docs/repo-maturity-report.md
@@ -6,7 +6,7 @@ Mode: audit + implementation PR
 
 ## Executive summary
 
-`kicad-mcp` already has many strong professional open-source signals: README, MIT license, contribution guide, code of conduct, security policy, support policy, release automation, CI, CodeQL, Gitleaks, Scorecard, fuzzing, package metadata, OpenSSF Silver evidence, generated tool references, and documented governance.
+`kicad-mcp-pro` already has many strong professional open-source signals: README, MIT license, contribution guide, code of conduct, security policy, support policy, release automation, CI, CodeQL, Gitleaks, Scorecard, fuzzing, package metadata, OpenSSF Silver evidence, generated tool references, and documented governance.
 
 The current maturity level is **Professional OSS / Mature OSS**. This report does **not** claim Gold or foundation-grade status because several conditions need human confirmation or are not yet true: single active maintainer, no evidence of independent human PR review in sampled recent PRs, classic branch protection is not used because an active GitHub ruleset protects `main`, and only team-growth controls remain out of scope for a solo maintainer.
 

--- a/docs/security/release-integrity.md
+++ b/docs/security/release-integrity.md
@@ -113,7 +113,7 @@ GitHub Actions OIDC. PyPI and TestPyPI project owners must configure trusted
 publishers for the package-index environments:
 
 - Owner: `oaslananka`
-- Repository: `kicad-mcp`
+- Repository: `kicad-mcp-pro`
 - Workflow: `publish-python.yml`
 - Environments: `pypi` and `testpypi`
 

--- a/docs/submission/openai-mcp-registry.md
+++ b/docs/submission/openai-mcp-registry.md
@@ -93,7 +93,7 @@ OIDC under the `oaslananka` namespace (`id-token: write`).
 - [ ] Confirm workflow is `release-please.yml`.
 - [ ] Confirm release environment is `release`.
 - [ ] Confirm owner is `oaslananka`.
-- [ ] Confirm repository is `kicad-mcp`.
+- [ ] Confirm repository is `kicad-mcp-pro`.
 - [ ] Confirm OIDC `id-token: write` remains configured for release publish.
 - [ ] Remove token-based PyPI secrets after Trusted Publishing is active.
 - [ ] Do not paste PyPI credentials into registry forms or docs.


### PR DESCRIPTION
## What

Three docs still called the repository `kicad-mcp` after it was renamed to
`kicad-mcp-pro`:

- `docs/submission/openai-mcp-registry.md` — submission checklist "Confirm
  repository is `kicad-mcp`" (misleading for an actual submission step).
- `docs/security/release-integrity.md` — "Repository: `kicad-mcp`".
- `docs/repo-maturity-report.md` — body line, while the doc's own header already
  reads `oaslananka/kicad-mcp-pro` (internal inconsistency).

## Left intentionally unchanged

Verified these `kicad-mcp` occurrences are correct, not stale:

- `.kicad-mcp/` — the runtime state directory (hyphen is canonical).
- `@kicad-mcp/opencode-plugin` — the real npm package name in
  `integrations/opencode/.../package.json`.
- "kicad-mcp companion" — matches `packages/kicad-plugin/__init__.py`.

## Checks

Docs nav has no missing files; `generate_tools_reference.py` and
`build_parity_matrix.py` produce no drift.
