### PR TITLE
ci: add Codecov coverage and test analytics

### DIFF
--- a/.github/actions-policy.json
+++ b/.github/actions-policy.json
@@ -15,6 +15,7 @@
   "allowed_action_repositories": [
     "aquasecurity/trivy-action",
     "astral-sh/setup-uv",
+    "codecov/codecov-action",
     "docker/build-push-action",
     "docker/login-action",
     "docker/metadata-action",
@@ -36,6 +37,9 @@
     "ci.yml": {
       "security": [
         "security-events"
+      ],
+      "coverage": [
+        "id-token"
       ]
     },
     "codeql.yml": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
+              - '.github/actions-policy.json'
+              - 'codecov.yml'
             dependencies:
               - 'package.json'
               - 'pnpm-lock.yaml'
@@ -100,17 +102,19 @@ jobs:
           fi
       - name: Summarize detected changes
         run: |
-          echo '## Change Detection Summary' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo '| Category | Changed |' >> "$GITHUB_STEP_SUMMARY"
-          echo '|----------|---------|' >> "$GITHUB_STEP_SUMMARY"
-          echo '| python | ${{ steps.filter.outputs.python }} |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| npm | ${{ steps.filter.outputs.npm }} |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| schemas | ${{ steps.filter.outputs.schemas }} |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| workflows | ${{ steps.filter.outputs.workflows }} |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| dependencies | ${{ steps.filter.outputs.dependencies }} |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| docs | ${{ steps.filter.outputs.docs }} |' >> "$GITHUB_STEP_SUMMARY"
-          echo '| **docs_only** | **${{ steps.check.outputs.docs_only }}** |' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo '## Change Detection Summary'
+            echo ''
+            echo '| Category | Changed |'
+            echo '|----------|---------|'
+            echo '| python | ${{ steps.filter.outputs.python }} |'
+            echo '| npm | ${{ steps.filter.outputs.npm }} |'
+            echo '| schemas | ${{ steps.filter.outputs.schemas }} |'
+            echo '| workflows | ${{ steps.filter.outputs.workflows }} |'
+            echo '| dependencies | ${{ steps.filter.outputs.dependencies }} |'
+            echo '| docs | ${{ steps.filter.outputs.docs }} |'
+            echo '| **docs_only** | **${{ steps.check.outputs.docs_only }}** |'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   mcp-server:
     needs: [changes]
@@ -162,6 +166,77 @@ jobs:
         if: env.skip_ci != 'true'
       - run: corepack pnpm run package:check
         if: env.skip_ci != 'true'
+
+  coverage:
+    name: CI Tests / Coverage
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Skip full coverage for non-Python PR
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.outputs.python != 'true' &&
+          needs.changes.outputs.workflows != 'true'
+        run: |
+          echo "::notice::Skipping full Python coverage — no Python or workflow changes detected"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        if: env.skip_ci != 'true'
+        with:
+          enable-cache: true
+          version-file: uv.toml
+      - name: Install Python dependencies
+        if: env.skip_ci != 'true'
+        run: uv sync --all-extras --frozen
+      - name: Run full Python suite with coverage and JUnit
+        id: python-tests
+        if: env.skip_ci != 'true'
+        continue-on-error: true
+        run: >-
+          uv run python scripts/run_pytest.py full
+          --junitxml=python.junit.xml
+          -o junit_family=legacy
+      - name: Upload Python coverage to Codecov
+        if: env.skip_ci != 'true' && !cancelled() && hashFiles('coverage.xml') != ''
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          files: coverage.xml
+          disable_search: true
+          disable_telem: true
+          fail_ci_if_error: false
+          flags: python-full
+          name: python-full
+          verbose: true
+      - name: Upload Python test results to Codecov
+        if: env.skip_ci != 'true' && !cancelled() && hashFiles('python.junit.xml') != ''
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          use_oidc: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          report_type: test_results
+          files: python.junit.xml
+          disable_search: true
+          disable_telem: true
+          fail_ci_if_error: false
+          flags: python-full
+          name: python-full-tests
+          verbose: true
+      - name: Propagate Python test failure
+        if: env.skip_ci != 'true' && steps.python-tests.outcome == 'failure'
+        run: |
+          echo "Full Python suite failed; Codecov uploads were attempted before failing the job."
+          exit 1
 
   mcp-npm:
     needs: [changes]
@@ -281,7 +356,7 @@ jobs:
 
   required-pr-gate:
     name: Required PR Gate
-    needs: [changes, mcp-server, mcp-npm, protocol-schemas, workflow-policy, security]
+    needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, workflow-policy, security]
     if: always()
     runs-on: ubuntu-24.04
     steps:
