### PR TITLE
fix(test): isolate Git integration repositories

### DIFF
--- a/docs/development/testing-policy.md
+++ b/docs/development/testing-policy.md
@@ -29,3 +29,9 @@ CI runs on pull requests and pushes to `main`. Required jobs cover server behavi
 ## Fuzzing
 
 Atheris fuzz smoke testing covers shared KiCad S-expression helpers. Fuzzing should expand to additional parsers and file import boundaries as those surfaces grow.
+
+## Git subprocess isolation
+
+Tests that initialize or mutate Git repositories must use test-owned temporary directories and an isolated process environment. Set `HOME`, `XDG_CONFIG_HOME`, `GIT_CONFIG_GLOBAL`, and `GIT_CONFIG_SYSTEM` to test-owned paths, disable system configuration, and use an empty `GIT_TEMPLATE_DIR` so contributor hooks and templates cannot enter fixtures.
+
+Production Git helpers discard repository-local variables such as `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` before spawning Git. Regression tests must seed hostile caller values and prove the source checkout status, unstaged diff, and staged diff remain unchanged across normal and failure paths. Destructive operations must revalidate the resolved repository root immediately before mutation.

--- a/src/kicad_mcp/tools/version_control.py
+++ b/src/kicad_mcp/tools/version_control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -16,6 +17,17 @@ from .validation import _entries, _evaluate_project_gate, _run_drc_report
 _CHECKPOINT_TRAILER = "KiCad-MCP-Checkpoint: true"
 _DEFAULT_GIT_NAME = "KiCad MCP Pro"
 _DEFAULT_GIT_EMAIL = "kicad-mcp@example.invalid"
+_REPOSITORY_LOCAL_GIT_ENV = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_QUARANTINE_PATH",
+    "GIT_WORK_TREE",
+)
 
 
 def _git_executable() -> str:
@@ -41,6 +53,14 @@ def _resolve_project_dir(project_dir: str | None = None) -> Path:
     return path
 
 
+def _git_subprocess_env() -> dict[str, str]:
+    """Return a Git environment detached from the caller repository context."""
+    env = os.environ.copy()
+    for variable in _REPOSITORY_LOCAL_GIT_ENV:
+        env.pop(variable, None)
+    return env
+
+
 def _run_git(
     repo_dir: Path,
     *args: str,
@@ -52,6 +72,7 @@ def _run_git(
         capture_output=True,
         text=True,
         errors="replace",
+        env=_git_subprocess_env(),
         timeout=30,
         check=False,
     )
@@ -69,9 +90,28 @@ def _git_repo_root(project_dir: Path) -> Path | None:
 
 
 def _project_pathspec(repo_root: Path, project_dir: Path) -> str:
-    if repo_root == project_dir:
+    resolved_root = repo_root.resolve()
+    resolved_project = project_dir.resolve()
+    if resolved_root == resolved_project:
         return "."
-    return project_dir.relative_to(repo_root).as_posix()
+    try:
+        return resolved_project.relative_to(resolved_root).as_posix()
+    except ValueError as exc:
+        raise ValueError(
+            f"Project directory {resolved_project} is outside Git repository {resolved_root}."
+        ) from exc
+
+
+def _verify_repo_scope(repo_root: Path, project_dir: Path) -> None:
+    """Fail closed when Git resolves a different repository than the active project."""
+    expected = repo_root.resolve()
+    _project_pathspec(expected, project_dir)
+    actual = _git_repo_root(project_dir)
+    if actual != expected:
+        raise ValueError(
+            "Git repository context changed before a destructive operation: "
+            f"expected {expected}, resolved {actual or '<none>'}."
+        )
 
 
 def _ensure_git_identity(repo_root: Path) -> list[str]:
@@ -292,6 +332,7 @@ def register(mcp: FastMCP) -> None:
                     "Rerun with confirm=true to restore project files.",
                 ]
             )
