### PR TITLE
docs: add Zenodo DOI badge and Cite this software section

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,11 +7,20 @@ authors:
     given-names: Osman
 repository-code: "https://github.com/oaslananka/kicad-mcp-pro"
 url: "https://oaslananka.github.io/kicad-mcp-pro"
+doi: "10.5281/zenodo.21283791"
 license: MIT
 version: "3.25.0" # x-release-please-version
 date-released: "2026-07-10"
+abstract: >-
+  KiCad MCP Pro is a Model Context Protocol server for automating KiCad
+  schematic capture, PCB layout, ERC/DRC validation, DFM checks, and
+  manufacturing export workflows from any MCP-capable AI agent.
 keywords:
   - KiCad
   - EDA
+  - electronic design automation
+  - PCB design
   - Model Context Protocol
+  - AI agents
+  - engineering automation
   - PCB automation

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://www.npmjs.com/package/kicad-mcp-pro"><img src="https://img.shields.io/npm/v/kicad-mcp-pro?label=npm" alt="npm Version" /></a>
   <a href="https://pypi.org/project/kicad-mcp-pro/"><img src="https://img.shields.io/pypi/pyversions/kicad-mcp-pro?label=python" alt="Python Version" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="MIT License" /></a>
+  <a href="https://doi.org/10.5281/zenodo.21283791"><img src="https://zenodo.org/badge/1255527274.svg" alt="DOI" /></a>
 </p>
 
 <p>
@@ -265,6 +266,25 @@ All changes must pass `task verify` before opening a pull request.
 Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request. All
 changes must pass the repository's format, lint, type-check, test, workflow,
 security, and package metadata gates.
+
+## Cite this software
+
+If you use KiCad MCP Pro in research or a technical publication, cite the
+archived release via its DOI (see [`CITATION.cff`](CITATION.cff) for full
+metadata):
+
+```bibtex
+@software{aslan_kicad_mcp_pro,
+  author  = {Aslan, Osman},
+  title   = {KiCad MCP Pro},
+  license = {MIT},
+  url     = {https://github.com/oaslananka/kicad-mcp-pro},
+  doi     = {10.5281/zenodo.21283791}
+}
+```
+
+Every GitHub release is archived on Zenodo under this concept DOI, which
+always resolves to the most recent version.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add the Zenodo concept DOI badge to the README badge row (resolves to
  the latest archived release).
- Add a "Cite this software" section with a BibTeX block pointing at the
  DOI.
- Add `doi`, `abstract`, and expanded `keywords` to `CITATION.cff` so
  future Zenodo archival records carry richer metadata (Zenodo's GitHub
  integration reads this file at release time).

## Context
The GitHub-Zenodo integration for `oaslananka/kicad-mcp-pro` is already
enabled and has been auto-archiving releases (v3.24.0, v3.24.1) with
DOIs. This PR just surfaces that in the repo's own docs/metadata.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('CITATION.cff'))"` parses cleanly
- [x] Badge/link URLs match the snippet Zenodo generated for this repo