### PR TITLE
fix(release): synchronize citation release date

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ url: "https://oaslananka.github.io/kicad-mcp-pro"
 doi: "10.5281/zenodo.21283791"
 license: MIT
 version: "3.25.0" # x-release-please-version
-date-released: "2026-07-10"
+date-released: "2026-07-10" # x-release-please-date
 abstract: >-
   KiCad MCP Pro is a Model Context Protocol server for automating KiCad
   schematic capture, PCB layout, ERC/DRC validation, DFM checks, and

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -17,6 +17,20 @@ REPO_ROOT = ROOT
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
 INIT_VERSION_RE = re.compile(r'^__version__\s*=\s*"([^"]+)"', re.MULTILINE)
 CHANGELOG_VERSION_RE = re.compile(r"^## \[(?P<version>[^\]]+)\]", re.MULTILINE)
+CHANGELOG_RELEASE_DATE_RE = re.compile(
+    r"^## \[(?P<version>[^\]]+)\](?:\([^)]+\))?\s+"
+    r"\((?P<date>\d{4}-\d{2}-\d{2})\)\s*$",
+    re.MULTILINE,
+)
+CITATION_VERSION_RE = re.compile(
+    r'^version:\s*["\']?(?P<version>[^"\'#\s]+)["\']?\s*(?:#.*)?$',
+    re.MULTILINE,
+)
+CITATION_DATE_RE = re.compile(
+    r'^date-released:\s*["\']?(?P<date>\d{4}-\d{2}-\d{2})["\']?'
+    r"\s*(?P<comment>#.*)?$",
+    re.MULTILINE,
+)
 
 
 def _read_json(path: str) -> dict[str, object]:
@@ -114,6 +128,44 @@ def _changelog_section(changelog: str, version: str) -> str:
     return ""
 
 
+def _check_citation(version: str) -> list[str]:
+    citation = (ROOT / "CITATION.cff").read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    version_match = CITATION_VERSION_RE.search(citation)
+    if version_match is None:
+        errors.append("CITATION.cff must declare a version")
+    elif version_match.group("version") != version:
+        errors.append(
+            "CITATION.cff version drift detected: "
+            f"citation={version_match.group('version')}, project={version}"
+        )
+
+    date_match = CITATION_DATE_RE.search(citation)
+    if date_match is None:
+        errors.append("CITATION.cff must declare date-released in YYYY-MM-DD format")
+        return errors
+
+    comment = date_match.group("comment") or ""
+    if "x-release-please-date" not in comment:
+        errors.append(
+            "CITATION.cff date-released must include the x-release-please-date annotation"
+        )
+
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    release_dates = {
+        match.group("version"): match.group("date")
+        for match in CHANGELOG_RELEASE_DATE_RE.finditer(changelog)
+    }
+    expected_date = release_dates.get(version)
+    if expected_date is not None and date_match.group("date") != expected_date:
+        errors.append(
+            "CITATION.cff date-released does not match the current changelog release date: "
+            f"citation={date_match.group('date')}, changelog={expected_date}"
+        )
+    return errors
+
+
 def _check_changelog(version: str) -> list[str]:
     changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     errors: list[str] = []
@@ -154,6 +206,7 @@ def main() -> int:
     errors = [
         *_check_versions(),
         *_check_protocol_schema_version(),
+        *_check_citation(version),
         *_check_changelog(version),
         *validate_compatibility_matrix(),
     ]

--- a/tests/unit/test_release_preflight_guard.py
+++ b/tests/unit/test_release_preflight_guard.py
@@ -69,6 +69,44 @@ def test_release_preflight_scans_only_current_changelog_section(
     assert "current release section" in errors[0]
 
 
+def test_release_preflight_rejects_unmanaged_stale_citation_date(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script("check_release_preflight.py")
+    (tmp_path / "CITATION.cff").write_text(
+        """
+version: "3.26.0" # x-release-please-version
+date-released: "2026-07-10"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [3.26.0](https://example.test/compare) (2026-07-21)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_project_version", lambda: "3.26.0")
+    monkeypatch.setattr(module, "_check_versions", lambda: [])
+    monkeypatch.setattr(module, "_check_protocol_schema_version", lambda: [])
+    monkeypatch.setattr(module, "_check_changelog", lambda version: [])
+    monkeypatch.setattr(module, "validate_compatibility_matrix", lambda: [])
+
+    assert module.main() == 1
+    stderr = capsys.readouterr().err
+    assert "CITATION.cff date-released" in stderr
+    assert "x-release-please-date" in stderr
+
+
+def test_repository_citation_release_date_is_release_please_managed() -> None:
+    citation = (ROOT / "CITATION.cff").read_text(encoding="utf-8")
+    date_line = next(line for line in citation.splitlines() if line.startswith("date-released:"))
+
+    assert "x-release-please-date" in date_line
+
+
 def test_release_preflight_skips_release_please_generated_changelog_noise(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- mark `CITATION.cff` `date-released` with Release Please's supported `x-release-please-date` annotation
- extend release preflight to reject citation version drift, unmanaged dates, invalid date format, and changelog/date mismatches
- add regression coverage for the stale `3.26.0` / `2026-07-10` release-PR case

## Root cause

PR #398 correctly advanced `CITATION.cff` to version `3.26.0`, but `date-released` remained `2026-07-10`. The file only had the generic version annotation. Release Please's generic updater supports a separate `x-release-please-date` annotation, so the date must be explicitly marked as managed.

## Verification

- TDD red: both the stale-date preflight case and missing annotation test failed before the change
- `pytest -q tests/unit/test_release_preflight_guard.py`: 9 passed
- Ruff format and lint on changed Python files: passed
- `pnpm run check:release`: passed
- `pnpm run metadata:check`: passed
- changed-file pre-commit hooks: passed

## Release decision

PR #398 remains intentionally unmerged until this PR lands and Release Please regenerates `CITATION.cff` with the `3.26.0` release date.

Related: #397, #405
