### PR TITLE
fix(repo): make CITATION.cff version track release-please

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 repository-code: "https://github.com/oaslananka/kicad-mcp-pro"
 url: "https://oaslananka.github.io/kicad-mcp-pro"
 license: MIT
-version: "3.17.1"
-date-released: "2026-07-03"
+version: "3.25.0" # x-release-please-version
+date-released: "2026-07-10"
 keywords:
   - KiCad
   - EDA


### PR DESCRIPTION
## Summary
- `CITATION.cff`'s `version` field never got bumped by release-please: it was
  configured as a `generic` extra-file, but the Generic updater requires an
  inline `x-release-please-version` annotation to know what to replace —
  which was missing. It had been frozen at `3.17.1` (2026-07-03, from #377)
  while the real version moved on to `3.25.0`.
- Added the same annotation pattern already proven working in this repo
  (`README.md`, `src/kicad_mcp/__init__.py`), and synced the value/date to
  the current release so the file is correct right now.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('CITATION.cff'))"` parses cleanly
- [x] Annotation matches the working pattern already in README.md / __init__.py
- [ ] Next release-please run bumps `CITATION.cff` automatically (verify on the next release PR)