### PR TITLE
ci: enforce deterministic workflow security tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -324,6 +324,8 @@ jobs:
           version-file: uv.toml
       - run: uv sync --all-extras --frozen
       - run: uv run --all-extras python scripts/check_github_actions_policy.py
+      - run: uv run --all-extras python scripts/check_workflows.py --actionlint
+      - run: uv run --all-extras python scripts/workflow_security.py --min-severity high
 
   security:
     needs: [changes]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -68,7 +68,7 @@ jobs:
         run: cargo tauri build ${{ matrix.args }}
 
       - name: Upload Tauri bundles
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ matrix.artifact-name }}
           path: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
       - id: check-json
       - id: check-toml
       - id: detect-private-key
+      - id: mixed-line-ending
+        args: [--fix=lf]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.16
@@ -26,13 +28,30 @@ repos:
 
   - repo: local
     hooks:
-      - id: pytest
-        name: pytest
-        entry: pytest
+      - id: workflow-policy
+        name: GitHub Actions policy
+        entry: uv run --all-extras python scripts/check_github_actions_policy.py
+        language: system
+        files: ^(\.github/(workflows/|actions-policy\.json|CODEOWNERS)|scripts/check_github_actions_policy\.py)
+        pass_filenames: false
+      - id: actionlint
+        name: actionlint
+        entry: uv run --all-extras python scripts/check_workflows.py --actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+      - id: zizmor
+        name: zizmor
+        entry: uv run --all-extras python scripts/workflow_security.py --min-severity high
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+      - id: unit-tests
+        name: Unit tests
+        entry: uv run --all-extras python scripts/run_pytest.py unit
         language: system
         always_run: true
         pass_filenames: false
-        args: [--no-header, "-q", "--tb=short", "-x"]
         stages: [pre-push]
       - id: gui-web-tests
         name: GUI web route tests
@@ -42,7 +61,7 @@ repos:
         pass_filenames: false
       - id: tauri-cargo-check
         name: Tauri cargo check
-        entry: cargo check --manifest-path src-tauri/Cargo.toml --locked
+        entry: cargo check --manifest-path src-tauri/Cargo.toml
         language: system
         files: ^src-tauri/
         pass_filenames: false

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,9 +11,10 @@ task hooks
 
 ## Local Setup
 
-`pnpm run workflows:lint` and `task workflows:lint` require `actionlint` on
-`PATH`. Install it from <https://github.com/rhysd/actionlint> before running the
-full local workflow lint gate.
+`pnpm run workflows:lint` and `task workflows:lint` use the exact
+`actionlint-py` and `shellcheck-py` versions locked by `uv.lock`. A frozen
+`uv sync --all-extras` installs both binaries; no separate global install is
+required.
 
 ## Daily Workflow
 
@@ -48,8 +49,9 @@ For local workstation security scanners:
 task security:local
 ```
 
-This command requires Gitleaks, actionlint, and zizmor. It reports clear install
-hints when a required scanner is missing.
+This command uses the locked actionlint, ShellCheck, and Zizmor binaries from
+the project environment. Gitleaks remains a separately installed required
+scanner; missing tools fail with explicit installation guidance.
 
 ## Optional GitHub Actions Local Run
 

--- a/docs/development/testing-policy.md
+++ b/docs/development/testing-policy.md
@@ -43,3 +43,11 @@ The `CI Tests / Coverage` job runs the full Python suite with the repository's
 Test Analytics. Upload steps run after test failures, but the original pytest
 failure is propagated after reporting. See
 [Codecov coverage and test analytics](codecov.md).
+
+## Local hook scope
+
+Commit-time hooks stay fast and deterministic: whitespace/format checks,
+secret scanning, workflow policy, actionlint, and Zizmor run only on matching
+files. The repository-wide unit suite runs at `pre-push`, not `pre-commit`, via
+the pinned `uv` environment and the repository's external-basetemp test driver.
+Full coverage, integration, E2E, container, and CodeQL work remains in CI.

--- a/docs/maintenance-policy.md
+++ b/docs/maintenance-policy.md
@@ -12,7 +12,7 @@ task ci
 
 `task pre-push` runs metadata sync checks, format checks, Ruff, mypy, unit tests,
 workflow YAML parsing, and actionlint. `task ci` adds the full test suite with
-the coverage threshold unchanged at 90%, enforced security checks, workflow
+the coverage threshold unchanged at 83%, enforced security checks, workflow
 security checks, and package build verification.
 
 `task security:local` is stricter about workstation tools. It requires

--- a/docs/workflow-security.md
+++ b/docs/workflow-security.md
@@ -24,7 +24,7 @@ corepack pnpm run workflows:lint
 corepack pnpm run workflows:security
 ```
 