@@ -292,6 +367,7 @@ jobs:
           declare -A results=(
             [changes]="${{ needs.changes.result }}"
             [mcp-server]="${{ needs.mcp-server.result }}"
+            [coverage]="${{ needs.coverage.result }}"
             [mcp-npm]="${{ needs.mcp-npm.result }}"
             [protocol-schemas]="${{ needs.protocol-schemas.result }}"
             [workflow-policy]="${{ needs.workflow-policy.result }}"
@@ -309,7 +385,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=0
-          for job in changes mcp-server mcp-npm protocol-schemas workflow-policy security; do
+          for job in changes mcp-server coverage mcp-npm protocol-schemas workflow-policy security; do
             result="${results[$job]}"
             echo "| $job | $result |" >> "$GITHUB_STEP_SUMMARY"
             case "$result" in

--- a/.github/workflows/kicad-live-e2e.yml
+++ b/.github/workflows/kicad-live-e2e.yml
@@ -86,18 +86,19 @@ jobs:
         id: nightly
         run: |
           set -uo pipefail
+          exec 3>>"$GITHUB_OUTPUT"
           sudo add-apt-repository -y ppa:kicad/kicad-dev-nightly || {
-            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "available=false" >&3
             echo "KiCad nightly PPA is not available on this runner."
             exit 0
           }
           sudo apt-get update || {
-            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "available=false" >&3
             echo "Unable to refresh package metadata for KiCad nightly."
             exit 0
           }
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends kicad-nightly || {
-            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "available=false" >&3
             echo "KiCad nightly package is not currently installable on this runner."
             exit 0
           }
@@ -116,14 +117,14 @@ jobs:
             /usr/bin/kicad-nightly-cli \
             /usr/bin/kicad-cli; do
             if [ -x "$candidate" ] && "$candidate" version; then
-              echo "available=true" >> "$GITHUB_OUTPUT"
-              echo "kicad_cli=$candidate" >> "$GITHUB_OUTPUT"
-              echo "ld_library_path=${LD_LIBRARY_PATH:-}" >> "$GITHUB_OUTPUT"
+              echo "available=true" >&3
+              echo "kicad_cli=$candidate" >&3
+              echo "ld_library_path=${LD_LIBRARY_PATH:-}" >&3
               exit 0
             fi
           done
 
-          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "available=false" >&3
           echo "KiCad nightly installed but no runnable CLI candidate was found."
 
       - name: Install Python dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ site/
 coverage/
 htmlcov/
 coverage.xml
+python.junit.xml
 .coverage
 performance-results/
 artifacts/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,7 +233,7 @@ tasks:
   clean:
     desc: Remove generated build and test artifacts
     cmds:
-      - cmd: rm -rf dist build .pytest_cache .mypy_cache .ruff_cache htmlcov coverage.xml junit.xml
+      - cmd: rm -rf dist build .pytest_cache .mypy_cache .ruff_cache htmlcov coverage.xml junit.xml python.junit.xml
         platforms: [linux, darwin]
-      - cmd: powershell -NoProfile -Command "Remove-Item -Recurse -Force dist,build,.pytest_cache,.mypy_cache,.ruff_cache,htmlcov,coverage.xml,junit.xml -ErrorAction SilentlyContinue"
+      - cmd: powershell -NoProfile -Command "Remove-Item -Recurse -Force dist,build,.pytest_cache,.mypy_cache,.ruff_cache,htmlcov,coverage.xml,junit.xml,python.junit.xml -ErrorAction SilentlyContinue"
         platforms: [windows]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+codecov:
+  branch: main
+
+coverage:
+  precision: 2
+  round: down
+  range: 80..100
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+github_checks:
+  annotations: true
+
+flags:
+  python-full:
+    paths:
+      - src/kicad_mcp/
+    carryforward: false

--- a/docs/development/codecov.md
+++ b/docs/development/codecov.md
@@ -1,0 +1,76 @@
+# Codecov coverage and test analytics
+
+Codecov is an external reporting layer over the repository's existing test
+quality gates. It does not replace pytest, the local 83% coverage minimum, or
+the Required PR Gate.
+
+## CI contract
+
+The `CI Tests / Coverage` job runs the full Python unit, integration, and
+headless E2E suite on Ubuntu for Python and workflow changes, and on every push
+to `main`. NPM/schema-only pull requests keep the same visible check but use a
+cheap no-op. The test driver continues to force pytest's temporary directory
+outside the checkout. The job emits:
+
+- `coverage.xml` for Python source coverage;
+- `python.junit.xml` for Codecov Test Analytics and failed-test reporting.
+
+Reports from `main`, manual runs, and repository-owned pull requests are
+uploaded with GitHub OIDC, so those contexts do not consume the long-lived
+`CODECOV_TOKEN`. Public fork pull requests use Codecov's tokenless public-repo
+path. The Codecov Action is pinned to an immutable commit SHA, CLI integrity
+validation remains enabled, and Codecov telemetry is disabled.
+
+The pytest step uses `continue-on-error` only to allow coverage and JUnit
+reports to upload after a failing test. A final step propagates the original
+test failure, so test failures still block the Required PR Gate.
+
+## Rollout policy
+
+Repository-level `codecov.yml` uses relative `auto` targets and initially
+marks project and patch statuses as informational. The local pytest gate remains
+authoritative at 83%. After a
+stable baseline exists across normal pull requests, a separate reviewed change
+may make Codecov status checks blocking and add them to the branch ruleset.
+
+Upload failures are non-blocking during this first phase so an external Codecov
+outage cannot prevent maintenance or security fixes. Upload logs must still be
+reviewed when changing the workflow.
+
+## Coverage scope
+
+Codecov is largely language-agnostic once a supported coverage report exists.
+The `python-full` flag currently covers `src/kicad_mcp/` because pytest-cov
+already produces Cobertura XML. TypeScript packages currently use
+compile-and-execute contract tests without an instrumented coverage producer,
+and the Tauri bridge currently runs `cargo check` rather than Rust coverage.
+They should not upload fabricated or partial coverage reports.
+
+## Bundle analysis decision
+
+Codecov Bundle Analysis is intentionally not enabled yet. The shipped desktop
+frontend and dashboard are inline/static HTML rather than a production
+Vite/Rollup/Webpack bundle. Adding a bundler plugin now would not produce a
+meaningful module graph. Enable Bundle Analysis when the frontend adopts a real
+production bundle pipeline; at that point use OIDC, disable plugin telemetry,
+and start with an informational size threshold.
+
+## Validation
+
+Validate repository configuration before merging changes:
+
+```bash
+curl --fail-with-body --data-binary @codecov.yml https://codecov.io/validate
+```
+
+Workflow changes must also pass the repository action-policy checker,
+actionlint, Zizmor, and the focused Codecov contract tests.
+
+## References
+
+- [Codecov Quick Start](https://docs.codecov.com/docs/quick-start)
+- [About code coverage](https://docs.codecov.com/docs/about-code-coverage)
+- [Supported languages](https://docs.codecov.com/docs/supported-languages)
+- [Codecov YAML](https://docs.codecov.com/docs/codecov-yaml)
+- [Test Analytics and failed-test reporting](https://docs.codecov.com/docs/test-analytics#failed-test-reporting)
+- [JavaScript Bundle Analysis](https://docs.codecov.com/docs/javascript-bundle-analysis)

--- a/docs/development/testing-policy.md
+++ b/docs/development/testing-policy.md
@@ -35,3 +35,11 @@ Atheris fuzz smoke testing covers shared KiCad S-expression helpers. Fuzzing sho
 Tests that initialize or mutate Git repositories must use test-owned temporary directories and an isolated process environment. Set `HOME`, `XDG_CONFIG_HOME`, `GIT_CONFIG_GLOBAL`, and `GIT_CONFIG_SYSTEM` to test-owned paths, disable system configuration, and use an empty `GIT_TEMPLATE_DIR` so contributor hooks and templates cannot enter fixtures.
 
 Production Git helpers discard repository-local variables such as `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` before spawning Git. Regression tests must seed hostile caller values and prove the source checkout status, unstaged diff, and staged diff remain unchanged across normal and failure paths. Destructive operations must revalidate the resolved repository root immediately before mutation.
+
+## Coverage and failed-test reporting
+
+The `CI Tests / Coverage` job runs the full Python suite with the repository's
+83% pytest-cov gate, publishes `coverage.xml`, and emits JUnit XML for Codecov
+Test Analytics. Upload steps run after test failures, but the original pytest
+failure is propagated after reporting. See
+[Codecov coverage and test analytics](codecov.md).

--- a/docs/engineering/ci-cd-policy.md
+++ b/docs/engineering/ci-cd-policy.md
@@ -45,23 +45,22 @@ would incorrectly no-op on a real dependency/Dockerfile change.
 | Job / Check | Docs-only PR | Python PR | NPM PR | Schema PR | Workflow PR | Full / Mixed PR |
 |-------------|:------------:|:---------:|:------:|:---------:|:-----------:|:---------------:|
 | `mcp-server` (3 OS) | no-op ✅ | **full** | no-op ✅ | no-op ✅ | **full** | **full** |
+| `CI Tests / Coverage` | no-op ✅ | **full** | no-op ✅ | no-op ✅ | **full** | **full** |
 | `mcp-npm` (3 OS) | no-op ✅ | no-op ✅ | **full** | no-op ✅ | **full** | **full** |
 | `protocol-schemas` | no-op ✅ | **full** | **full** | **full** | **full** | **full** |
 | `scan` (Gitleaks) | **full** | **full** | **full** | **full** | **full** | **full** |
 | `analyze` (CodeQL) | no-op ✅ | **full** | **full** | **full** | **full** | **full** |
-| Dependency Review | not triggered | if deps ∆ | if deps ∆ | not triggered | if workflow file ∆ | if deps ∆ |
+| Dependency Review | **full** | **full** | **full** | **full** | **full** | **full** |
 | `required-pr-gate` | ✅ pass | ✅ pass/fail | ✅ pass/fail | ✅ pass/fail | ✅ pass/fail | ✅ pass/fail |
 
 **no-op** means the job runs and reports success, but skips expensive steps.
 This ensures the required status check is never left pending.
 
-Dependency Review is scoped at the **workflow trigger** level (`on.pull_request.paths`
-in `dependency-review.yml`), not via the `changes` job, so it does not run at
-all (no check appears) unless the PR touches `package.json`, `pnpm-lock.yaml`,
-`pyproject.toml`, `uv.lock`, `Dockerfile`, `renovate.json`,
-`packages/mcp-npm/package.json`/`package-lock.json`, or the workflow file
-itself. This is safe only because Dependency Review is **not** a required
-status check.
+Dependency Review runs on every pull request to `main` and is a required
+status check. It must not be path-filtered at the workflow trigger because a
+missing required context would leave an otherwise valid pull request blocked.
+The action itself reports success when a pull request has no dependency-graph
+delta.
 
 ## Required Status Checks
 
@@ -98,27 +97,28 @@ skipped entirely.
 ### Aggregate Gate (`required-pr-gate`)
 
 `ci.yml` includes a `required-pr-gate` job that evaluates the results of
-`changes`, `mcp-server`, `mcp-npm`, `protocol-schemas`, and `security`,
+`changes`, `mcp-server`, `coverage`, `mcp-npm`, `protocol-schemas`, and `security`,
 failing on any `failure`/`cancelled` result and passing on `success`/`skipped`.
 It exists to let branch protection eventually depend on **one** check instead
 of pinning every individual matrix context, so job renames or new matrix
 entries don't require a ruleset edit.
 
-**As of this writing it is not yet part of the branch ruleset.** The required
-migration sequence, in order:
+`Required PR Gate` is active in ruleset `18233373`. The existing operating-
+system matrix, protocol schema, secret scan, CodeQL, and dependency-review
+contexts remain required alongside it. New internal jobs such as `coverage`
+become merge-blocking by joining the aggregate gate; they should not be added
+directly to the ruleset until they have a stable history and a deliberate
+migration plan.
 
-1. Merge the `required-pr-gate` job to `main`.
-2. Confirm it appears and reports correctly on a fresh PR built from updated `main`.
-3. Additively add `Required PR Gate` to ruleset `18233373`'s required checks
-   (keep the existing 10 contexts — do not remove them yet).
-4. As a separate, explicitly-labeled follow-up, once confidence is established,
-   remove the 7 matrix-specific contexts (`mcp-server (*)`, `mcp-npm (*)`,
-   `protocol-schemas`), leaving `Required PR Gate` + `scan` +
-   `analyze (python)` + `analyze (javascript-typescript)`.
+### Codecov reporting
 
-Adding step 3 before step 1/2 would create an unsatisfiable pending check on
-every already-open PR that doesn't yet contain the job — this is exactly the
-"required check pending" failure mode this whole policy exists to avoid.
+`CI Tests / Coverage` is the recognized full-test summary check for OpenSSF
+Scorecard and the source of Codecov Python coverage and JUnit test analytics.
+It authenticates with OIDC and runs upload steps after failed tests. Codecov
+project and patch statuses use relative `auto` targets and are informational
+during baseline collection; the pytest failure and 83% local coverage threshold
+remain blocking through the
+aggregate gate.
 
 ## Security Workflows
 
@@ -126,7 +126,7 @@ every already-open PR that doesn't yet contain the job — this is exactly the
 |----------|:---------------------:|-----------|
 | **Gitleaks** (`scan`) | ✅ Always | Fast; secrets can appear in any file. |
 | **CodeQL** (`analyze`) | no-op | Code analysis is irrelevant for docs changes. Scheduled full scan runs weekly regardless. |
-| **Dependency Review** | Not triggered (no lockfile/manifest changes) | Only meaningful when dependency files change; scoped via workflow-level `paths:`, not a `changes` output. |
+| **Dependency Review** | ✅ Always | Required context; evaluates dependency-graph changes and succeeds when no dependency delta exists. |
 | **Scorecard** | Not triggered on PR | Runs on push to main and weekly schedule. |
 | **Trivy** (in CI `security` job) | no-op on docs-only | Filesystem vulnerability scan is code-focused. |
 | **SonarQube Cloud** | Runs (Automatic Analysis, not workflow-gated) | Not a required check; see below for scope. |

--- a/docs/security/scorecard-exceptions.md
+++ b/docs/security/scorecard-exceptions.md
@@ -27,3 +27,14 @@ Accepted Scorecard exceptions must be revisited before each release and after an
 The Scorecard CI-Tests check reads recent pull-request associations, CheckRuns, and commit statuses. The Scorecard job therefore has read-only access to `pull-requests`, `checks`, and `statuses`; it does not receive write access to any of them. Code-bearing pull requests remain unable to merge unless the operating-system server matrix and `Required PR Gate` succeed under the active `main` ruleset.
 
 A Scorecard run after a permission change is the authoritative detection check. Keep the alert open if the upstream detector still cannot associate successful GitHub Actions checks, and record that limitation rather than weakening the merge gate.
+
+## CI-Tests detector follow-up
+
+The Scorecard `CI-Tests` probe did not recognize the repository's historical
+job names even after read access to checks, statuses, and pull requests was
+granted. The workflow now emits a dedicated `CI Tests / Coverage` check on pull
+requests and `main` commits. Scorecard evaluates approximately 30 recent merged
+changes, so the normalized score will improve as that history is replaced. The
+finding must not be dismissed as fixed until a future Scorecard run observes
+the recognized check history or an upstream detector limitation is accepted
+with evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,7 @@ nav:
       - Testing: testing.md
       - Coding Standards: development/coding-standards.md
       - Testing Policy: development/testing-policy.md
+      - Codecov and Test Analytics: development/codecov.md
       - Dependency Management: development/dependency-management.md
       - Commit Conventions: development/commit-conventions.md
       - Release Process: development/release-process.md

--- a/scripts/run_pytest.py
+++ b/scripts/run_pytest.py
@@ -42,7 +42,7 @@ def main(argv: list[str]) -> int:
         valid = ", ".join(sorted(SUITES))
         print(f"Usage: python scripts/run_pytest.py <{valid}>", file=sys.stderr)
         return 2
-    args = [*SUITES[suite], "--basetemp", str(_basetemp(suite))]
+    args = [*SUITES[suite], *argv[2:], "--basetemp", str(_basetemp(suite))]
     return pytest.main(args)
 
 

--- a/tests/unit/test_codecov_integration.py
+++ b/tests/unit/test_codecov_integration.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+CODECOV_ACTION_SHA = "fb8b3582c8e4def4969c97caa2f19720cb33a72f"
+
+
+def _load_run_pytest() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("run_pytest", ROOT / "scripts" / "run_pytest.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_test_driver_forwards_junit_args_and_preserves_external_basetemp(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_run_pytest()
+    captured: list[str] = []
+    external = tmp_path / "external-basetemp"
+    monkeypatch.setattr(module, "_basetemp", lambda _suite: external)
+    monkeypatch.setattr(module.pytest, "main", lambda args: captured.extend(args) or 0)
+
+    result = module.main(
+        ["run_pytest.py", "unit", "--junitxml=python.junit.xml", "-o", "junit_family=legacy"]
+    )
+
+    assert result == 0
+    assert "--junitxml=python.junit.xml" in captured
+    assert "junit_family=legacy" in captured
+    assert captured[-2:] == ["--basetemp", str(external)]
+
+
+def test_ci_uploads_coverage_and_failed_test_results_with_oidc() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "name: CI Tests / Coverage" in workflow
+    assert workflow.count(f"codecov/codecov-action@{CODECOV_ACTION_SHA}") == 2
+    assert workflow.count("use_oidc: ${{ github.event_name != 'pull_request'") == 2
+    assert "report_type: test_results" in workflow
+    assert "continue-on-error: true" in workflow
+    assert "--junitxml=python.junit.xml" in workflow
+    assert "steps.python-tests.outcome == 'failure'" in workflow
+    assert "needs.changes.outputs.python != 'true'" in workflow
+    assert "needs.changes.outputs.workflows != 'true'" in workflow
+    assert "needs: [changes, mcp-server, coverage, mcp-npm" in workflow
+
+
+def test_codecov_yaml_starts_in_informational_mode() -> None:
+    config = yaml.safe_load((ROOT / "codecov.yml").read_text(encoding="utf-8"))
+
+    assert config["codecov"]["branch"] == "main"
+    assert config["coverage"]["status"]["project"]["default"]["target"] == "auto"
+    assert config["coverage"]["status"]["project"]["default"]["informational"] is True
+    assert config["coverage"]["status"]["patch"]["default"]["informational"] is True
+    assert config["flags"]["python-full"]["paths"] == ["src/kicad_mcp/"]
+    assert "bundle_analysis" not in config


### PR DESCRIPTION
## Summary

- add a path-aware `CI Tests / Coverage` job for the full Python unit, integration, and headless E2E suite
- upload Cobertura coverage and JUnit test results to Codecov with OIDC for trusted repository contexts and tokenless upload for public forks
- preserve the local 83% pytest-cov gate and propagate test failures after report upload
- add a validated repository-level `codecov.yml` with informational `auto` project/patch targets during baseline collection
- document coverage scope, failed-test reporting, rollout/rollback policy, and why JavaScript Bundle Analysis is deferred until a real production bundle exists
- add Codecov to the committed and live GitHub Actions allowlist with a full-SHA-pinned Node 24 compatible action
- expose a dedicated `CI Tests / Coverage` check that OpenSSF Scorecard can recognize as history accumulates
- fix two pre-existing ShellCheck SC2129 findings surfaced by running the real actionlint binary

## Safety and rollout

- Codecov service/upload failures are non-blocking during baseline collection; pytest failures and the 83% local threshold remain blocking through `Required PR Gate`
- report upload runs after failed tests, then the original test outcome is propagated
- no new long-lived Codecov credential is introduced
- bundle analysis is tracked separately in #420 and will not introduce a bundler solely for telemetry

## Validation

- Codecov YAML validation API: passed
- focused unit/policy/release tests: passed
- Ruff format/lint and strict mypy: passed
- GitHub Actions policy: passed
- actionlint + ShellCheck: passed
- Zizmor high-severity audit: passed
- strict documentation build: passed
- private infrastructure reference scan: clean

## Follow-up

- verify the first live Codecov coverage and Test Analytics uploads on this PR
- remove the legacy `CODECOV_TOKEN` only after OIDC upload is proven
- re-run OpenSSF Scorecard after recognized check history accumulates for #404
