### PR TITLE
fix(release): verify TestPyPI attestations locally

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -152,20 +152,15 @@ jobs:
             --package kicad-mcp-pro \
             --version "$version" \
             --checksums release-evidence/SHA256SUMS.txt
-          uv run --frozen python scripts/generate_release_evidence.py verify-pypi-provenance \
+          uv run --frozen --group release python scripts/generate_release_evidence.py verify-pypi-provenance \
             --repository testpypi \
             --package kicad-mcp-pro \
             --version "$version" \
             --checksums release-evidence/SHA256SUMS.txt \
             --publisher-repository oaslananka/kicad-mcp-pro \
             --publisher-workflow publish-python.yml \
-            --publisher-environment testpypi
-          while read -r _digest filename; do
-            uv run --frozen --group release pypi-attestations verify pypi \
-              --staging \
-              --repository https://github.com/oaslananka/kicad-mcp-pro \
-              "pypi:${filename}"
-          done < release-evidence/SHA256SUMS.txt
+            --publisher-environment testpypi \
+            --artifacts dist
 
   publish-pypi:
     if: >-
@@ -224,14 +219,15 @@ jobs:
             --package kicad-mcp-pro \
             --version "$version" \
             --checksums release-evidence/SHA256SUMS.txt
-          uv run --frozen python scripts/generate_release_evidence.py verify-pypi-provenance \
+          uv run --frozen --group release python scripts/generate_release_evidence.py verify-pypi-provenance \
             --repository pypi \
             --package kicad-mcp-pro \
             --version "$version" \
             --checksums release-evidence/SHA256SUMS.txt \
             --publisher-repository oaslananka/kicad-mcp-pro \
             --publisher-workflow publish-python.yml \
-            --publisher-environment pypi
+            --publisher-environment pypi \
+            --artifacts dist
           while read -r _digest filename; do
             uv run --frozen --group release pypi-attestations verify pypi \
               --repository https://github.com/oaslananka/kicad-mcp-pro \

--- a/scripts/generate_release_evidence.py
+++ b/scripts/generate_release_evidence.py
@@ -297,6 +297,51 @@ def _provenance_failure(
     )
 
 
