### PR TITLE
fix(security): scope patched body-parser override

### DIFF
--- a/integrations/chatgpt-app/apps-sdk/package-lock.json
+++ b/integrations/chatgpt-app/apps-sdk/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.4.0",
-        "express": "^4.21.0",
+        "express": "4.22.2",
         "express-rate-limit": "^8.1.0",
         "zod": "^3.23.0"
       },
@@ -981,9 +981,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",

--- a/integrations/chatgpt-app/apps-sdk/package.json
+++ b/integrations/chatgpt-app/apps-sdk/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.4.0",
-    "express": "^4.21.0",
+    "express": "4.22.2",
     "express-rate-limit": "^8.1.0",
     "zod": "^3.23.0"
   },
@@ -22,5 +22,10 @@
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
+  },
+  "overrides": {
+    "express@4.22.2": {
+      "body-parser": "1.20.6"
+    }
   }
 }

--- a/tests/unit/test_chatgpt_app_dependency_policy.py
+++ b/tests/unit/test_chatgpt_app_dependency_policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "integrations" / "chatgpt-app" / "apps-sdk"
+
+
+def test_chatgpt_app_scopes_body_parser_security_override() -> None:
+    package = json.loads((APP / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((APP / "package-lock.json").read_text(encoding="utf-8"))
+
+    assert package["dependencies"]["express"] == "4.22.2"
+    assert package["overrides"] == {
+        "express@4.22.2": {"body-parser": "1.20.6"},
+    }
+    assert lock["packages"]["node_modules/body-parser"]["version"] == "1.20.6"
+    assert (
+        lock["packages"]["node_modules/@modelcontextprotocol/sdk/node_modules/body-parser"][
+            "version"
+        ]
+        == "2.3.0"
+    )


### PR DESCRIPTION
## Summary

- pin the direct ChatGPT App Express dependency to 4.22.2
- scope an npm override so only the Express 4 tree uses patched `body-parser` 1.20.6
- preserve the MCP SDK's Express 5 tree on `body-parser` 2.3.0
- add a regression test that verifies both resolved dependency paths

## Security context

Fixes Dependabot alert #2 for `GHSA-v422-hmwv-36x6` / `CVE-2026-12590` without applying a broad override that could make Express 5 consume an incompatible 1.x parser.

## Validation

- clean `npm ci`: passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- ChatGPT App TypeScript typecheck: passed
- ChatGPT App production build: passed
- dependency policy regression test: passed
- resolved dependency tree:
  - direct Express 4.22.2 → body-parser 1.20.6
  - MCP SDK Express 5.2.1 → body-parser 2.3.0
