### PR TITLE
docs: add a discreet Sponsor / Buy me a coffee footer link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,10 @@ site_name: KiCad MCP Pro
 site_url: https://oaslananka.github.io/kicad-mcp-pro
 repo_url: https://github.com/oaslananka/kicad-mcp-pro
 repo_name: oaslananka/kicad-mcp-pro
+copyright: >
+  &copy; 2026 oaslananka &middot;
+  <a href="https://github.com/sponsors/oaslananka">Sponsor</a> &middot;
+  <a href="https://www.buymeacoffee.com/oaslananka">Buy me a coffee</a>
 theme:
   name: material
   palette:


### PR DESCRIPTION
Adds a low-key funding line to the MkDocs footer (rendered on every docs page): **GitHub Sponsors** (primary) and **Buy me a coffee** (secondary). Kept off the core product/app UI on purpose — funding belongs in the docs footer, not the tool workspace. Verified with a strict `properdocs build`; footer renders both links.