### PR TITLE
fix(security): patch vulnerable dependency chains

### DIFF
--- a/integrations/chatgpt-app/apps-sdk/package-lock.json
+++ b/integrations/chatgpt-app/apps-sdk/package-lock.json
@@ -464,12 +464,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1306,6 +1306,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1372,9 +1373,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1521,10 +1522,11 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2197,6 +2199,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/integrations/chatgpt-app/apps-sdk/package.json
+++ b/integrations/chatgpt-app/apps-sdk/package.json
@@ -26,6 +26,9 @@
   "overrides": {
     "express@4.22.2": {
       "body-parser": "1.20.6"
-    }
+    },
+    "@hono/node-server": "2.0.11",
+    "hono": "4.12.31",
+    "fast-uri": "3.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fast-uri: 3.1.4
   js-yaml: 4.3.0
 
 importers:
@@ -221,8 +222,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -500,7 +501,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -572,7 +573,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   get-caller-file@2.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - "packages/protocol-schemas"
 
 overrides:
+  fast-uri: 3.1.4
   js-yaml: 4.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ http = ["httpx>=0.27.0", "uvicorn[standard]>=0.30.0"]
 tray = ["pystray>=0.19.5", "Pillow>=10.0.0"]
 simulation = ["numpy>=1.26.0"]
 vcs = [
-    "gitpython>=3.1.49,<4.0.0",
+    "gitpython>=3.1.51,<4.0.0",
 ]
 
 [project.scripts]

--- a/tests/unit/test_chatgpt_app_dependency_policy.py
+++ b/tests/unit/test_chatgpt_app_dependency_policy.py
@@ -14,6 +14,9 @@ def test_chatgpt_app_scopes_body_parser_security_override() -> None:
     assert package["dependencies"]["express"] == "4.22.2"
     assert package["overrides"] == {
         "express@4.22.2": {"body-parser": "1.20.6"},
+        "@hono/node-server": "2.0.11",
+        "hono": "4.12.31",
+        "fast-uri": "3.1.4",
     }
     assert lock["packages"]["node_modules/body-parser"]["version"] == "1.20.6"
     assert (

--- a/tests/unit/test_dependency_security_floors.py
+++ b/tests/unit/test_dependency_security_floors.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+from packaging.version import Version
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "integrations" / "chatgpt-app" / "apps-sdk"
+
+
+def test_gitpython_security_floor_is_patched() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    uv_lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+
+    vcs_dependencies = pyproject["project"]["optional-dependencies"]["vcs"]
+    assert any("gitpython>=3.1.51" in dependency.lower() for dependency in vcs_dependencies)
+
+    locked = next(
+        package["version"]
+        for package in uv_lock["package"]
+        if package["name"].lower() == "gitpython"
+    )
+    assert Version(locked) >= Version("3.1.51")
+
+
+def test_root_pnpm_lock_uses_patched_fast_uri() -> None:
+    workspace = yaml.safe_load((ROOT / "pnpm-workspace.yaml").read_text(encoding="utf-8"))
+    lock = (ROOT / "pnpm-lock.yaml").read_text(encoding="utf-8")
+    versions = {Version(value) for value in re.findall(r"fast-uri@(\d+\.\d+\.\d+)", lock)}
+
+    assert workspace["overrides"]["fast-uri"] == "3.1.4"
+    assert versions
+    assert min(versions) >= Version("3.1.4")
+
+
+def test_chatgpt_app_transitive_security_overrides_are_patched() -> None:
+    package = json.loads((APP / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((APP / "package-lock.json").read_text(encoding="utf-8"))
+
+    assert package["overrides"]["@hono/node-server"] == "2.0.11"
+    assert package["overrides"]["hono"] == "4.12.31"
+    assert package["overrides"]["fast-uri"] == "3.1.4"
+
+    patched = {
+        "node_modules/@hono/node-server": "2.0.5",
+        "node_modules/hono": "4.12.27",
+        "node_modules/fast-uri": "3.1.4",
+    }
+    for path, minimum in patched.items():
+        assert Version(lock["packages"][path]["version"]) >= Version(minimum)

--- a/uv.lock
+++ b/uv.lock
@@ -641,14 +641,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/24/0e0c12cb6f7cb864779a9d2fefee9ca91838f6db402c8780c9d28a8d7ebe/gitpython-3.1.53.tar.gz", hash = "sha256:06ae8d9623b0ed0d67b8adeac5c7008d0a5a404b087a9e0d0c7163bdd3a6b497", size = 224597, upload-time = "2026-07-20T13:41:52.839Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a6/bff12b3238885eeef7d28ef908b24e0cba91c476c31cb876a00a0986ce2c/gitpython-3.1.53-py3-none-any.whl", hash = "sha256:187885556b64ab357bd4ea84e2c4cce2861a613a7f4268b3f7f7ba05f2ce4ab0", size = 216237, upload-time = "2026-07-20T13:41:51.473Z" },
 ]
 
 [[package]]
@@ -1175,7 +1175,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.7.1" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.9" },
     { name = "cairosvg", marker = "extra == 'dev'", specifier = ">=2.7.0,<3.0.0" },
-    { name = "gitpython", marker = "extra == 'vcs'", specifier = ">=3.1.49,<4.0.0" },
+    { name = "gitpython", marker = "extra == 'vcs'", specifier = ">=3.1.51,<4.0.0" },
     { name = "gql", marker = "extra == 'components'", specifier = ">=3.5.0" },
     { name = "httpx", marker = "extra == 'components'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'http'", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary

- raise the GitPython security floor to `>=3.1.51` and lock `3.1.53`
- override the root workspace to `fast-uri 3.1.4`, covering both currently published high-severity advisories
- patch the ChatGPT Apps dependency tree to `@hono/node-server 2.0.11`, `hono 4.12.31`, and `fast-uri 3.1.4`
- preserve the existing scoped Express 4 / body-parser security override
- add regression tests that reject vulnerable dependency floors and lockfile drift

## Security context

This addresses the open GitHub dependency alerts for GitPython, fast-uri, Hono, and the Hono Node adapter. The v3.27.0 release PR remains intentionally blocked until this change is merged and the alerts are verified fixed.

## Verification

- Python frozen sync and GitPython `3.1.53` import passed
- repository dependency audit reported no known Python vulnerabilities
- root pnpm audit reported 0 vulnerabilities
- ChatGPT Apps clean `npm ci` and npm audit reported 0 vulnerabilities
- ChatGPT Apps dependency tree, typecheck, build, and runtime startup smoke passed
- metadata sync, release preflight, submission readiness, package build/metadata checks, focused regression tests, and the full pre-push unit suite passed