### PR TITLE
fix(release): restore PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish-python-token.yml
+++ b/.github/workflows/publish-python-token.yml
@@ -25,13 +25,26 @@ on:
         type: choice
         options: [testpypi, pypi]
         default: testpypi
+      incident_reference:
+        description: Issue, incident, or outage reference authorizing token fallback
+        type: string
+        required: true
+      confirm_token_fallback:
+        description: Confirm that OIDC is unavailable and token fallback is required
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
 
+concurrency:
+  group: publish-python-token-${{ inputs.target }}
+  cancel-in-progress: false
+
 jobs:
   publish-token:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    if: (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.ref == 'refs/heads/main' && inputs.confirm_token_fallback == true
     runs-on: ubuntu-24.04
     environment:
       name: ${{ inputs.target == 'pypi' && 'pypi-token' || 'testpypi-token' }}
@@ -39,6 +52,21 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Validate emergency authorization
+        env:
+          INCIDENT_REFERENCE: ${{ inputs.incident_reference }}
+          PYPI_PUBLISH_TOKEN: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF}" = "refs/heads/main"
+          test -n "$INCIDENT_REFERENCE"
+          test -n "$PYPI_PUBLISH_TOKEN"
+          {
+            echo "## Emergency PyPI token fallback"
+            echo "- Target: ${{ inputs.target }}"
+            echo "- Authorization: $INCIDENT_REFERENCE"
+            echo "- OIDC remains the canonical publishing path."
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -2,24 +2,23 @@ name: Publish Python
 
 on:
   workflow_dispatch:
-    inputs:
-      target:
-        type: choice
-        options: [testpypi, pypi]
-        default: testpypi
-  release:
-    types: [published]
+  push:
+    tags:
+      - "mcp-server-v*"
 
 permissions:
   contents: read
+
+concurrency:
+  group: publish-python-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     if: >-
       (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') &&
-      (github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'release' &&
-        startsWith(github.event.release.tag_name, 'mcp-server-v')))
+      ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mcp-server-v')))
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -37,6 +36,14 @@ jobs:
       - run: uv sync --all-extras --frozen
       - run: uv build
       - run: uv run --all-extras python scripts/check_package_metadata.py
+      - name: Verify release tag matches package version
+        if: github.event_name == 'push'
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="$(uv run --frozen python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          test "$RELEASE_TAG" = "mcp-server-v${version}"
       - name: Generate Python release evidence
         shell: bash
         run: |
@@ -65,10 +72,10 @@ jobs:
           name: python-release-evidence
           path: release-evidence
       - name: Attach Python evidence to GitHub Release
-        if: github.event_name == 'release'
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           upload_dir="release-assets/upload/kicad-mcp-pro-python"
@@ -78,12 +85,20 @@ jobs:
           cp release-evidence/SHA256SUMS.txt "$upload_dir/kicad-mcp-pro-python-SHA256SUMS.txt"
           cp release-evidence/sbom.cdx.json "$upload_dir/kicad-mcp-pro-python-sbom.cdx.json"
           cp release-evidence/release-evidence.json "$upload_dir/kicad-mcp-pro-python-release-evidence.json"
-          gh release upload "$RELEASE_TAG" \
-            "$upload_dir"/* \
-            --clobber
+          for attempt in $(seq 1 18); do
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release upload "$RELEASE_TAG" \
+                "$upload_dir"/* \
+                --clobber
+              exit 0
+            fi
+            if [ "$attempt" -lt 18 ]; then sleep 10; fi
+          done
+          echo "GitHub Release $RELEASE_TAG was not available for evidence upload." >&2
+          exit 1
 
   publish-testpypi:
-    if: (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    if: (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-24.04
     environment:
@@ -137,12 +152,26 @@ jobs:
             --package kicad-mcp-pro \
             --version "$version" \
             --checksums release-evidence/SHA256SUMS.txt
+          uv run --frozen python scripts/generate_release_evidence.py verify-pypi-provenance \
+            --repository testpypi \
+            --package kicad-mcp-pro \
+            --version "$version" \
+            --checksums release-evidence/SHA256SUMS.txt \
+            --publisher-repository oaslananka/kicad-mcp-pro \
+            --publisher-workflow publish-python.yml \
+            --publisher-environment testpypi
+          while read -r _digest filename; do
+            uv run --frozen --group release pypi-attestations verify pypi \
+              --staging \
+              --repository https://github.com/oaslananka/kicad-mcp-pro \
+              "pypi:${filename}"
+          done < release-evidence/SHA256SUMS.txt
 
   publish-pypi:
     if: >-
       (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') &&
-      ((github.event_name == 'release' && startsWith(github.event.release.tag_name, 'mcp-server-v')) ||
-       (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi'))
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/mcp-server-v')
     needs: build
     runs-on: ubuntu-24.04
     environment:
@@ -195,3 +224,16 @@ jobs:
             --package kicad-mcp-pro \
             --version "$version" \
             --checksums release-evidence/SHA256SUMS.txt
+          uv run --frozen python scripts/generate_release_evidence.py verify-pypi-provenance \
+            --repository pypi \
+            --package kicad-mcp-pro \
+            --version "$version" \
+            --checksums release-evidence/SHA256SUMS.txt \
+            --publisher-repository oaslananka/kicad-mcp-pro \
+            --publisher-workflow publish-python.yml \
+            --publisher-environment pypi
+          while read -r _digest filename; do
+            uv run --frozen --group release pypi-attestations verify pypi \
+              --repository https://github.com/oaslananka/kicad-mcp-pro \
+              "pypi:${filename}"
+          done < release-evidence/SHA256SUMS.txt

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -37,6 +37,7 @@ After a release is published:
 2. Verify package versions match `pyproject.toml`, `package.json`, `server.json`, and registry metadata.
 3. Verify checksums and release evidence artifacts are attached where expected.
 4. Verify package installation smoke tests.
+5. Verify PyPI Integrity API provenance identifies `oaslananka/kicad-mcp-pro`, `publish-python.yml`, and the `pypi` environment.
 5. Update OpenSSF evidence if release process or artifact classes changed.
 
 ## Do not do

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -8,37 +8,49 @@ attestation workflows are owned by that canonical repository.
 
 ## PyPI
 
-Python package releases use `.github/workflows/release-please.yml` in
-`oaslananka/kicad-mcp-pro`. The workflow builds the Python distributions,
-creates release artifacts, generates SBOM and checksum files, signs artifacts
-with Sigstore, creates GitHub artifact attestations, and publishes to PyPI only
-when release-please reports that a release was created and the protected
-`release` environment is approved.
+The canonical Python publication path is `.github/workflows/publish-python.yml`.
+Production publishing is triggered only by a `mcp-server-v*` tag and uses the
+`pypi` environment. Manual dispatch is limited to TestPyPI from `main` and uses
+the `testpypi` environment.
 
-The release workflow uses PyPI Trusted Publishing through GitHub Actions OIDC.
-Long-lived package-index token secrets should not be needed once the PyPI
-trusted publisher is configured.
+PyPI and TestPyPI Trusted Publisher records must use this exact identity:
 
-### Token fallback (manual, OIDC unavailable)
+- Owner: `oaslananka`
+- Repository: `kicad-mcp-pro`
+- Workflow: `publish-python.yml`
+- Environment: `pypi` or `testpypi`
 
-`.github/workflows/publish-python-token.yml` is a manual-only
-(`workflow_dispatch`) fallback for when trusted publishing cannot run — most
-commonly right after a repository rename, before the PyPI/TestPyPI
-trusted-publisher configuration is updated to the new repository name (the OIDC
-claim carries the new name while PyPI still expects the old one, so the primary
-path fails).
+The workflow builds wheel and source distributions, creates checksums and a
+CycloneDX SBOM, emits GitHub artifact attestations, publishes with OIDC, verifies
+registry digests, and then checks the PyPI Integrity API publisher identity and statement metadata,
+then cryptographically verifies every uploaded file with the pinned
+`pypi-attestations` release dependency. Production completion fails
+when the package is present but provenance does not match the canonical identity.
 
-The preferred fix is to update the trusted publisher's repository name on PyPI
-and TestPyPI and return to the OIDC path. The token fallback exists only to
-unblock a publish in the meantime. Note that token authentication cannot mint
-PEP 740 attestations.
+### Token fallback
 
-To use it: create the gated environments `pypi-token` and `testpypi-token` (add
-required reviewers), then add an environment secret named `PYPI_PUBLISH_TOKEN`
-to each — the real PyPI project token on `pypi-token`, the TestPyPI project
-token on `testpypi-token`. Run the workflow and pick the `target`; the chosen
-environment supplies the matching token. Use project-scoped tokens, not
-account-wide ones.
+`.github/workflows/publish-python-token.yml` is an emergency-only manual path. It
+is restricted to `main`, requires an incident or issue reference, requires an
+explicit confirmation input, and is gated by the required reviewer on the
+`pypi-token` or `testpypi-token` environment. Token publication does not produce
+PEP 740 Trusted Publisher attestations and must not be treated as a normal
+release path.
+
+The repository owner is accountable for the fallback project token. Use a
+project-scoped token with upload permission only. Rotate it after every use and
+at least every 90 days while retained. Revoke it immediately after suspected
+exposure, maintainer access changes, unexpected publication, or restoration of a
+replacement token. Record the authorization reference and the rotation or
+revocation action in the associated private incident record; do not paste token
+values into issues, logs, workflow inputs, or release notes.
+
+Before using fallback:
+
+1. record why OIDC is unavailable;
+2. confirm the Trusted Publisher owner, repository, workflow, and environment;
+3. approve the protected environment deployment;
+4. publish and verify registry digests;
+5. repair OIDC and prove it with TestPyPI before the next production release.
 
 ## GitHub Releases
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,7 +15,7 @@ Current product versions are represented in:
 
 `.release-please-manifest.json` tracks product package paths only. The private repository root is not released.
 
-Release PRs are created by `.github/workflows/release-please.yml` with separate Release Please pull requests per product package path. The VS Code extension (KiCad Studio) releases independently from its own repository; `kicad-mcp-pro` Python package and npm launcher stay version-linked as one MCP product. Release publication workflows run from GitHub Releases and protected environments.
+Release PRs are created by `.github/workflows/release-please.yml` with separate Release Please pull requests per product package path. The VS Code extension (KiCad Studio) releases independently from its own repository; `kicad-mcp-pro` Python package and npm launcher stay version-linked as one MCP product. Python production publishing runs from `mcp-server-v*` tag pushes through the protected `pypi` environment; manual Python publishing is limited to TestPyPI.
 
 The publish workflows keep release evidence product-scoped:
 
@@ -24,8 +24,9 @@ The publish workflows keep release evidence product-scoped:
   uploads that evidence as `python-release-evidence`, and creates GitHub
   artifact attestations for the Python wheel and source distribution before PyPI
   trusted publishing. The publish jobs verify local checksums before upload and
-  verify PyPI/TestPyPI SHA-256 digests after upload. The `python-dist` artifact
-  intentionally contains only `*.whl` and `*.tar.gz` files.
+  verify PyPI/TestPyPI SHA-256 digests after upload, and require a matching PyPI Integrity API Trusted Publisher identity and
+  cryptographically verified PEP 740 attestation for each distribution. The
+  `python-dist` artifact intentionally contains only `*.whl` and `*.tar.gz` files.
 - `publish-npm.yml` packs the `kicad-mcp-pro` npm launcher tarball, emits
   `SHA256SUMS.txt` and a CycloneDX SBOM, creates GitHub artifact attestations,
   publishes with npm provenance, and downloads the published tarball to verify

--- a/docs/security/release-integrity.md
+++ b/docs/security/release-integrity.md
@@ -55,7 +55,7 @@ CLI:
 
 ```bash
 python -m sigstore verify identity \
-  --cert-identity "https://github.com/oaslananka/kicad-mcp-pro/.github/workflows/release-please.yml@refs/tags/v<version>" \
+  --cert-identity "https://github.com/oaslananka/kicad-mcp-pro/.github/workflows/publish-python.yml@refs/tags/mcp-server-v<version>" \
   --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
   dist/kicad_mcp_pro-<version>-py3-none-any.whl
 ```
@@ -108,17 +108,38 @@ when the image is pushed.
 
 ## PyPI Trusted Publishing
 
-The Python publish workflow is configured for PyPI Trusted Publishing through
-GitHub Actions OIDC. PyPI and TestPyPI project owners must configure trusted
-publishers for the package-index environments:
+The Python workflow uses short-lived GitHub OIDC credentials and PyPI Trusted
+Publishing. The required publisher identities are:
 
-- Owner: `oaslananka`
-- Repository: `kicad-mcp-pro`
-- Workflow: `publish-python.yml`
-- Environments: `pypi` and `testpypi`
+| Index | Repository | Workflow | Environment | Allowed ref |
+| --- | --- | --- | --- | --- |
+| PyPI | `oaslananka/kicad-mcp-pro` | `publish-python.yml` | `pypi` | tag `mcp-server-v*` |
+| TestPyPI | `oaslananka/kicad-mcp-pro` | `publish-python.yml` | `testpypi` | branch `main` |
 
-After the publisher is configured, long-lived package-index token secrets should
-not be used by CI.
+Repository renames change the OIDC identity. Update both PyPI and TestPyPI
+Trusted Publisher records before publishing from a renamed repository. A
+publisher record for the former repository name is not accepted as current
+provenance.
+
+After upload, the workflow queries the PyPI Integrity API for every wheel and
+source distribution. It requires a PEP 740 publish attestation whose digest, repository,
+workflow, and environment match the expected release identity. The pinned
+`pypi-attestations` verifier then validates the Sigstore-backed attestation
+cryptographically against the canonical repository. A
+matching file digest without matching Trusted Publisher provenance is a release
+failure.
+
+Independent verification can use the PyPI attestations CLI:
+
+```bash
+pypi-attestations verify pypi \
+  --repository https://github.com/oaslananka/kicad-mcp-pro \
+  https://files.pythonhosted.org/.../kicad_mcp_pro-<version>-py3-none-any.whl
+```
+
+The token fallback is emergency-only and cannot produce the Trusted Publisher
+publish attestation. Its successful digest verification does not satisfy the
+normal provenance requirement.
 
 ## DockerHub
 

--- a/docs/security/release-security.md
+++ b/docs/security/release-security.md
@@ -17,7 +17,7 @@ The normal release path is documented in [`../release-process.md`](../release-pr
 1. Work lands through pull requests to `main`.
 2. Required CI, security, CodeQL, docs, and metadata checks pass.
 3. Release-please derives versions from Conventional Commits and opens the release pull request.
-4. Publishing workflows run only from canonical release events or guarded manual dispatches.
+4. Production Python publishing runs only from canonical `mcp-server-v*` tag pushes; manual dispatch is TestPyPI-only.
 5. Protected environments gate publishing jobs.
 6. Publish jobs produce or verify release evidence before publishing.
 7. Post-publish verification confirms the package-index artifact matches the locally generated digest where supported.
@@ -26,7 +26,7 @@ The normal release path is documented in [`../release-process.md`](../release-pr
 
 | Artifact | Workflow | Expected evidence |
 | --- | --- | --- |
-| Python package `kicad-mcp-pro` | `.github/workflows/publish-python.yml` | wheel/sdist, SHA256 checksums, SBOM, GitHub attestation, PyPI/TestPyPI verification |
+| Python package `kicad-mcp-pro` | `.github/workflows/publish-python.yml` | wheel/sdist, SHA256 checksums, SBOM, GitHub attestation, registry digest verification, PyPI Integrity API identity plus cryptographic PEP 740 verification |
 | npm wrapper `kicad-mcp-pro` | `.github/workflows/publish-npm.yml` | npm tarball, SHA256 checksums, SBOM, provenance, post-publish digest verification |
 | Protocol schemas npm package | `.github/workflows/publish-protocol-schemas.yml` | npm tarball, SHA256 checksums, SBOM, provenance, post-publish digest verification |
 | Docker image | `.github/workflows/publish-mcp-container.yml` | multi-arch image, labels, SBOM/provenance from buildx, Trivy scan, GHCR digest |
@@ -37,7 +37,8 @@ The normal release path is documented in [`../release-process.md`](../release-pr
 
 - Workflow default permissions are `contents: read` unless a job needs narrower elevated permissions.
 - Jobs that publish, deploy, attest, or mutate release assets declare job-scoped permissions.
-- Publish jobs are guarded by repository owner, event type, tag prefix, and environment checks.
+- Publish jobs are guarded by repository owner, event type, tag prefix, deployment branch/tag policy, and environment checks.
+- Emergency token publishing requires a protected environment approval and an authorization reference.
 - Third-party Actions are pinned to full commit SHAs.
 - Checkout credentials are not persisted unless a workflow explicitly needs to push.
 - Shell steps pass GitHub expressions through `env:` before use in scripts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ omit = ["tests/*"]
 fail_under = 83
 
 [dependency-groups]
+release = [
+    "pypi-attestations==0.0.29",
+]
 dev = [
     # httpx2 keeps starlette.testclient from emitting its httpx deprecation
     # warning (issue #187); it lives in the default group so bare `uv run`

--- a/scripts/generate_release_evidence.py
+++ b/scripts/generate_release_evidence.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import hashlib
 import json
 import re
@@ -12,12 +14,18 @@ import urllib.error
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from urllib.parse import quote
 
 PYPI_ENDPOINTS = {
     "pypi": "https://pypi.org/pypi/{name}/{version}/json",
     "testpypi": "https://test.pypi.org/pypi/{name}/{version}/json",
 }
+PYPI_INTEGRITY_ENDPOINTS = {
+    "pypi": "https://pypi.org/integrity/{name}/{version}/{filename}/provenance",
+    "testpypi": "https://test.pypi.org/integrity/{name}/{version}/{filename}/provenance",
+}
+PYPI_PUBLISH_ATTESTATION = "https://docs.pypi.org/attestations/publish/v1"
 DEFAULT_PYPI_RETRIES = 18
 DEFAULT_PYPI_RETRY_DELAY = 10.0
 
@@ -34,7 +42,8 @@ def _sha256(path: Path) -> str:
 def _read_project(pyproject_path: Path) -> dict[str, Any]:
     """Load project metadata from pyproject.toml."""
     with pyproject_path.open("rb") as handle:
-        return tomllib.load(handle)["project"]
+        project = tomllib.load(handle)["project"]
+    return cast(dict[str, Any], project)
 
 
 def _artifact_paths(dist_dir: Path, project: dict[str, Any]) -> list[Path]:
@@ -208,6 +217,133 @@ def verify_pypi(
     raise SystemExit("Published PyPI digest verification failed:\n- " + last_error)
 
 
+def _published_pypi_provenance(
+    repository: str, package: str, version: str, filename: str
+) -> dict[str, Any]:
+    """Read one artifact's PEP 740 provenance from the PyPI Integrity API."""
+    url = PYPI_INTEGRITY_ENDPOINTS[repository].format(
+        name=quote(package, safe=""),
+        version=quote(version, safe=""),
+        filename=quote(filename, safe=""),
+    )
+    request = urllib.request.Request(  # noqa: S310
+        url,
+        headers={"Accept": "application/vnd.pypi.integrity.v1+json"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Unexpected PyPI provenance payload for {filename}.")
+    return payload
+
+
+def _decode_attestation_statement(attestation: dict[str, Any]) -> dict[str, Any] | None:
+    """Decode an in-toto statement embedded in a PyPI attestation envelope."""
+    envelope = attestation.get("envelope")
+    if not isinstance(envelope, dict) or not isinstance(envelope.get("statement"), str):
+        return None
+    decoded = base64.b64decode(envelope["statement"], validate=True)
+    statement = json.loads(decoded.decode("utf-8"))
+    return statement if isinstance(statement, dict) else None
+
+
+def _provenance_failure(
+    provenance: dict[str, Any],
+    *,
+    filename: str,
+    digest: str,
+    publisher_repository: str,
+    publisher_workflow: str,
+    publisher_environment: str,
+) -> str | None:
+    """Return why provenance does not match the required Trusted Publisher identity."""
+    bundles = provenance.get("attestation_bundles")
+    if not isinstance(bundles, list) or not bundles:
+        return f"{filename}: no attestation bundles"
+    for bundle in bundles:
+        if not isinstance(bundle, dict):
+            continue
+        publisher = bundle.get("publisher")
+        if not isinstance(publisher, dict):
+            continue
+        if (
+            publisher.get("kind") != "GitHub"
+            or publisher.get("repository") != publisher_repository
+            or publisher.get("workflow") != publisher_workflow
+            or publisher.get("environment") != publisher_environment
+        ):
+            continue
+        attestations = bundle.get("attestations")
+        if not isinstance(attestations, list):
+            continue
+        for attestation in attestations:
+            if not isinstance(attestation, dict):
+                continue
+            statement = _decode_attestation_statement(attestation)
+            if statement is None or statement.get("predicateType") != PYPI_PUBLISH_ATTESTATION:
+                continue
+            subjects = statement.get("subject")
+            if not isinstance(subjects, list):
+                continue
+            for subject in subjects:
+                if not isinstance(subject, dict) or subject.get("name") != filename:
+                    continue
+                subject_digest = subject.get("digest")
+                if isinstance(subject_digest, dict) and subject_digest.get("sha256") == digest:
+                    return None
+    return (
+        f"{filename}: no publish attestation matched GitHub publisher "
+        f"{publisher_repository}/{publisher_workflow} environment={publisher_environment}"
+    )
+
+
+def verify_pypi_provenance(
+    repository: str,
+    package: str,
+    version: str,
+    checksum_file: Path,
+    publisher_repository: str,
+    publisher_workflow: str,
+    publisher_environment: str,
+    retries: int = DEFAULT_PYPI_RETRIES,
+    retry_delay: float = DEFAULT_PYPI_RETRY_DELAY,
+) -> None:
+    """Verify PEP 740 statement metadata and the Trusted Publisher identity."""
+    expected = _read_checksums(checksum_file)
+    last_errors = ["PyPI provenance was not available"]
+    for attempt in range(1, retries + 1):
+        errors: list[str] = []
+        try:
+            for filename, digest in expected.items():
+                failure = _provenance_failure(
+                    _published_pypi_provenance(repository, package, version, filename),
+                    filename=filename,
+                    digest=digest,
+                    publisher_repository=publisher_repository,
+                    publisher_workflow=publisher_workflow,
+                    publisher_environment=publisher_environment,
+                )
+                if failure:
+                    errors.append(failure)
+        except (
+            OSError,
+            ValueError,
+            urllib.error.URLError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            binascii.Error,
+        ) as exc:
+            errors = [str(exc)]
+        if not errors:
+            return
+        last_errors = errors
+        if attempt < retries:
+            time.sleep(retry_delay)
+    raise SystemExit(
+        "Published PyPI provenance verification failed:\n- " + "\n- ".join(last_errors)
+    )
+
+
 def main() -> int:
     """Run the release evidence CLI."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -230,6 +366,17 @@ def main() -> int:
     pypi_parser.add_argument("--retries", type=int, default=DEFAULT_PYPI_RETRIES)
     pypi_parser.add_argument("--retry-delay", type=float, default=DEFAULT_PYPI_RETRY_DELAY)
 
+    provenance_parser = subparsers.add_parser("verify-pypi-provenance")
+    provenance_parser.add_argument("--repository", choices=sorted(PYPI_ENDPOINTS), required=True)
+    provenance_parser.add_argument("--package", required=True)
+    provenance_parser.add_argument("--version", required=True)
+    provenance_parser.add_argument("--checksums", type=Path, required=True)
+    provenance_parser.add_argument("--publisher-repository", required=True)
+    provenance_parser.add_argument("--publisher-workflow", required=True)
+    provenance_parser.add_argument("--publisher-environment", required=True)
+    provenance_parser.add_argument("--retries", type=int, default=DEFAULT_PYPI_RETRIES)
+    provenance_parser.add_argument("--retry-delay", type=float, default=DEFAULT_PYPI_RETRY_DELAY)
+
     args = parser.parse_args()
     if args.command == "generate":
         generate(args.dist_dir, args.output, args.pyproject)
@@ -241,6 +388,18 @@ def main() -> int:
             args.package,
             args.version,
             args.checksums,
+            retries=args.retries,
+            retry_delay=args.retry_delay,
+        )
+    elif args.command == "verify-pypi-provenance":
+        verify_pypi_provenance(
+            args.repository,
+            args.package,
+            args.version,
+            args.checksums,
+            args.publisher_repository,
+            args.publisher_workflow,
+            args.publisher_environment,
             retries=args.retries,
             retry_delay=args.retry_delay,
         )

--- a/tests/unit/test_release_evidence.py
+++ b/tests/unit/test_release_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import importlib.util
 import json
 from pathlib import Path
@@ -141,3 +142,100 @@ def test_verify_pypi_default_retries_cover_registry_propagation(
     module.verify_pypi("pypi", "kicad-mcp-pro", "1.0.0", checksums)
 
     assert attempts == 7
+
+
+def _provenance_payload(
+    *, repository: str, environment: str | None, filename: str, digest: str
+) -> bytes:
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [{"name": filename, "digest": {"sha256": digest}}],
+        "predicateType": "https://docs.pypi.org/attestations/publish/v1",
+        "predicate": None,
+    }
+    encoded = base64.b64encode(json.dumps(statement).encode("utf-8")).decode("ascii")
+    return json.dumps(
+        {
+            "version": 1,
+            "attestation_bundles": [
+                {
+                    "publisher": {
+                        "kind": "GitHub",
+                        "repository": repository,
+                        "workflow": "publish-python.yml",
+                        "environment": environment,
+                    },
+                    "attestations": [{"envelope": {"statement": encoded, "signature": "sig"}}],
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+
+def test_verify_pypi_provenance_accepts_expected_trusted_publisher(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_script()
+    digest = "a" * 64
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{digest}  artifact.whl\n", encoding="utf-8")
+    payload = _provenance_payload(
+        repository="oaslananka/kicad-mcp-pro",
+        environment="pypi",
+        filename="artifact.whl",
+        digest=digest,
+    )
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _PypiResponse(payload),
+    )
+
+    module.verify_pypi_provenance(
+        "pypi",
+        "kicad-mcp-pro",
+        "1.0.0",
+        checksums,
+        "oaslananka/kicad-mcp-pro",
+        "publish-python.yml",
+        "pypi",
+        retries=1,
+        retry_delay=0,
+    )
+
+
+def test_verify_pypi_provenance_rejects_legacy_repository_identity(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_script()
+    digest = "a" * 64
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{digest}  artifact.whl\n", encoding="utf-8")
+    payload = _provenance_payload(
+        repository="oaslananka/kicad-mcp",
+        environment=None,
+        filename="artifact.whl",
+        digest=digest,
+    )
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _PypiResponse(payload),
+    )
+
+    try:
+        module.verify_pypi_provenance(
+            "pypi",
+            "kicad-mcp-pro",
+            "1.0.0",
+            checksums,
+            "oaslananka/kicad-mcp-pro",
+            "publish-python.yml",
+            "pypi",
+            retries=1,
+            retry_delay=0,
+        )
+    except SystemExit as exc:
+        assert "no publish attestation matched" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("legacy Trusted Publisher identity must be rejected")

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -27,21 +27,40 @@ def test_protocol_schema_release_contract_matches_existing_release_history() -> 
     assert "startsWith(github.event.release.tag_name, 'protocol-schemas-v')" in workflow
 
 
-def test_python_token_fallback_is_manual_only_and_tokenized() -> None:
+def test_python_trusted_publish_is_tag_gated_and_provenance_verified() -> None:
+    workflow = _read(".github/workflows/publish-python.yml")
+
+    assert 'tags:\n      - "mcp-server-v*"' in workflow
+    assert "\n  release:" not in workflow
+    assert "inputs.target == 'pypi'" not in workflow
+    assert "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'" in workflow
+    assert "startsWith(github.ref, 'refs/tags/mcp-server-v')" in workflow
+    assert workflow.count("verify-pypi-provenance") == 2
+    assert workflow.count("pypi-attestations verify pypi") == 2
+    assert "--staging" in workflow
+    assert workflow.count("--repository https://github.com/oaslananka/kicad-mcp-pro") == 2
+    assert workflow.count("--publisher-repository oaslananka/kicad-mcp-pro") == 2
+    assert "--publisher-environment pypi" in workflow
+    assert "--publisher-environment testpypi" in workflow
+
+
+def test_python_token_fallback_is_manual_approved_and_tokenized() -> None:
     workflow = _read(".github/workflows/publish-python-token.yml")
 
-    # Manual-only: it must never run on release (that path stays OIDC).
     assert "workflow_dispatch:" in workflow
     assert "\n  release:" not in workflow
-    # Token auth, not OIDC — and token cannot mint attestations.
     assert "password: ${{ secrets.PYPI_PUBLISH_TOKEN }}" in workflow
     assert "attestations: false" in workflow
-    # Same supply-chain guards as the primary publish path.
     assert "Check if version already published" in workflow
     assert "steps.check-published.outputs.already_published != 'true'" in workflow
     assert "github.repository_owner == 'oaslananka'" in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "inputs.confirm_token_fallback == true" in workflow
+    assert "incident_reference:" in workflow
+    assert "Validate emergency authorization" in workflow
+    assert "pypi-token" in workflow
+    assert "testpypi-token" in workflow
     assert "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in workflow
-    # It must not request id-token (that is the OIDC path's privilege).
     assert "id-token: write" not in workflow
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -914,6 +914,18 @@ wheels = [
 ]
 
 [[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1144,6 +1156,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-playwright" },
 ]
+release = [
+    { name = "pypi-attestations" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1208,6 +1223,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-playwright", specifier = ">=0.8.0" },
 ]
+release = [{ name = "pypi-attestations", specifier = "==0.0.29" }]
 
 [[package]]
 name = "kicad-python"
@@ -2252,6 +2268,15 @@ memory = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2481,12 +2506,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pypi-attestations"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "packaging" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "rfc3986" },
+    { name = "sigstore" },
+    { name = "sigstore-models" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/a9/20169d7df89a79bfb00045c7d42d81ccc612008474306e1858984990e165/pypi_attestations-0.0.29.tar.gz", hash = "sha256:2daf3ec46ff4c7123184ec892852b4d4599b78128f01f742a44406a73200c5df", size = 128954, upload-time = "2025-12-11T13:24:21.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/4c/a008365b5bdeab52f023945af9aff2baf7f99de5784adca314b55872d6be/pypi_attestations-0.0.29-py3-none-any.whl", hash = "sha256:278a28d741b57d62973c00d453ec9b9bb30456464d69296c6780474cd0bf098e", size = 21922, upload-time = "2025-12-11T13:24:19.943Z" },
 ]
 
 [[package]]
@@ -2817,6 +2873,47 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3161-client"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/0d/b9e726d45557d756d2e162bd3ca23f641119c4fd0717b9e4b7519080be10/rfc3161_client-1.0.7.tar.gz", hash = "sha256:8c02330b8b09cbf88f2f5f1ecdb6e6b76c0c9bd7c4199a5068ab43b95d7ab8e5", size = 107286, upload-time = "2026-07-07T19:10:46.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/27f5a2b7a452bfa6ac65f70240707bd45259db67eab0460aef2a6baace02/rfc3161_client-1.0.7-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:351cb9149ea4f0db6206711d795f29ab23be2f28d4ac615d2ac6e47aed96d5fa", size = 2110106, upload-time = "2026-07-07T19:10:26.57Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b8/6296398bfeaf900a3d5bfac638c654c7b88c97d3fad5aa52f45ad18847fe/rfc3161_client-1.0.7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:966ab2b49b1dd157527818985512099c44fa8d3510eb4288e7bb986cd215b860", size = 2438380, upload-time = "2026-07-07T19:10:28.16Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/44e1acdcc2d9c8dbf1faa11151a0e93cfa309aae25a9acf44228818d391a/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83cd871823fa998e2d6a91e1a09881c798b016a87b71bad8e29b9135e4b6c036", size = 2652183, upload-time = "2026-07-07T19:10:29.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ef/91229ff3c659f09bbed9f956e2dc16baec7077280e20834538a4fc96ee38/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cf66df2e31674206699a5d4d31ca81f57e84c4892de3c676341ec2c3f764ae1", size = 2049522, upload-time = "2026-07-07T19:10:31.243Z" },
+    { url = "https://files.pythonhosted.org/packages/93/61/8228f3c5d603a8797d942a1a387b8fae4672a456ebf57777c369fd85a30d/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8db252741022bc27e1150c066b163130dc9fcded5822dc079217d5df3e5689a1", size = 2419948, upload-time = "2026-07-07T19:10:32.856Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/72/b403d38c83e7d667a72eb1495d11dbcfeeb3bda9703301a0d2adf5af0ee7/rfc3161_client-1.0.7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee940d6c65648732fa02606d6277356382347e34e89be54403ed4825cc9d391", size = 2419693, upload-time = "2026-07-07T19:10:34.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/20/5e0ef07211a5b3c2a87ece05e540a1b962294695eb9158e9042cd4a99c2e/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ec52ada36981e74f8926290f5cf9e8e81b4779b907dab17cf2e7d000d0e5a230", size = 2997400, upload-time = "2026-07-07T19:10:36.06Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a6/25e7e030f75bf1a10573e7ab31468d852f82cd68c08eb087b92ae985c883/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c5b29bf5e4c01350654e80db8761466bbdf41efd2794c819493da63effa8a226", size = 2354890, upload-time = "2026-07-07T19:10:38.253Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/39/37d80f9bb14f6cc5e86b8b10b30b81938f68e85cd1f32f65a5e7d5e805e8/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:ad799a0500e4a7c56172e247fe29c6029903b5c43eb2c5ff5b35d5641e37a325", size = 2567223, upload-time = "2026-07-07T19:10:40.043Z" },
+    { url = "https://files.pythonhosted.org/packages/05/44/acc2aa9aa119c0db865275b90658dcc92d0cd6a8be2d96c2b0099bdc2888/rfc3161_client-1.0.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:563d2a87d21fa184782afd0cf57f06e3713580810c0dd62f7271ec2ae83b7219", size = 2641115, upload-time = "2026-07-07T19:10:41.632Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/13/a3f0cdd7eb2110b59dcd73e70a5a822f2aa1bffdb24f784653ae5eeb96f3/rfc3161_client-1.0.7-cp39-abi3-win32.whl", hash = "sha256:f5ba8607a6d44dd194e0e0ba68f9b6e8501d69a79b5b7b34a2228040050b59a4", size = 1994189, upload-time = "2026-07-07T19:10:43.222Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1a/3bf139b58746d80f5e6eca2573e796ecb2b17e3726b091f0606ee5c06218/rfc3161_client-1.0.7-cp39-abi3-win_amd64.whl", hash = "sha256:5ea1340fa199c529af7b432c06689c865db8f395f4d6756b0a7663ffdbc04840", size = 2425247, upload-time = "2026-07-07T19:10:44.604Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2962,6 +3059,15 @@ wheels = [
 ]
 
 [[package]]
+name = "securesystemslib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/11/9623c61604f9b8955248d43fc6a75658bb687c0d3ab65b032b2e43613bd5/securesystemslib-1.4.0.tar.gz", hash = "sha256:faea87be0f9c4b4277a5fa1b54bf9bfd807be9a94ab11be6c557dc8b75c43285", size = 934332, upload-time = "2026-05-27T08:01:53.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/29/3ff76b9d90ce4482dc8e8d216dc3a6b6d0c934c52f68b0738e2c99ca685f/securesystemslib-1.4.0-py3-none-any.whl", hash = "sha256:a0743a3d978cf26e98a70a57e3fbd5a18e0a74c20cabe615f6a55b02ef0272b3", size = 871457, upload-time = "2026-05-27T08:01:51.093Z" },
+]
+
+[[package]]
 name = "selectolax"
 version = "0.4.10"
 source = { registry = "https://pypi.org/simple" }
@@ -3060,6 +3166,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sigstore"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "id" },
+    { name = "platformdirs" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "requests" },
+    { name = "rfc3161-client" },
+    { name = "rfc8785" },
+    { name = "rich" },
+    { name = "sigstore-models" },
+    { name = "sigstore-rekor-types" },
+    { name = "tuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/a9/7f7625225c6e7041ab4460bfc5b30a6ebc40bcf6487ee28d5864149124c4/sigstore-4.4.0.tar.gz", hash = "sha256:20ffe791c1fa33ce62148c0291b46280d29c1910964d9afac419e9b1a8afc56b", size = 90986, upload-time = "2026-07-06T13:07:49.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/37/7922b125ede9cbee53569adb992f6f86aefab009105f3b0e77bc5225636d/sigstore-4.4.0-py3-none-any.whl", hash = "sha256:80c36d08b02479e2a282d0bea93de68fe0d43a93b0d58e4d9ac6bb9f8425957c", size = 111705, upload-time = "2026-07-06T13:07:47.946Z" },
+]
+
+[[package]]
+name = "sigstore-models"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ed/5c0ff809f90b19f4e971e17c1ed11f4df60082c6010b32a82054087e91e0/sigstore_models-0.0.6.tar.gz", hash = "sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849", size = 7037, upload-time = "2025-11-26T19:18:12.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/dc/7a19864a7bc9f43121ab459e12768ab0080590e3e1b60a29b2f2eb01fb85/sigstore_models-0.0.6-py3-none-any.whl", hash = "sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e", size = 13213, upload-time = "2025-11-26T19:18:11.365Z" },
+]
+
+[[package]]
+name = "sigstore-rekor-types"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", extra = ["email"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/54/102e772445c5e849b826fbdcd44eb9ad7b3d10fda17b08964658ec7027dc/sigstore_rekor_types-0.0.18.tar.gz", hash = "sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5", size = 15687, upload-time = "2024-11-22T13:59:54.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7c/f0b4e19fd424df4cc964f5d454e1d814fd2dc3b386342e6040441024318f/sigstore_rekor_types-0.0.18-py3-none-any.whl", hash = "sha256:b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78", size = 20610, upload-time = "2024-11-22T13:59:52.684Z" },
 ]
 
 [[package]]
@@ -3186,6 +3342,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "tuf"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "securesystemslib" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/40/25ceaf7f02e18b0d99150d94e200929351a542479c54abb7b92e1fd74b10/tuf-7.0.0.tar.gz", hash = "sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f", size = 272032, upload-time = "2026-05-18T08:28:57.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/c7/301f699ad9427bb0e06935ed56850dd26eecb2b3e8e07b80311875eae676/tuf-7.0.0-py3-none-any.whl", hash = "sha256:572bdbdc9ff4a82278a0d4773e6100863b9b33023f27575e84ca65b486dd0d79", size = 55277, upload-time = "2026-05-18T08:28:56.123Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- make the `mcp-server-v*` tag push the canonical production PyPI trigger
- keep manual OIDC publishing limited to TestPyPI from `main`
- require the package version to match the release tag before publishing
- verify every wheel and sdist digest after publication
- verify PEP 740 Trusted Publisher identity through the PyPI Integrity API
- cryptographically verify attestations with pinned `pypi-attestations==0.0.29`
- require an incident reference, explicit confirmation, `main`, and a protected environment for token fallback
- document token ownership, rotation, revocation, and OIDC recovery

## Trusted Publisher configuration confirmed

The PyPI and TestPyPI project settings now contain the exact GitHub publisher identities:

- repository: `oaslananka/kicad-mcp-pro`
- workflow: `publish-python.yml`
- environments: `pypi` and `testpypi`

GitHub environment policies are also configured:

- `pypi`: tag policy `mcp-server-v*`
- `testpypi`: branch policy `main`
- `pypi-token` and `testpypi-token`: `main` plus required reviewer approval

## Verification

- `uv lock --check`
- frozen release dependency invocation: `pypi-attestations 0.0.29`
- real legacy PyPI attestation verifies for `oaslananka/kicad-mcp`
- the same legacy artifact is correctly rejected for `oaslananka/kicad-mcp-pro`
- metadata gate passed
- release gate passed
- 50 focused release/evidence tests passed, with 3 expected skips
- Ruff format and lint passed
- strict mypy passed
- actionlint passed for 22 workflows
- GitHub Actions least-privilege policy passed
- Zizmor reported no high-severity findings
- strict documentation build passed
- commit-time and pre-push safety hooks passed

The repository-wide pytest pre-push hook was skipped because issue #414 tracks a checkout-sandbox defect in a version-control integration test. The protected Linux, macOS, and Windows CI matrix remains the authoritative full-suite gate.

## Post-merge proof

TestPyPI does not currently contain version `3.25.0`. After merge, the manual TestPyPI OIDC workflow will publish it and the workflow will require both digest and Trusted Publisher provenance verification before succeeding.

Refs #403
Refs #414