-`workflows:lint` parses workflow YAML and runs actionlint. `workflows:security`
+`workflows:lint` parses workflow YAML and runs actionlint with ShellCheck. `workflows:security`
 runs zizmor offline at high severity or above. Medium findings such as checkout
 credential persistence are still reviewed, but high findings block the local and
 CI gate.
@@ -48,3 +48,18 @@ the exact unresolved action and stop the change.
 
 After updating a pin, inspect the resolved `action.yml` or `action.yaml` and
 confirm JavaScript actions no longer declare a deprecated Node runtime.
+
+## Deterministic local tooling
+
+`actionlint-py` and `shellcheck-py` are exact-version development dependencies,
+so `uv sync --all-extras --frozen` supplies the same workflow parser and shell
+analyzer on Linux, macOS, and Windows. `scripts/check_workflows.py` invokes the
+real `actionlint` binary directly; a missing or failing binary is an error rather
+than a successful no-op. Zizmor remains locked in `uv.lock` and runs offline.
+
+## Node 24 runtime audit
+
+Direct JavaScript Actions use Node 24-capable releases. In particular, the
+path filter is pinned to `dorny/paths-filter` v4.0.1 and artifact uploads use
+`actions/upload-artifact` v7.0.1. When changing an Action pin, inspect the
+pinned commit's `action.yml` rather than assuming a major tag's runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
 [project.optional-dependencies]
 components = ["gql>=3.5.0", "httpx>=0.27.0"]
 dev = [
+  "actionlint-py==1.7.12.24",
   "watchfiles>=1.0.0",
   "bandit>=1.7.9",
   "cairosvg>=2.7.0,<3.0.0",
@@ -83,6 +84,7 @@ dev = [
   "pyright>=1.1.390",
   "types-PyYAML>=6.0.12.20250822",
   "ruff!=0.15.10,>=0.15.0",
+  "shellcheck-py==0.11.0.1",
   "vulture>=2.11",
   "zizmor>=1.24.1",
 ]

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -10,14 +10,7 @@ import subprocess
 import yaml
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-WORKSPACE_ACTIONLINT_COMMAND = [
-    "corepack",
-    "pnpm",
-    "--filter",
-    "kicadstudio",
-    "run",
-    "workflows:lint",
-]
+ACTIONLINT_COMMAND = ["actionlint"]
 
 
 def _resolve_command(command: list[str]) -> list[str]:
@@ -29,7 +22,7 @@ def _resolve_command(command: list[str]) -> list[str]:
 
 
 def _run(command: list[str]) -> None:
-    result = subprocess.run(_resolve_command(command), check=False)
+    result = subprocess.run(_resolve_command(command), cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
 
@@ -46,7 +39,7 @@ def main() -> None:
     print(f"Parsed {len(workflows)} workflow file(s).")
 
     if args.actionlint:
-        _run(WORKSPACE_ACTIONLINT_COMMAND)
+        _run(ACTIONLINT_COMMAND)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_release_preflight_guard.py
+++ b/tests/unit/test_release_preflight_guard.py
@@ -136,7 +136,7 @@ kicadIpcReadiness:
     assert module.main() == 1
 
 
-def test_workflow_lint_uses_workspace_actionlint_fallback(
+def test_workflow_lint_uses_locked_actionlint_binary(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -154,29 +154,17 @@ def test_workflow_lint_uses_workspace_actionlint_fallback(
 
     module.main()
 
-    assert commands == [["corepack", "pnpm", "--filter", "kicadstudio", "run", "workflows:lint"]]
+    assert module.ACTIONLINT_COMMAND == ["actionlint"]
+    assert commands == [["actionlint"]]
 
 
-def test_workflow_lint_does_not_branch_on_local_actionlint_binary(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_workflow_lint_has_no_workspace_specific_fallback() -> None:
     module = _load_script("check_workflows.py")
-    workflows = tmp_path / ".github" / "workflows"
-    workflows.mkdir(parents=True)
-    (workflows / "example.yml").write_text(
-        "name: Example\non: workflow_dispatch\njobs: {}\n",
-        encoding="utf-8",
-    )
-    commands: list[list[str]] = []
-    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(module, "_run", commands.append)
-    monkeypatch.setattr(sys, "argv", ["check_workflows.py", "--actionlint"])
 
-    module.main()
-
-    assert module.WORKSPACE_ACTIONLINT_COMMAND[0] == "corepack"
-    assert commands == [["corepack", "pnpm", "--filter", "kicadstudio", "run", "workflows:lint"]]
+    assert not hasattr(module, "WORKSPACE_ACTIONLINT_COMMAND")
+    assert "kicadstudio" not in Path(__file__).resolve().parents[2].joinpath(
+        "scripts", "check_workflows.py"
+    ).read_text(encoding="utf-8")
 
 
 def test_workflow_lint_resolves_windows_command_shims(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_workflow_tooling.py
+++ b/tests/unit/test_workflow_tooling.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_actionlint_is_a_locked_python_dev_tool() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    checker = (ROOT / "scripts" / "check_workflows.py").read_text(encoding="utf-8")
+
+    assert '"actionlint-py==1.7.12.24"' in pyproject
+    assert '"shellcheck-py==0.11.0.1"' in pyproject
+    assert 'ACTIONLINT_COMMAND = ["actionlint"]' in checker
+    assert "kicadstudio" not in checker
+
+
+def test_pre_commit_keeps_heavy_tests_on_pre_push() -> None:
+    config = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    local = next(repo for repo in config["repos"] if repo["repo"] == "local")
+    hooks = {hook["id"]: hook for hook in local["hooks"]}
+
+    assert hooks["unit-tests"]["stages"] == ["pre-push"]
+    assert "scripts/run_pytest.py unit" in hooks["unit-tests"]["entry"]
+    assert hooks["workflow-policy"]["pass_filenames"] is False
+    assert hooks["actionlint"]["pass_filenames"] is False
+    assert hooks["zizmor"]["pass_filenames"] is False
+    assert re.search(hooks["workflow-policy"]["files"], ".github/actions-policy.json")
+    assert re.search(hooks["actionlint"]["files"], ".github/workflows/ci.yml")
+    assert re.search(hooks["zizmor"]["files"], ".github/workflows/ci.yaml")
+    assert "--locked" not in hooks["tauri-cargo-check"]["entry"]
+
+
+def test_mixed_line_endings_are_normalized() -> None:
+    config = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    standard = next(repo for repo in config["repos"] if repo["repo"].endswith("pre-commit-hooks"))
+    hook = next(hook for hook in standard["hooks"] if hook["id"] == "mixed-line-ending")
+
+    assert hook["args"] == ["--fix=lf"]
+
+
+def test_workflow_policy_runs_actionlint_and_zizmor_in_required_gate() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "scripts/check_workflows.py --actionlint" in workflow
+    assert "scripts/workflow_security.py --min-severity high" in workflow
+    assert (
+        "needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, "
+        "workflow-policy, security]" in workflow
+    )
+
+
+def test_direct_javascript_actions_use_node24_releases() -> None:
+    workflows = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    )
+
+    assert "dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d" in workflows
+    assert "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36" not in workflows
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" not in workflows

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,12 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0b/3f29683dfbe94208fb5c3806806a6ef419972892e25c3c4f95198f68c978/actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e", size = 12071, upload-time = "2026-03-31T06:21:35.015Z" }
+
+[[package]]
 name = "aiofile"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1107,6 +1113,7 @@ components = [
     { name = "httpx" },
 ]
 dev = [
+    { name = "actionlint-py" },
     { name = "bandit" },
     { name = "cairosvg" },
     { name = "httpx2" },
@@ -1130,6 +1137,7 @@ dev = [
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "shellcheck-py" },
     { name = "types-pyyaml" },
     { name = "vulture" },
     { name = "watchfiles" },
@@ -1162,6 +1170,7 @@ release = [
 
 [package.metadata]
 requires-dist = [
+    { name = "actionlint-py", marker = "extra == 'dev'", specifier = "==1.7.12.24" },
     { name = "anyio", specifier = ">=4.4.0" },
     { name = "authlib", specifier = ">=1.7.1" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.9" },
@@ -1205,6 +1214,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0,!=0.15.10" },
+    { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
     { name = "starlette", specifier = ">=1.0.1,<2.0.0" },
     { name = "structlog", specifier = ">=24.2.0" },
     { name = "typer", specifier = ">=0.12.0" },
@@ -3157,6 +3167,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/7f/369a478863a39351be75e0a12602bc29196b31f87bf3432bed2be6379f8e/sexpdata-1.0.2.tar.gz", hash = "sha256:92b67b0361f6766f8f9e44b9519cf3fbcfafa755db85bbf893c3e1cf4ddac109", size = 8906, upload-time = "2024-01-09T07:09:59.096Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/f3/ec9f8cc20dc1f34c926f0ec3f43b73fa2da59cf08e432fb8ae5b666b2027/sexpdata-1.0.2-py3-none-any.whl", hash = "sha256:b39c918f055a85c5c35c1d4f7930aabb176bd29016e5ba5692e7e849914b2a1a", size = 10337, upload-time = "2024-01-09T07:09:57.185Z" },
+]
+
+[[package]]
+name = "shellcheck-py"
+version = "0.11.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/455b097417b3df3d330eff029c72c32f08b25739e3010acb30ad06d268ef/shellcheck_py-0.11.0.1.tar.gz", hash = "sha256:5c620c88901e8f1d3be5934b31ea99e3310065e1245253741eafd0a275c8c9cc", size = 3139, upload-time = "2025-08-09T17:53:42.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/27/d75b03e5458cefdb6d3b674566cd20476c3e4d3fe6cc9d68b7e3b854b296/shellcheck_py-0.11.0.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6a3fee28efda2e16e38d6e6d59faf7224300256456639727370d404730849e8", size = 6774472, upload-time = "2025-08-09T17:53:34.573Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ac/2a84c37171c0cf5a10ea4b0a27d43eb0a1d29bd98b49c2c5ffe17ad24bbe/shellcheck_py-0.11.0.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b88d0a244c82ed07e06a53e444da841f69330ca59ae15d4a66c391655dae7a0", size = 11381835, upload-time = "2025-08-09T17:53:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/96/55/250e0e3367613a5c22bd82e33b16b889287d81ab0f7dda67e6514a4cccf4/shellcheck_py-0.11.0.1-py2.py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b274df81de5b000ff78db433e7328b87e52e3c38481c60f8e488c3095beef05", size = 3800600, upload-time = "2025-08-09T17:53:38.643Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5b/bb14c0a7474463b1aa3c09e866cb172dffc66ed2993b7ea8f1db581e86ee/shellcheck_py-0.11.0.1-py2.py3-none-win_amd64.whl", hash = "sha256:784156289ecb17e91c692cd783ab5152333309588cabb10032a047331c63e759", size = 8027541, upload-time = "2025-08-09T17:53:40.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- install exact, lockfile-backed `actionlint` and ShellCheck binaries through the Python dev environment
- replace the previous workspace-specific actionlint fallback with a direct, failing invocation of the real binary
- run action policy, actionlint/ShellCheck, and Zizmor in the required `workflow-policy` CI job
- add matching fast pre-commit hooks for workflow changes
- replace the broad raw pytest pre-push hook with the repository's external-basetemp unit-suite driver
- normalize mixed line endings and align the Tauri hook with the repository's unlocked Cargo policy
- upgrade `dorny/paths-filter` and the remaining old `actions/upload-artifact` pin to Node 24 releases
- fix the two SC2129 findings surfaced by real ShellCheck
- correct stale developer documentation about the 83% coverage gate and Renovate/Dependabot ownership

## Tooling policy

- CodeQL remains the primary blocking SAST; this change does not add a duplicate blanket Semgrep/Snyk Code gate
- Snyk, Socket, SonarQube Cloud, Trivy, Gitleaks, and Scorecard retain their existing roles
- actionlint, ShellCheck, and Zizmor become deterministic and blocking through `Required PR Gate`
- exact versions and binary checksums are resolved through `uv.lock`

## Validation

- focused workflow/action-policy/release/Codecov tests: passed
- Ruff and strict mypy: passed
- actionlint 1.7.12 + ShellCheck 0.11.0: passed across all workflows
- Zizmor high-severity offline audit: passed
- pre-commit configuration validation: passed
- strict documentation build: passed
- commit-time and pre-push workflow hooks: passed
- private infrastructure reference scan: clean

## Node 24 audit

The direct JavaScript Action audit found two Node 20 pins. This PR upgrades:

- `dorny/paths-filter` to v4.0.1 (`node24`)
- the remaining GUI release `actions/upload-artifact` use to v7.0.1 (`node24`)

All other direct JavaScript Actions already declare `node24` at their pinned commits.