+        _verify_repo_scope(repo_root, project_dir)
         stash_note = _stash_project_state(repo_root, pathspec, commit_hash)
         _run_git(
             repo_root,

--- a/tests/integration/test_version_control_tools.py
+++ b/tests/integration/test_version_control_tools.py
@@ -1,12 +1,96 @@
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from kicad_mcp.server import build_server
 from tests.conftest import call_tool_text
+
+SOURCE_ROOT = Path(__file__).resolve().parents[2]
+
+_REPOSITORY_LOCAL_GIT_ENV = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_QUARANTINE_PATH",
+    "GIT_WORK_TREE",
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_git_process_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Keep test-owned repositories detached from user and caller Git configuration."""
+    git_env = tmp_path / "git-environment"
+    home = git_env / "home"
+    xdg = git_env / "xdg"
+    templates = git_env / "templates"
+    hostile_hooks = git_env / "hostile-hooks"
+    for directory in (home, xdg, templates, hostile_hooks):
+        directory.mkdir(parents=True)
+
+    hostile_marker = git_env / "hostile-hook-ran"
+    hook = hostile_hooks / "pre-commit"
+    hook.write_text(
+        '#!/bin/sh\nprintf hostile > "$HOSTILE_GIT_HOOK_MARKER"\nexit 91\n',
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+    (home / ".gitconfig").write_text(
+        f"[core]\n\thooksPath = {hostile_hooks.as_posix()}\n",
+        encoding="utf-8",
+    )
+    global_config = git_env / "global.gitconfig"
+    system_config = git_env / "system.gitconfig"
+    global_config.write_text("", encoding="utf-8")
+    system_config.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(system_config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_TEMPLATE_DIR", str(templates))
+    monkeypatch.setenv("HOSTILE_GIT_HOOK_MARKER", str(hostile_marker))
+    for variable in _REPOSITORY_LOCAL_GIT_ENV:
+        monkeypatch.delenv(variable, raising=False)
+    return hostile_marker
+
+
+def _clean_git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for variable in _REPOSITORY_LOCAL_GIT_ENV:
+        env.pop(variable, None)
+    return env
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    git = shutil.which("git")
+    assert git is not None
+    return subprocess.run(
+        [git, *args],
+        cwd=repo,
+        env=_clean_git_env(),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _caller_checkout_snapshot() -> tuple[str, str, str]:
+    return (
+        _git_output(SOURCE_ROOT, "status", "--porcelain=v1", "--untracked-files=all"),
+        _git_output(SOURCE_ROOT, "diff", "--binary"),
+        _git_output(SOURCE_ROOT, "diff", "--cached", "--binary"),
+    )
 
 
 def _commit_hash(text: str) -> str:
@@ -17,7 +101,19 @@ def _commit_hash(text: str) -> str:
 
 
 @pytest.mark.anyio
-async def test_vcs_checkpoint_diff_and_restore_roundtrip(sample_project: Path) -> None:
+async def test_vcs_checkpoint_diff_and_restore_roundtrip(
+    sample_project: Path,
+    isolated_git_process_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    caller_before = _caller_checkout_snapshot()
+    git_dir = _git_output(SOURCE_ROOT, "rev-parse", "--absolute-git-dir").strip()
+    git_index = _git_output(SOURCE_ROOT, "rev-parse", "--git-path", "index").strip()
+    monkeypatch.setenv("GIT_DIR", git_dir)
+    monkeypatch.setenv("GIT_WORK_TREE", str(SOURCE_ROOT))
+    monkeypatch.setenv("GIT_INDEX_FILE", git_index)
+    monkeypatch.setenv("GIT_PREFIX", "hostile-prefix/")
+
     server = build_server("full")
     await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
 
@@ -70,6 +166,8 @@ async def test_vcs_checkpoint_diff_and_restore_roundtrip(sample_project: Path) -
     assert "backed up" in restore_text
     assert "Recovery branch: mcp-restore-" in restore_text
     assert restored_schematic == initial_schematic
+    assert not isolated_git_process_environment.exists()
+    assert _caller_checkout_snapshot() == caller_before
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_version_control_helpers.py
+++ b/tests/unit/test_version_control_helpers.py
@@ -103,6 +103,37 @@ def test_version_control_helper_functions(monkeypatch, tmp_path: Path) -> None:
     assert version_control._has_session_scraps([" M demo.kicad_pcb"]) is None
 
 
+def test_git_subprocess_environment_drops_caller_repository_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for variable in version_control._REPOSITORY_LOCAL_GIT_ENV:
+        monkeypatch.setenv(variable, f"hostile-{variable.lower()}")
+    monkeypatch.setenv("HOME", "/safe/home")
+
+    env = version_control._git_subprocess_env()
+
+    assert env["HOME"] == "/safe/home"
+    assert set(version_control._REPOSITORY_LOCAL_GIT_ENV).isdisjoint(env)
+
+
+def test_project_pathspec_and_destructive_scope_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    project_dir = repo_root / "project"
+    outside = tmp_path / "outside"
+    project_dir.mkdir(parents=True)
+    outside.mkdir()
+
+    assert version_control._project_pathspec(repo_root, project_dir) == "project"
+    with pytest.raises(ValueError, match="outside Git repository"):
+        version_control._project_pathspec(repo_root, outside)
+
+    monkeypatch.setattr(version_control, "_git_repo_root", lambda _path: outside)
+    with pytest.raises(ValueError, match="repository context changed"):
+        version_control._verify_repo_scope(repo_root, project_dir)
+
+
 def test_commit_blocked_by_drc_branches(monkeypatch, tmp_path: Path) -> None:
     pcb_file = tmp_path / "demo.kicad_pcb"
     pcb_file.write_text("board", encoding="utf-8")


### PR DESCRIPTION
## Summary

- strip repository-local `GIT_*` variables before every product Git subprocess
- fail closed when the active project resolves to a different Git root immediately before restore
- isolate integration-test `HOME`, XDG config, global/system Git config, and Git template directories
- seed a hostile inherited hook and caller-checkout Git context in regression coverage
- prove source checkout status, unstaged diff, and staged diff remain unchanged
- document the Git subprocess isolation contract for contributors

## Root cause

The repository-wide pytest hook can execute tests with repository-local variables such as `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` inherited from the caller checkout. Temporary project Git commands inherited that context. Separately, contributor-level `core.hooksPath` or Git templates could enter freshly initialized fixture repositories.

## Verification

- Ruff format and lint passed
- strict mypy passed for the production helper
- focused unit and integration suite: 8 passed
- hostile `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, and `GIT_PREFIX` regression passed
- hostile global pre-commit hook was not executed
- caller checkout status, unstaged diff, and staged diff remained identical
- strict documentation build passed
- commit-time and non-pytest pre-push hooks passed

The repository-wide pytest pre-push hook is skipped only for this bootstrap push because this PR is the fix that makes that inherited caller context safe. Protected Linux, macOS, and Windows CI are the authoritative cross-platform gates.

Closes #414
