### PR TITLE
fix(security): let Scorecard inspect CI checks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      checks: read
+      pull-requests: read
+      statuses: read
       security-events: write
       id-token: write
       actions: read

--- a/docs/security/scorecard-exceptions.md
+++ b/docs/security/scorecard-exceptions.md
@@ -6,6 +6,7 @@ This page records OpenSSF Scorecard findings that are not immediate code vulnera
 
 | Check | Current status | Rationale | Remediation path |
 | --- | --- | --- | --- |
+| CI-Tests | Remediation in progress | The Scorecard job declared an explicit permission map but omitted `checks`, `statuses`, and `pull-requests`. GitHub therefore supplied `none` for those scopes, so Scorecard could not inspect the successful CheckRuns attached to recent merged pull requests and reported 0/30 despite the protected multi-platform CI gate. | Grant read-only access to those three metadata scopes, keep all mutation scopes disabled, rerun Scorecard, and retain the required `mcp-server` test matrix plus `Required PR Gate` in the main ruleset. |
 | Branch-Protection | Accepted temporary exception | `main` is protected by a GitHub ruleset that blocks deletion and force-pushes, requires pull requests, requires linear history, requires CI/CodeQL/Gitleaks checks, and requires resolved review threads. Required human approval, code-owner review, and last-push approval are intentionally not enabled while the repository has a single trusted maintainer because doing so can block routine maintenance and security fixes. | Enable required approvals, code-owner review, and last-push approval after adding a second trusted maintainer with verified signing and review availability. |
 | Code-Review | Accepted temporary exception | Recent changes are single-maintainer changes. Bot review and automated analysis are not a substitute for independent human review, so Scorecard correctly cannot award full credit yet. | Recruit at least one additional trusted maintainer and require independent human review for protected-branch merges. |
 | Maintained | Accepted time-based exception | The repository is new, and Scorecard intentionally treats projects younger than 90 days as too new to assess long-term maintenance. | Re-run Scorecard after the repository has more than 90 days of public history and weekly maintenance activity. |
@@ -21,3 +22,8 @@ This page records OpenSSF Scorecard findings that are not immediate code vulnera
 ## Review policy
 
 Accepted Scorecard exceptions must be revisited before each release and after any maintainer or repository-permission change. Do not dismiss a finding without either fixing it or documenting the accepted-risk rationale here.
+## CI-Tests detection contract
+
+The Scorecard CI-Tests check reads recent pull-request associations, CheckRuns, and commit statuses. The Scorecard job therefore has read-only access to `pull-requests`, `checks`, and `statuses`; it does not receive write access to any of them. Code-bearing pull requests remain unable to merge unless the operating-system server matrix and `Required PR Gate` succeed under the active `main` ruleset.
+
+A Scorecard run after a permission change is the authoritative detection check. Keep the alert open if the upstream detector still cannot associate successful GitHub Actions checks, and record that limitation rather than weakening the merge gate.

--- a/tests/unit/test_release_hardening.py
+++ b/tests/unit/test_release_hardening.py
@@ -794,6 +794,9 @@ def test_scorecard_workflow_uses_pinned_actions_without_artifact_storage() -> No
     workflow = _workflow("scorecard.yml")
 
     assert "security-events: write" in workflow
+    assert "checks: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert "statuses: read" in workflow
     assert "ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46" in workflow
     assert "results_format: sarif" in workflow
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow


### PR DESCRIPTION
## Summary

- grant the Scorecard job read-only access to pull-request associations, CheckRuns, and commit statuses
- retain all mutation scopes as disabled except the existing SARIF upload permission
- add a regression contract for the required read scopes
- document why the previous explicit permission map produced the CI-Tests false negative

## Root cause

The Scorecard workflow declared explicit job permissions. GitHub therefore set every omitted scope to `none`. The CI-Tests check could not inspect recent merged pull requests and their successful CheckRuns/Statuses, so it reported 0/30 even though the protected Linux, Windows, and macOS test matrix and Required PR Gate ran before merge.

## Verification

- release-hardening unit suite: 37 passed, 3 expected skips
- GitHub Actions least-privilege policy passed
- actionlint parsed all 22 workflows
- Zizmor reported no high-severity findings
- strict documentation build passed
- commit-time and non-pytest pre-push hooks passed

## Post-merge proof

After merge, run Scorecard manually and keep #404 open until the `CITestsID` code-scanning alert reports successful CI coverage or the upstream detector is documented as a continuing false negative.

Closes #404
