### PR TITLE
fix(release): synchronize Tauri bundle version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,11 @@
     {
       "type": "linked-versions",
       "groupName": "kicad-mcp-pro",
-      "components": ["mcp-server", "mcp-npm", "kicad-mcp-gui"]
+      "components": [
+        "mcp-server",
+        "mcp-npm",
+        "kicad-mcp-gui"
+      ]
     }
   ],
   "packages": {
@@ -93,7 +97,11 @@
       "component": "kicad-mcp-gui",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "src-tauri/tauri.conf.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "tauri.conf.json",
+          "jsonpath": "$.version"
+        }
       ]
     }
   }

--- a/scripts/check_release_preflight.py
+++ b/scripts/check_release_preflight.py
@@ -61,6 +61,10 @@ def _collect_versions() -> dict[str, str]:
     server = _read_json("server.json")
     wrapper = _read_repo_json("packages/mcp-npm/package.json")
     manifest = _read_repo_json(".release-please-manifest.json")
+    tauri_cargo = tomllib.loads(
+        (REPO_ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8")
+    )
+    tauri_config = _read_repo_json("src-tauri/tauri.conf.json")
     versions = {
         "pyproject.toml": _project_version(),
         "src/kicad_mcp/__init__.py": _init_version(),
@@ -68,6 +72,9 @@ def _collect_versions() -> dict[str, str]:
         "packages/mcp-npm/package.json": str(wrapper.get("version", "")),
         ".release-please-manifest.json .": str(manifest.get(".", "")),
         ".release-please-manifest.json packages/mcp-npm": str(manifest.get("packages/mcp-npm", "")),
+        "src-tauri/Cargo.toml": str(tauri_cargo.get("package", {}).get("version", "")),
+        "src-tauri/tauri.conf.json": str(tauri_config.get("version", "")),
+        ".release-please-manifest.json src-tauri": str(manifest.get("src-tauri", "")),
     }
     packages = server.get("packages")
     if not isinstance(packages, list) or not packages:

--- a/scripts/check_submission_readiness.py
+++ b/scripts/check_submission_readiness.py
@@ -152,9 +152,17 @@ def _runner_check() -> CheckResult:
 
 def _version_check() -> CheckResult:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    tauri_cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
+    tauri_config = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
+    release_manifest = json.loads(
+        (ROOT / ".release-please-manifest.json").read_text(encoding="utf-8")
+    )
     versions = {
         "pyproject.toml": pyproject["project"]["version"],
         "server.json": json.loads((ROOT / "server.json").read_text(encoding="utf-8"))["version"],
+        "src-tauri/Cargo.toml": tauri_cargo["package"]["version"],
+        "src-tauri/tauri.conf.json": tauri_config["version"],
+        ".release-please-manifest.json src-tauri": release_manifest["src-tauri"],
     }
     init_text = (ROOT / "src" / "kicad_mcp" / "__init__.py").read_text(encoding="utf-8")
     match = re.search(r'__version__\s*=\s*"([^"]+)"', init_text)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "KiCad MCP Pro",
-  "version": "3.14.1",
+  "version": "3.25.0",
   "identifier": "dev.oaslananka.kicad-mcp-pro",
   "build": {
     "frontendDist": "frontend",

--- a/tests/unit/test_release_preflight_guard.py
+++ b/tests/unit/test_release_preflight_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -105,6 +106,31 @@ def test_repository_citation_release_date_is_release_please_managed() -> None:
     date_line = next(line for line in citation.splitlines() if line.startswith("date-released:"))
 
     assert "x-release-please-date" in date_line
+
+
+def test_release_preflight_tracks_tauri_bundle_version() -> None:
+    module = _load_script("check_release_preflight.py")
+    versions = module._collect_versions()
+
+    expected = {
+        "src-tauri/Cargo.toml",
+        "src-tauri/tauri.conf.json",
+        ".release-please-manifest.json src-tauri",
+    }
+    assert expected.issubset(versions)
+    assert len({versions[source] for source in expected}) == 1
+
+
+def test_release_please_tauri_extra_file_is_package_relative() -> None:
+    config = json.loads((ROOT / "release-please-config.json").read_text(encoding="utf-8"))
+    extra_files = config["packages"]["src-tauri"]["extra-files"]
+
+    assert {
+        "type": "json",
+        "path": "tauri.conf.json",
+        "jsonpath": "$.version",
+    } in extra_files
+    assert all(entry["path"] != "src-tauri/tauri.conf.json" for entry in extra_files)
 
 
 def test_release_preflight_skips_release_please_generated_changelog_noise(

--- a/tests/unit/test_submission_readiness.py
+++ b/tests/unit/test_submission_readiness.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from scripts import check_submission_readiness
 
 
@@ -5,3 +9,31 @@ def test_readme_listing_references_use_current_package_version() -> None:
     result = check_submission_readiness._readme_check()
 
     assert result.status == "PASS"
+
+
+def test_submission_readiness_rejects_tauri_bundle_version_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "src" / "kicad_mcp").mkdir(parents=True)
+    (tmp_path / "src-tauri").mkdir()
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "3.25.0"\n', encoding="utf-8")
+    (tmp_path / "server.json").write_text('{"version":"3.25.0"}\n', encoding="utf-8")
+    (tmp_path / "src" / "kicad_mcp" / "__init__.py").write_text(
+        '__version__ = "3.25.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "src-tauri" / "Cargo.toml").write_text(
+        '[package]\nversion = "3.25.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "src-tauri" / "tauri.conf.json").write_text(
+        '{"version":"3.14.1"}\n', encoding="utf-8"
+    )
+    (tmp_path / ".release-please-manifest.json").write_text(
+        '{"src-tauri":"3.25.0"}\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(check_submission_readiness, "ROOT", tmp_path)
+
+    result = check_submission_readiness._version_check()
+
+    assert result.status == "FAIL"
+    assert "src-tauri/tauri.conf.json" in result.detail


### PR DESCRIPTION
## Summary

- make the Tauri `tauri.conf.json` extra-file path relative to the `src-tauri` Release Please package root
- restore the current GUI bundle version from stale `3.14.1` to `3.25.0`
- include Tauri Cargo/config/manifest versions in release preflight and submission readiness
- add regression coverage for package-relative Release Please paths and GUI bundle version drift

## Root cause

PR #398 prepared the GUI release tag at `3.26.0`, but `src-tauri/tauri.conf.json` remained `3.14.1`. Tauri uses that config value for installer filenames, which explains why the previous `kicad-mcp-gui-v3.25.0` release uploaded installers named `3.14.1`.

The `src-tauri` Release Please package configured its extra file as `src-tauri/tauri.conf.json`. Extra-file paths are package-relative, so Release Please effectively looked below the package root twice and did not update the config.

## Verification

- TDD red: preflight omitted all Tauri versions, the extra-file path assertion failed, and submission readiness accepted a stale GUI bundle version
- 13 targeted release/submission tests passed
- release preflight and submission readiness passed
- Ruff format/lint passed
- changed-file hooks passed, including Tauri cargo check with the Linux GUI sysroot

## Release decision

PR #398 remains blocked until this PR merges and Release Please regenerates the branch with `src-tauri/tauri.conf.json` at `3.26.0`.

Related: #405
