### PR TITLE
test: make canary fixture copies metadata-independent

### DIFF
--- a/scripts/kicad_canary.py
+++ b/scripts/kicad_canary.py
@@ -208,6 +208,19 @@ def _project_file(fixture: str, suffix: str) -> Path:
     return _fixture_file(FIXTURE_ROOT, fixture, suffix)
 
 
+def _copy_fixture_tree(source: Path, target: Path) -> None:
+    """Copy fixture contents without requiring writable filesystem metadata."""
+    target.mkdir(parents=True, exist_ok=False)
+    for entry in source.iterdir():
+        destination = target / entry.name
+        if entry.is_dir():
+            _copy_fixture_tree(entry, destination)
+        elif entry.is_file():
+            shutil.copyfile(entry, destination)
+        else:
+            raise OSError(f"Unsupported fixture entry: {entry}")
+
+
 def _prepare_fixture_workspaces(artifacts: Path, fixtures: set[str]) -> Path:
     workspace_root = artifacts / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
@@ -218,7 +231,7 @@ def _prepare_fixture_workspaces(artifacts: Path, fixtures: set[str]) -> Path:
             raise FileNotFoundError(f"Unknown KiCad fixture: {fixture}")
         if target.exists():
             shutil.rmtree(target)
-        shutil.copytree(source, target)
+        _copy_fixture_tree(source, target)
     return workspace_root
 
 

--- a/tests/unit/test_kicad_canary.py
+++ b/tests/unit/test_kicad_canary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -157,6 +158,41 @@ def test_kicad_canary_uses_shared_fixture_corpus() -> None:
         kicad_canary._project_file("clean-led-kicad10", ".kicad_pcb").name
         == "clean-led-kicad10.kicad_pcb"
     )
+
+
+def test_fixture_workspace_copy_does_not_require_directory_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fixture_root = tmp_path / "fixtures"
+    source = fixture_root / "portable-fixture"
+    nested = source / "nested"
+    nested.mkdir(parents=True)
+    (source / "board.kicad_pcb").write_text("board\n", encoding="utf-8")
+    (nested / "sheet.kicad_sch").write_text("sheet\n", encoding="utf-8")
+    monkeypatch.setattr(kicad_canary, "FIXTURE_ROOT", fixture_root)
+
+    original_copystat = shutil.copystat
+
+    def deny_directory_metadata(source_path, target_path, *, follow_symlinks=True):
+        if Path(source_path).is_dir():
+            raise PermissionError("directory metadata is not writable")
+        return original_copystat(
+            source_path,
+            target_path,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(kicad_canary.shutil, "copystat", deny_directory_metadata)
+
+    workspace = kicad_canary._prepare_fixture_workspaces(
+        tmp_path / "artifacts",
+        {"portable-fixture"},
+    )
+
+    copied = workspace / "portable-fixture"
+    assert (copied / "board.kicad_pcb").read_text(encoding="utf-8") == "board\n"
+    assert (copied / "nested" / "sheet.kicad_sch").read_text(encoding="utf-8") == "sheet\n"
 
 
 def test_command_plan_covers_oaslana_38_export_surface(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- replace `shutil.copytree` fixture staging with a content-only recursive copy
- avoid requiring directory timestamp/mode metadata writes in restricted filesystems
- preserve the writable fixture workspace contract used by KiCad canary commands
- add a regression test that denies directory metadata writes while verifying nested fixture contents

## Why

The full local pre-push unit suite exposed three KiCad canary tests that copied every fixture file successfully but failed when `shutil.copytree` attempted the final directory `copystat`. Canary workspaces only require the file bytes and directory structure; source ownership, timestamps, and directory modes are not part of the test contract.

## Verification

- new metadata-denial regression: passed
- all 16 `test_kicad_canary.py` tests: passed
- full pre-push unit suite: passed
- Ruff format/check: passed
- pre-commit and pre-push safety hooks: passed

This is test infrastructure portability only and intentionally uses a non-release conventional commit type.