+def _cryptographic_provenance_failure(
+    provenance_payload: dict[str, Any],
+    *,
+    artifact_path: Path,
+    publisher_repository: str,
+    publisher_workflow: str,
+    publisher_environment: str,
+) -> str | None:
+    """Cryptographically verify a local artifact against PyPI provenance."""
+    try:
+        from pypi_attestations import Distribution, GitHubPublisher, Provenance
+    except ImportError:
+        return "pypi-attestations is required for cryptographic provenance verification"
+
+    publisher = GitHubPublisher(
+        repository=publisher_repository,
+        workflow=publisher_workflow,
+        environment=publisher_environment,
+    )
+    try:
+        provenance = Provenance.model_validate(provenance_payload)
+        distribution = Distribution.from_file(artifact_path)
+    except Exception as exc:
+        return f"{artifact_path.name}: invalid provenance or artifact: {exc}"
+
+    matching_bundles = [
+        bundle for bundle in provenance.attestation_bundles if bundle.publisher == publisher
+    ]
+    if not matching_bundles:
+        return f"{artifact_path.name}: no cryptographic bundle matched the expected publisher"
+
+    failures: list[str] = []
+    for bundle in matching_bundles:
+        for attestation in bundle.attestations:
+            try:
+                predicate_type, _predicate = attestation.verify(publisher, distribution)
+            except Exception as exc:
+                failures.append(str(exc))
+                continue
+            if predicate_type == PYPI_PUBLISH_ATTESTATION:
+                return None
+    detail = "; ".join(failures) if failures else "no PyPI publish attestation was present"
+    return f"{artifact_path.name}: cryptographic provenance verification failed: {detail}"
+
+
 def verify_pypi_provenance(
     repository: str,
     package: str,
@@ -305,18 +350,22 @@ def verify_pypi_provenance(
     publisher_repository: str,
     publisher_workflow: str,
     publisher_environment: str,
+    artifact_dir: Path | None = None,
     retries: int = DEFAULT_PYPI_RETRIES,
     retry_delay: float = DEFAULT_PYPI_RETRY_DELAY,
 ) -> None:
-    """Verify PEP 740 statement metadata and the Trusted Publisher identity."""
+    """Verify PEP 740 metadata, identity, and optional cryptographic provenance."""
     expected = _read_checksums(checksum_file)
     last_errors = ["PyPI provenance was not available"]
     for attempt in range(1, retries + 1):
         errors: list[str] = []
         try:
             for filename, digest in expected.items():
+                provenance_payload = _published_pypi_provenance(
+                    repository, package, version, filename
+                )
                 failure = _provenance_failure(
-                    _published_pypi_provenance(repository, package, version, filename),
+                    provenance_payload,
                     filename=filename,
                     digest=digest,
                     publisher_repository=publisher_repository,
@@ -325,6 +374,21 @@ def verify_pypi_provenance(
                 )
                 if failure:
                     errors.append(failure)
+                    continue
+                if artifact_dir is not None:
+                    artifact_path = artifact_dir / filename
+                    if not artifact_path.is_file():
+                        errors.append(f"{filename}: local artifact is missing from {artifact_dir}")
+                        continue
+                    crypto_failure = _cryptographic_provenance_failure(
+                        provenance_payload,
+                        artifact_path=artifact_path,
+                        publisher_repository=publisher_repository,
+                        publisher_workflow=publisher_workflow,
+                        publisher_environment=publisher_environment,
+                    )
+                    if crypto_failure:
+                        errors.append(crypto_failure)
         except (
             OSError,
             ValueError,
@@ -374,6 +438,7 @@ def main() -> int:
     provenance_parser.add_argument("--publisher-repository", required=True)
     provenance_parser.add_argument("--publisher-workflow", required=True)
     provenance_parser.add_argument("--publisher-environment", required=True)
+    provenance_parser.add_argument("--artifacts", type=Path)
     provenance_parser.add_argument("--retries", type=int, default=DEFAULT_PYPI_RETRIES)
     provenance_parser.add_argument("--retry-delay", type=float, default=DEFAULT_PYPI_RETRY_DELAY)
 
@@ -400,6 +465,7 @@ def main() -> int:
             args.publisher_repository,
             args.publisher_workflow,
             args.publisher_environment,
+            artifact_dir=args.artifacts,
             retries=args.retries,
             retry_delay=args.retry_delay,
         )

--- a/tests/unit/test_release_evidence.py
+++ b/tests/unit/test_release_evidence.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import base64
 import importlib.util
 import json
+import sys
 from pathlib import Path
-from types import ModuleType, TracebackType
+from types import ModuleType, SimpleNamespace, TracebackType
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -239,3 +240,88 @@ def test_verify_pypi_provenance_rejects_legacy_repository_identity(
         assert "no publish attestation matched" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("legacy Trusted Publisher identity must be rejected")
+
+
+def test_verify_pypi_provenance_cryptographically_verifies_local_artifact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_script()
+    digest = "a" * 64
+    artifact_dir = tmp_path / "dist"
+    artifact_dir.mkdir()
+    artifact = artifact_dir / "artifact.whl"
+    artifact.write_bytes(b"artifact")
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{digest}  {artifact.name}\n", encoding="utf-8")
+    payload = _provenance_payload(
+        repository="oaslananka/kicad-mcp-pro",
+        environment="testpypi",
+        filename=artifact.name,
+        digest=digest,
+    )
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _PypiResponse(payload),
+    )
+
+    verified: list[Path] = []
+
+    class FakePublisher:
+        def __init__(self, *, repository: str, workflow: str, environment: str) -> None:
+            self.identity = (repository, workflow, environment)
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, FakePublisher) and self.identity == other.identity
+
+    class FakeDistribution:
+        @classmethod
+        def from_file(cls, path: Path) -> Path:
+            return path
+
+    class FakeAttestation:
+        def verify(self, publisher: FakePublisher, distribution: Path):
+            assert publisher.identity == (
+                "oaslananka/kicad-mcp-pro",
+                "publish-python.yml",
+                "testpypi",
+            )
+            verified.append(distribution)
+            return module.PYPI_PUBLISH_ATTESTATION, None
+
+    class FakeProvenance:
+        @classmethod
+        def model_validate(cls, _payload: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                attestation_bundles=[
+                    SimpleNamespace(
+                        publisher=FakePublisher(
+                            repository="oaslananka/kicad-mcp-pro",
+                            workflow="publish-python.yml",
+                            environment="testpypi",
+                        ),
+                        attestations=[FakeAttestation()],
+                    )
+                ]
+            )
+
+    fake_module = ModuleType("pypi_attestations")
+    fake_module.Distribution = FakeDistribution
+    fake_module.GitHubPublisher = FakePublisher
+    fake_module.Provenance = FakeProvenance
+    monkeypatch.setitem(sys.modules, "pypi_attestations", fake_module)
+
+    module.verify_pypi_provenance(
+        "testpypi",
+        "kicad-mcp-pro",
+        "1.0.0",
+        checksums,
+        "oaslananka/kicad-mcp-pro",
+        "publish-python.yml",
+        "testpypi",
+        artifact_dir=artifact_dir,
+        retries=1,
+        retry_delay=0,
+    )
+
+    assert verified == [artifact]

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -36,9 +36,17 @@ def test_python_trusted_publish_is_tag_gated_and_provenance_verified() -> None:
     assert "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'" in workflow
     assert "startsWith(github.ref, 'refs/tags/mcp-server-v')" in workflow
     assert workflow.count("verify-pypi-provenance") == 2
-    assert workflow.count("pypi-attestations verify pypi") == 2
-    assert "--staging" in workflow
-    assert workflow.count("--repository https://github.com/oaslananka/kicad-mcp-pro") == 2
+    assert workflow.count("pypi-attestations verify pypi") == 1
+    assert "--staging" not in workflow
+    assert workflow.count("--repository https://github.com/oaslananka/kicad-mcp-pro") == 1
+    assert "--publisher-environment testpypi \\\n            --artifacts dist" in workflow
+    assert "--publisher-environment pypi \\\n            --artifacts dist" in workflow
+    assert (
+        workflow.count(
+            "--group release python scripts/generate_release_evidence.py verify-pypi-provenance"
+        )
+        == 2
+    )
     assert workflow.count("--publisher-repository oaslananka/kicad-mcp-pro") == 2
     assert "--publisher-environment pypi" in workflow
     assert "--publisher-environment testpypi" in workflow


### PR DESCRIPTION
## Summary

- stop using `pypi-attestations --staging` for TestPyPI; that flag targets PyPI's separate staging deployment, not `test.pypi.org`
- cryptographically verify TestPyPI artifacts through the pinned `pypi-attestations` Python API using the local wheel/sdist and the TestPyPI Integrity API provenance
- keep the official CLI as an independent production-PyPI verification layer
- require both publisher metadata and cryptographic verification when `--artifacts` is supplied
- add regression coverage for the local-artifact verification path and workflow routing

## Root cause

The OIDC upload in run 29782438505 succeeded and TestPyPI exposed publisher identity:

- repository: `oaslananka/kicad-mcp-pro`
- workflow: `publish-python.yml`
- environment: `testpypi`

The final step failed because the CLI's `--staging` option does not mean TestPyPI. The CLI also rejects direct `test-files.pythonhosted.org` URLs. The underlying Python API supports local distribution verification and successfully verifies the same TestPyPI provenance.

## Verification

- Ruff format and lint passed
- strict mypy passed
- 13 focused tests passed
- actionlint passed for 22 workflows
- least-privilege workflow policy passed
- Zizmor reported no high-severity findings
- downloaded `python-dist` and `python-release-evidence` from run 29782438505
- verified TestPyPI SHA-256 digests against those exact artifacts
- cryptographically verified wheel and sdist publish attestations for the expected GitHub publisher identity
- commit-time hooks passed

The repository-wide pytest pre-push hook remains skipped only because #414 tracks its checkout-sandbox defect. Protected cross-platform CI remains authoritative.

Refs #403
Refs #414
