### PR TITLE
fix(metadata): enforce canonical public metadata

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
       # release-please bumps the bare version fields, but server.json / mcp.json embed
       # the version inside the OCI image identifier (ghcr.io/...:X.Y.Z), which its JSON
       # updater cannot bump (it replaces whole values, not substrings). Regenerate the
-      # version-derived metadata from the bumped pyproject and push it onto the release
+      # canonical public metadata from the bumped pyproject and push it onto the release
       # PR branch so the metadata-sync gate passes.
       - name: Detect release PR branch
         id: release-pr-branch
@@ -57,7 +57,7 @@ jobs:
         with:
           enable-cache: false
       - if: ${{ steps.release-pr-branch.outputs.branch != '' }}
-        name: Sync version-derived MCP metadata onto the release PR
+        name: Sync canonical public metadata onto the release PR
         env:
           RELEASE_PR_BRANCH: ${{ steps.release-pr-branch.outputs.branch }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -am "chore: sync version-derived MCP metadata"
+            git commit -am "chore: sync canonical public metadata"
             gh auth setup-git
             git push origin "HEAD:${RELEASE_PR_BRANCH}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
       - "pyproject.toml"
       - "package.json"
       - "server.json"
+      - "compatibility.yaml"
+      - "ROADMAP.md"
+      - "docs/faq.md"
+      - "scripts/sync_mcp_metadata.py"
       - "docs/development/release-process.md"
       - "docs/security/release-integrity.md"
   release:
@@ -39,5 +43,6 @@ jobs:
       - run: corepack enable
       - run: corepack pnpm install --frozen-lockfile
       - run: uv sync --all-extras --frozen
+      - run: corepack pnpm run metadata:check
       - run: corepack pnpm run release:check
       - run: corepack pnpm run package:check

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for `--core-only`, `--check`, cleanup, upgrade, and KiCad capability modes.
 
 ## Package metadata
 
-The canonical metadata source of truth is `server.json`, which defines the MCP server contract. It is synchronized with `pyproject.toml` and verified in CI via `pnpm run metadata:check`.
+The canonical metadata inputs are `pyproject.toml` for package version and repository identity, and `compatibility.yaml` for KiCad and MCP support policy. `server.json` is the generated registry manifest. `pnpm run metadata:sync` renders the public surfaces, and `pnpm run metadata:check` verifies them in CI and release validation.
 
 ## Usage
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,9 +20,13 @@ version-agnostic so it does not drift.
 - Public packages are verified for each release line on PyPI and npm.
 - GHCR `ghcr.io/oaslananka/kicad-mcp-pro:<version>` is published as a multi-arch
   OCI index per release.
-- KiCad 10.0.4 remains the primary stable KiCad baseline.
-- MCP protocol compatibility remains aligned with the 2025-11-25 schema used by
-  `server.json` and the generated tool contracts.
+<!-- public-metadata:runtime-policy:start -->
+- Primary KiCad line: `10.0.x`; latest verified patch: `10.0.4`.
+- Deprecated KiCad lines: `8.x`.
+- Dropped KiCad lines: `9.x`.
+- Preview KiCad lines: `11.x`.
+- MCP protocol contract: `2025-11-25`.
+<!-- public-metadata:runtime-policy:end -->
 
 ---
 
@@ -80,7 +84,7 @@ version-agnostic so it does not drift.
 
 ## Upcoming
 
-### 3.18 (Target: July 2026)
+### July 2026 Release-Readiness Closeout
 - **Release-readiness closeout:** keep PyPI, npm, GHCR, GitHub Releases,
   `server.json`, README, and docs synchronized before external submissions.
 - **Public listing readiness:** keep production screenshots, demo media, privacy,
@@ -90,7 +94,7 @@ version-agnostic so it does not drift.
 - **Scorecard evidence refresh:** verify branch ruleset, release evidence, and
   accepted solo-maintainer exceptions after workflow-name changes.
 
-### 3.19 (Target: Q3 2026)
+### Q3 2026 Productization
 - **Structured verdicts:** finish stable machine-readable PASS/WARN/FAIL payloads
   across high-traffic gates.
 - **Schematic write safety:** migrate remaining mutating schematic writers to the

--- a/docs/adr/0002-version-single-source.md
+++ b/docs/adr/0002-version-single-source.md
@@ -10,11 +10,11 @@ The package exposes version metadata through Python imports, Python packaging me
 
 ## Decision
 
-`pyproject.toml` and `src/kicad_mcp/__init__.py` are the authoritative version sources. Generated public metadata in `server.json` is synchronized by `scripts/sync_mcp_metadata.py` and checked in CI with `pnpm run metadata:check`.
+`pyproject.toml` (`project.version`) is the canonical package version source. `src/kicad_mcp/__init__.py` is a synchronized runtime surface that release automation updates in lockstep. Generated public metadata in `server.json` is synchronized by `scripts/sync_mcp_metadata.py` and checked in CI with `pnpm run metadata:check`. Repository identity and runtime support-policy sources are defined in ADR-0005.
 
 ## Consequences
 
-- Release changes must update the Python package version and Python module version together.
+- Release changes update the canonical Python package version and synchronized Python module version together.
 - `server.json` should be treated as a generated metadata surface, not a hand-edited version authority.
 - Pull requests must fail when metadata parity drifts.
 

--- a/docs/adr/0005-public-metadata-sources.md
+++ b/docs/adr/0005-public-metadata-sources.md
@@ -1,0 +1,58 @@
+# ADR-0005: Public Metadata Sources
+
+**Status:** Accepted
+**Date:** 2026-07-22
+**Deciders:** @oaslananka
+
+## Context
+
+KiCad MCP Pro publishes support statements and repository metadata through several public surfaces: Python package metadata, `server.json`, the FAQ, the roadmap, registry submissions, and release artifacts. Hand-maintained copies had diverged, including a dropped KiCad line being described as supported, already-published versions appearing under upcoming work, and a stale GitHub repository identifier.
+
+These values need explicit canonical sources and a deterministic check that runs before merge and release.
+
+## Decision
+
+The canonical public metadata sources are:
+
+| Metadata | Canonical source |
+| --- | --- |
+| Package version | `pyproject.toml` (`project.version`) |
+| Repository URL | `pyproject.toml` (`project.urls.Repository`) |
+| Stable GitHub repository node ID | `pyproject.toml` (`tool.kicad-mcp.public-metadata.repository-id`) |
+| KiCad support, deprecation, preview, and dropped-state policy | `compatibility.yaml` |
+| MCP protocol contract | `compatibility.yaml` |
+| Future roadmap commitments | Headings and content under `ROADMAP.md` → `Upcoming` |
+
+`scripts/sync_mcp_metadata.py` renders or validates the derived public surfaces:
+
+- `server.json`, including repository identity, package versions, registry URLs, and compatibility-aware prerequisites;
+- `packages/mcp-npm/package.json` and `src/kicad_mcp/__init__.py`;
+- the marked KiCad support block in `docs/faq.md`;
+- the marked runtime-policy block in `ROADMAP.md`.
+
+The roadmap remains editorial rather than fully generated. The metadata check rejects any semantic-version heading in the `Upcoming` section that is less than or equal to the current package version.
+
+## Consequences
+
+- Maintainers update canonical files rather than editing generated public metadata directly.
+- KiCad support wording in the FAQ and registry manifest cannot silently diverge from `compatibility.yaml`.
+- Repository transfers or recreation require an intentional update to the stable GitHub node ID.
+- Release automation can refresh generated metadata with `pnpm run metadata:sync`.
+- CI, pre-push hooks, and release dry-runs fail when generated metadata or roadmap state drifts.
+
+## Verification
+
+Run:
+
+```bash
+corepack pnpm run metadata:check
+uv run --all-extras pytest -q tests/unit/test_public_metadata.py
+```
+
+To verify the repository identity against GitHub before changing it:
+
+```bash
+gh api repos/oaslananka/kicad-mcp-pro --jq '{url: .html_url, node_id}'
+```
+
+The checked values must match `project.urls.Repository` and `tool.kicad-mcp.public-metadata.repository-id` in `pyproject.toml`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,9 @@ Use the client that already fits your workflow. VS Code, Cursor, Claude Desktop,
 
 ## Is KiCad 10 required?
 
-KiCad 10 is the primary target. KiCad 9 is supported on a best-effort basis for core PCB, schematic, validation, and export workflows. KiCad 10-only features are called out in the KiCad 10 docs.
+<!-- public-metadata:kicad-support:start -->
+KiCad 10.0.x is the primary supported target. KiCad 8.x remains deprecated and is limited to file-level read and migration support. KiCad 9.x has been dropped and is not supported. KiCad 11.x is preview-only. The executable support policy lives in `compatibility.yaml`.
+<!-- public-metadata:kicad-support:end -->
 
 ## Why does the server need a project directory?
 

--- a/docs/kicad10/time-domain.md
+++ b/docs/kicad10/time-domain.md
@@ -11,4 +11,4 @@ The following helpers were added for KiCad 10 style time-domain routing workflow
 
 Profile definitions are stored in `.kicad-mcp/tuning_profiles.json`. When a stackup is available, `route_tune_time_domain(...)` derives an effective dielectric constant from the selected layer context and converts delay targets into a computed length target. The resulting delay and length constraints are then written into `.kicad_dru`.
 
-If no usable stackup context exists, the helper falls back to the legacy propagation-speed-factor path so mixed KiCad 9/10 environments still get a practical constraint rule.
+If no usable stackup context exists, the helper falls back to the legacy propagation-speed-factor path. This fallback preserves file-level behavior but does not imply support for dropped KiCad lines.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,6 +1,6 @@
 # MCP Registry status
 
-KiCad MCP Pro publishes registry metadata from the repository-level `server.json` manifest.
+KiCad MCP Pro publishes the checked-in, generated registry payload from the repository-level `server.json` manifest.
 
 ## Canonical identity
 
@@ -15,8 +15,9 @@ KiCad MCP Pro publishes registry metadata from the repository-level `server.json
 
 ## Source of truth
 
-- `server.json` is the registry manifest source of truth.
-- `pyproject.toml`, package metadata, and `server.json` must stay synchronized.
+- `server.json` is the generated registry payload used for validation and submission.
+- `pyproject.toml` provides package version and repository identity; `compatibility.yaml` provides runtime support policy.
+- Generated package metadata, support documentation, and `server.json` must stay synchronized.
 - Registry publication should use the documented dry-run flow before any live publish.
 - Live publication requires maintainer review and should not run from a dirty tree.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -46,4 +46,4 @@ pnpm run metadata:sync
 pnpm run metadata:check
 ```
 
-`pyproject.toml` is the source of truth for `server.json`.
+`pyproject.toml` is canonical for package version and repository identity, while `compatibility.yaml` is canonical for runtime support policy. `server.json` and the marked public documentation blocks are generated surfaces.

--- a/docs/status/capability-levels.md
+++ b/docs/status/capability-levels.md
@@ -6,7 +6,7 @@
 | Schematic reading / inspection | Verified | Stable read surface with fixture-backed coverage. |
 | Schematic writing / editing | Experimental | File-backed editing uses the hybrid IPC reload path when KiCad 10+ reports an open schematic document; parser round-trip validation is still required for broad confidence. |
 | PCB inspection | Verified | Covered by IPC/file-backed tests and stable board-state helpers. |
-| PCB editing (IPC-backed) | Experimental | Requires KiCad 9+ live IPC and an open PCB context; live editing tool discovery is hidden when IPC is unavailable. |
+| PCB editing (IPC-backed) | Experimental | Requires KiCad 10 live IPC and an open PCB context; live editing tool discovery is hidden when IPC is unavailable. |
 | DRC / ERC validation | Verified | CLI and validation-gate backed, with fixture coverage. |
 | BOM export | Experimental | Multi-sheet BOM accuracy requires explicit fixture verification. |
 | Gerber / drill export | Verified | CLI-backed export path with integration coverage. |

--- a/docs/status/runtime-policy-matrix.md
+++ b/docs/status/runtime-policy-matrix.md
@@ -14,21 +14,26 @@ operating systems, and execution modes.
 
 ## KiCad Version and Feature Matrix
 
-| Capability             | KiCad 9.x   | KiCad 10.0.x | KiCad 11 readiness | Notes                                                     |
-| ---------------------- | ----------- | ------------ | ------------------ | --------------------------------------------------------- |
-| Project management     | Tested      | Tested       | Manual smoke       | Must stay IPC, CLI, or file backed.                       |
-| Schematic read (IPC)   | Caveat      | Tested       | Manual smoke       | IPC API is still evolving in KiCad.                       |
-| Schematic write (IPC)  | Best effort | Caveat       | Manual smoke       | Round-trip parsing validation required.                   |
-| PCB inspection (IPC)   | Caveat      | Tested       | Manual smoke       | Direct `pcbnew` fallback is forbidden.                    |
-| PCB editing (IPC)      | Best effort | Caveat       | Manual smoke       | Retryable errors are environment-dependent.               |
-| DRC/ERC (CLI)          | Tested      | Tested       | Manual smoke       | CLI-backed; most stable path.                             |
-| BOM export (CLI)       | Tested      | Tested       | Manual smoke       | Multi-sheet behavior needs explicit fixture verification. |
-| Gerber export (CLI)    | Tested      | Tested       | Manual smoke       |                                                           |
-| STEP export (CLI)      | Tested      | Tested       | Manual smoke       |                                                           |
-| FreeRouting            | Best effort | Best effort  | Best effort        | External binary; Specctra flow is install-dependent.      |
-| ngspice simulation     | Best effort | Best effort  | Best effort        | External binary; smoke-level only.                        |
-| KiCad 10 Design Blocks | Unsupported | Tested       | Manual smoke       | KiCad 10-specific behavior stays gated.                   |
-| KiCad 10 Time-Domain   | Unsupported | Tested       | Manual smoke       | KiCad 10-specific behavior stays gated.                   |
+`compatibility.yaml` is the executable source of truth for runtime support. KiCad
+10.0.x is the primary supported line. KiCad 8.x is deprecated and limited to
+file-level read and migration workflows. KiCad 9.x is dropped and excluded from
+runtime coverage. KiCad 11.x is preview-only and requires explicit canary evidence.
+
+| Capability             | KiCad 10.0.x | KiCad 11 readiness | Notes                                                     |
+| ---------------------- | ------------ | ------------------ | --------------------------------------------------------- |
+| Project management     | Tested       | Manual smoke       | Must stay IPC, CLI, or file backed.                       |
+| Schematic read (IPC)   | Tested       | Manual smoke       | IPC API is still evolving in KiCad.                       |
+| Schematic write (IPC)  | Caveat       | Manual smoke       | Round-trip parsing validation required.                   |
+| PCB inspection (IPC)   | Tested       | Manual smoke       | Direct `pcbnew` fallback is forbidden.                    |
+| PCB editing (IPC)      | Caveat       | Manual smoke       | Retryable errors are environment-dependent.               |
+| DRC/ERC (CLI)          | Tested       | Manual smoke       | CLI-backed; most stable path.                             |
+| BOM export (CLI)       | Tested       | Manual smoke       | Multi-sheet behavior needs explicit fixture verification. |
+| Gerber export (CLI)    | Tested       | Manual smoke       |                                                           |
+| STEP export (CLI)      | Tested       | Manual smoke       |                                                           |
+| FreeRouting            | Best effort  | Best effort        | External binary; Specctra flow is install-dependent.      |
+| ngspice simulation     | Best effort  | Best effort        | External binary; smoke-level only.                        |
+| KiCad 10 Design Blocks | Tested       | Manual smoke       | KiCad 10-specific behavior stays gated.                   |
+| KiCad 10 Time-Domain   | Tested       | Manual smoke       | KiCad 10-specific behavior stays gated.                   |
 
 KiCad 11 readiness is tracked in repository compatibility metadata rather than
 declared as supported runtime coverage. See `compatibility.yaml`
@@ -58,8 +63,6 @@ feature-parity evidence.
 
 1. IPC calls fail if KiCad is open and blocked by a modal dialog. Callers should back off
    and retry retryable errors.
-2. On KiCad 9.x, BOM export through IPC may reflect only the root sheet. Use `kicad-cli`
-   BOM export for more reliable multi-sheet behavior.
-3. FreeRouting requires the FreeRouting JAR or container path to be configured explicitly.
-4. The Docker image does not include KiCad. Mount a host KiCad installation and set
+2. FreeRouting requires the FreeRouting JAR or container path to be configured explicitly.
+3. The Docker image does not include KiCad. Mount a host KiCad installation and set
    `KICAD_CLI_PATH` explicitly.

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -73,7 +73,7 @@ Use this checklist before entering any external review form.
 
 - [ ] Run `pnpm run submission:check` before registry dry run.
 - [ ] Run `uv run --all-extras python scripts/publish_mcp_registry.py --dry-run` before live publish.
-- [ ] Use `server.json` as the registry source of truth.
+- [ ] Use the generated `server.json` as the registry submission payload.
 - [ ] Confirm PyPI Trusted Publisher OIDC is enabled for release workflow.
 - [ ] Confirm GHCR image is available as `ghcr.io/oaslananka/kicad-mcp-pro:<version>`.
 - [ ] Confirm release artifacts include SBOM evidence.

--- a/docs/submission/openai-mcp-registry.md
+++ b/docs/submission/openai-mcp-registry.md
@@ -4,9 +4,9 @@ This document covers the registry publish path driven by `server.json`.
 
 ## Source of Truth
 
-- Use `server.json` as the single source of truth for registry metadata.
-- Do not hand-edit registry payloads after generation.
-- Keep `server.json` synchronized with `pyproject.toml`.
+- Use the checked-in `server.json` as the generated registry payload for submission.
+- Do not hand-edit generated registry payloads.
+- Keep `server.json` synchronized with canonical `pyproject.toml` and `compatibility.yaml` inputs.
 - Version must match `src/kicad_mcp/__init__.py`.
 
 ## Verified Registry Status (2026-05-31)
@@ -15,7 +15,7 @@ Verification of the official MCP Registry (`registry.modelcontextprotocol.io`) f
 `io.github.oaslananka/kicad-mcp-pro`, per issue #272. No publish was performed and no
 version, tag, or release identity was changed.
 
-| Field            | Official registry record                              | Canonical repo (`server.json`)            |
+| Field            | Official registry record                              | Generated repo payload (`server.json`)            |
 | ---------------- | ----------------------------------------------------- | ----------------------------------------- |
 | Listing status   | `active`, `isLatest: true`                            | n/a                                       |
 | Published (UTC)  | `2026-04-15T21:15:40Z`                                | n/a                                       |
@@ -138,7 +138,7 @@ cosign verify ghcr.io/oaslananka/kicad-mcp-pro:${VERSION} \
 
 ## Final Registry Publish Controls
 
-- [ ] Confirm `server.json` remains the registry payload source of truth.
+- [ ] Confirm `server.json` remains the generated registry payload used for submission.
 - [ ] Confirm `server.json` schema validation passes before dry run.
 - [ ] Confirm `server.json` stays synchronized with `pyproject.toml`.
 - [ ] Confirm `pyproject.toml` version matches `server.json`.

--- a/docs/workflows/high-speed-review.md
+++ b/docs/workflows/high-speed-review.md
@@ -25,8 +25,9 @@ and the high-speed review loop.
 
 Use `pcb_get_stackup` to confirm dielectric and copper data, then run
 `route_tune_time_domain` for timing-critical nets. On KiCad 10 projects the tool
-derives required length from per-layer dielectric data; KiCad 9 keeps the legacy
-length-based fallback.
+derives required length from per-layer dielectric data. If no usable stackup
+context is available, it uses the legacy length-based fallback; that fallback is
+not a support guarantee for dropped KiCad lines.
 
 ```text
 route_tune_time_domain(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
           - Repository Topology: adr/0001-repository-topology.md
           - Version Single Source: adr/0002-version-single-source.md
           - Export Tool Naming: adr/0003-export-tool-naming.md
+          - Public Metadata Sources: adr/0005-public-metadata-sources.md
       - Regression Fixtures: development/contributing-fixtures.md
       - Production Principles: development/principles.md
       - 2026 Roadmap: development/roadmap-2026.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ Repository = "https://github.com/oaslananka/kicad-mcp-pro"
 Changelog = "https://github.com/oaslananka/kicad-mcp-pro/blob/main/CHANGELOG.md"
 Funding = "https://github.com/sponsors/oaslananka"
 
+[tool.kicad-mcp.public-metadata]
+# Stable GitHub GraphQL node ID for repository-resurrection protection.
+repository-id = "R_kgDOStXTag"
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/kicad_mcp"]

--- a/scripts/sync_mcp_metadata.py
+++ b/scripts/sync_mcp_metadata.py
@@ -11,27 +11,29 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+import yaml
+from packaging.version import InvalidVersion, Version
+
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
 PACKAGE_INIT = ROOT / "src" / "kicad_mcp" / "__init__.py"
 SERVER_JSON = ROOT / "server.json"
 NPM_WRAPPER_PACKAGE = ROOT / "packages" / "mcp-npm" / "package.json"
+COMPATIBILITY = ROOT / "compatibility.yaml"
+FAQ = ROOT / "docs" / "faq.md"
+ROADMAP = ROOT / "ROADMAP.md"
 # Authoritative public tool count is produced (and CI-checked) by
 # scripts/generate_tools_reference.py; we read it instead of hand-maintaining a
 # number that silently drifts away from the real tool surface.
 TOOLS_REFERENCE_GENERATED = ROOT / "docs" / "tools-reference.generated.md"
 MCP_SERVER_NAME = "io.github.oaslananka/kicad-mcp-pro"
-REPOSITORY = "https://github.com/oaslananka/kicad-mcp-pro"
-REPOSITORY_ID = "R_kgDOOIB7Lg"
 WEBSITE = "https://oaslananka.github.io/kicad-mcp-pro"
 GHCR_IMAGE = "ghcr.io/oaslananka/kicad-mcp-pro"
 REGISTRY_META_KEY = "io.github.oaslananka/kicad-mcp-pro"
-# In standalone kicad-mcp the root IS the package, so canonicalRepository
-# is the bare repository URL (no /tree/main suffix).
-CANONICAL_PACKAGE_URL = REPOSITORY
-CHANGELOG_URL = f"{REPOSITORY}/blob/main/CHANGELOG.md"
-TOOLS_REFERENCE_URL = f"{REPOSITORY}/blob/main/docs/tools-reference.generated.md"
-MCP_PROTOCOL_VERSION = "2025-11-25"
+FAQ_SUPPORT_START = "<!-- public-metadata:kicad-support:start -->"
+FAQ_SUPPORT_END = "<!-- public-metadata:kicad-support:end -->"
+ROADMAP_RUNTIME_START = "<!-- public-metadata:runtime-policy:start -->"
+ROADMAP_RUNTIME_END = "<!-- public-metadata:runtime-policy:end -->"
 SERVER_INFO_SCHEMA_VERSION = "1.1.0"
 TOOL_SCHEMA_VERSION = "1.0.0"
 SERVER_INFO_CAPABILITIES = [
@@ -116,12 +118,119 @@ def _license_text(project: dict[str, Any]) -> str:
 def _project_metadata() -> dict[str, Any]:
     data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
     project = data["project"]
+    repository_url = str(project["urls"]["Repository"]).rstrip("/")
+    public_metadata = data["tool"]["kicad-mcp"]["public-metadata"]
+    repository_id = str(public_metadata["repository-id"]).strip()
+    if not repository_url.startswith("https://github.com/"):
+        raise ValueError("project.urls.Repository must be a canonical GitHub HTTPS URL")
+    if not repository_id:
+        raise ValueError("tool.kicad-mcp.public-metadata.repository-id must be non-empty")
     return {
         "package_name": project["name"],
         "version": project["version"],
         "description": project["description"],
         "license": _license_text(project),
+        "repository_url": repository_url,
+        "repository_id": repository_id,
     }
+
+
+def _compatibility_metadata() -> dict[str, Any]:
+    data = yaml.safe_load(COMPATIBILITY.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError("compatibility.yaml must contain a mapping")
+    return data
+
+
+def _ranges_for_state(matrix: dict[str, Any], state: str) -> list[str]:
+    supported = matrix["kicad"]["supported"]
+    return [str(entry["range"]) for entry in supported if entry.get("state") == state]
+
+
+def _joined_ranges(ranges: list[str]) -> str:
+    if len(ranges) == 1:
+        return ranges[0]
+    if len(ranges) == 2:
+        return f"{ranges[0]} and {ranges[1]}"
+    return ", ".join(ranges[:-1]) + f", and {ranges[-1]}"
+
+
+def _render_faq_support_block(matrix: dict[str, Any]) -> str:
+    kicad = matrix["kicad"]
+    primary = str(kicad["primary"])
+    deprecated = _ranges_for_state(matrix, "deprecated")
+    dropped = [str(entry["range"]) for entry in kicad.get("dropped", [])]
+    preview = [str(entry["range"]) for entry in kicad.get("preview", [])]
+    sentences = [f"KiCad {primary} is the primary supported target."]
+    if deprecated:
+        sentences.append(
+            f"KiCad {_joined_ranges(deprecated)} remains deprecated and is limited to "
+            "file-level read and migration support."
+        )
+    if dropped:
+        sentences.append(f"KiCad {_joined_ranges(dropped)} has been dropped and is not supported.")
+    if preview:
+        sentences.append(f"KiCad {_joined_ranges(preview)} is preview-only.")
+    sentences.append("The executable support policy lives in `compatibility.yaml`.")
+    return " ".join(sentences)
+
+
+def _render_roadmap_runtime_block(matrix: dict[str, Any]) -> str:
+    kicad = matrix["kicad"]
+    deprecated = _ranges_for_state(matrix, "deprecated")
+    dropped = [str(entry["range"]) for entry in kicad.get("dropped", [])]
+    preview = [str(entry["range"]) for entry in kicad.get("preview", [])]
+    lines = [
+        f"- Primary KiCad line: `{kicad['primary']}`; latest verified patch: "
+        f"`{kicad['latestVerified']}`.",
+    ]
+    if deprecated:
+        lines.append(f"- Deprecated KiCad lines: `{_joined_ranges(deprecated)}`.")
+    if dropped:
+        lines.append(f"- Dropped KiCad lines: `{_joined_ranges(dropped)}`.")
+    if preview:
+        lines.append(f"- Preview KiCad lines: `{_joined_ranges(preview)}`.")
+    lines.append(f"- MCP protocol contract: `{matrix['mcp']['protocolVersion']}`.")
+    return "\n".join(lines)
+
+
+def _replace_generated_block(original: str, start: str, end: str, rendered: str) -> str:
+    if start not in original or end not in original:
+        raise ValueError(f"generated metadata markers are missing: {start} / {end}")
+    prefix, remainder = original.split(start, maxsplit=1)
+    _current, suffix = remainder.split(end, maxsplit=1)
+    return f"{prefix}{start}\n{rendered}\n{end}{suffix}"
+
+
+def _roadmap_version_errors(roadmap: str, current_version: str) -> list[str]:
+    if "## Upcoming" not in roadmap:
+        return ["ROADMAP.md is missing the Upcoming section"]
+    upcoming = roadmap.split("## Upcoming", maxsplit=1)[1].split("\n## ", maxsplit=1)[0]
+    try:
+        current = Version(current_version)
+    except InvalidVersion:
+        return [f"pyproject.toml contains invalid package version {current_version!r}"]
+    errors: list[str] = []
+    for value in re.findall(r"^###\s+(\d+\.\d+(?:\.\d+)?)\b", upcoming, re.M):
+        version = Version(value)
+        if version <= current:
+            errors.append(
+                "ROADMAP.md upcoming section lists already-published version "
+                f"{value} while the current package version is {current_version}"
+            )
+    return errors
+
+
+def _registry_prerequisite(matrix: dict[str, Any]) -> str:
+    primary = str(matrix["kicad"]["primary"])
+    deprecated = _ranges_for_state(matrix, "deprecated")
+    message = f"KiCad CLI {primary} available on PATH for file-backed DRC, ERC, and export tools."
+    if deprecated:
+        message += (
+            f" KiCad {_joined_ranges(deprecated)} is deprecated and limited to file-level read "
+            "and migration workflows."
+        )
+    return message
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -231,7 +340,11 @@ def _remotes_metadata() -> list[dict[str, Any]]:
     return []
 
 
-def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+def _registry_metadata(metadata: dict[str, Any], compatibility: dict[str, Any]) -> dict[str, Any]:
+    repository_url = metadata["repository_url"]
+    mcp_protocol_version = str(compatibility["mcp"]["protocolVersion"])
+    changelog_url = f"{repository_url}/blob/main/CHANGELOG.md"
+    tools_reference_url = f"{repository_url}/blob/main/docs/tools-reference.generated.md"
     return {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
         "name": MCP_SERVER_NAME,
@@ -252,9 +365,9 @@ def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
             },
         ],
         "repository": {
-            "url": REPOSITORY,
+            "url": repository_url,
             "source": "github",
-            "id": REPOSITORY_ID,
+            "id": metadata["repository_id"],
         },
         "version": metadata["version"],
         "packages": [
@@ -285,24 +398,21 @@ def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
                         "PCB inspection, DRC/ERC validation, BOM/netlist generation, "
                         "routing review, simulation, DFM, and manufacturing export."
                     ),
-                    "reference": TOOLS_REFERENCE_URL,
+                    "reference": tools_reference_url,
                 },
-                "prerequisites": [
-                    "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, "
-                    "ERC, and export tools."
-                ],
-                "supportedMcpProtocolVersions": [MCP_PROTOCOL_VERSION],
+                "prerequisites": [_registry_prerequisite(compatibility)],
+                "supportedMcpProtocolVersions": [mcp_protocol_version],
                 "maintainer": {
                     "name": "Osman Aslan",
                     "url": "https://github.com/oaslananka",
                 },
-                "canonicalRepository": CANONICAL_PACKAGE_URL,
+                "canonicalRepository": repository_url,
                 "license": metadata["license"],
-                "changelog": CHANGELOG_URL,
-                "releaseNotes": CHANGELOG_URL,
+                "changelog": changelog_url,
+                "releaseNotes": changelog_url,
                 "serverInfo": {
                     "schemaVersion": SERVER_INFO_SCHEMA_VERSION,
-                    "mcpProtocolVersion": MCP_PROTOCOL_VERSION,
+                    "mcpProtocolVersion": mcp_protocol_version,
                     "toolSchemaVersion": TOOL_SCHEMA_VERSION,
                     "capabilities": SERVER_INFO_CAPABILITIES,
                 },
@@ -332,24 +442,40 @@ def _updated_npm_wrapper_package(
     updated["version"] = metadata["version"]
     updated["homepage"] = WEBSITE
     updated["mcpName"] = MCP_SERVER_NAME
+    repository_url = metadata["repository_url"]
     updated["repository"] = {
         "type": "git",
-        "url": f"git+{REPOSITORY}.git",
+        "url": f"git+{repository_url}.git",
         "directory": "packages/mcp-npm",
     }
-    updated["bugs"] = {"url": f"{REPOSITORY}/issues"}
+    updated["bugs"] = {"url": f"{repository_url}/issues"}
     return updated
 
 
 def _planned_updates() -> dict[Path, str]:
     metadata = _project_metadata()
-    registry = _registry_metadata(metadata)
+    compatibility = _compatibility_metadata()
+    registry = _registry_metadata(metadata, compatibility)
+    faq = _replace_generated_block(
+        FAQ.read_text(encoding="utf-8"),
+        FAQ_SUPPORT_START,
+        FAQ_SUPPORT_END,
+        _render_faq_support_block(compatibility),
+    )
+    roadmap = _replace_generated_block(
+        ROADMAP.read_text(encoding="utf-8"),
+        ROADMAP_RUNTIME_START,
+        ROADMAP_RUNTIME_END,
+        _render_roadmap_runtime_block(compatibility),
+    )
     return {
         PACKAGE_INIT: _updated_init(metadata, PACKAGE_INIT.read_text(encoding="utf-8")),
         SERVER_JSON: _dump_json(registry),
         NPM_WRAPPER_PACKAGE: _dump_json(
             _updated_npm_wrapper_package(metadata, _load_json(NPM_WRAPPER_PACKAGE))
         ),
+        FAQ: faq,
+        ROADMAP: roadmap,
     }
 
 
@@ -363,6 +489,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    metadata = _project_metadata()
+    roadmap_errors = _roadmap_version_errors(
+        ROADMAP.read_text(encoding="utf-8"), metadata["version"]
+    )
+    if roadmap_errors:
+        for error in roadmap_errors:
+            print(error, file=sys.stderr)
+        return 1
     updates = _planned_updates()
     drift: list[Path] = []
 
@@ -378,12 +512,12 @@ def main(argv: list[str] | None = None) -> int:
             str(path.relative_to(ROOT)) if path.is_relative_to(ROOT) else str(path)
             for path in drift
         )
-        print(f"MCP metadata is out of sync: {rel}", file=sys.stderr)
+        print(f"Public metadata is out of sync: {rel}", file=sys.stderr)
         print("Run: pnpm run metadata:sync", file=sys.stderr)
         return 1
 
     if args.write:
-        print("MCP metadata already synchronized." if not drift else "Updated MCP metadata.")
+        print("Public metadata already synchronized." if not drift else "Updated public metadata.")
     return 0
 
 

--- a/server.json
+++ b/server.json
@@ -24,7 +24,7 @@
   "repository": {
     "url": "https://github.com/oaslananka/kicad-mcp-pro",
     "source": "github",
-    "id": "R_kgDOOIB7Lg"
+    "id": "R_kgDOStXTag"
   },
   "version": "3.27.0",
   "packages": [
@@ -180,7 +180,7 @@
         "reference": "https://github.com/oaslananka/kicad-mcp-pro/blob/main/docs/tools-reference.generated.md"
       },
       "prerequisites": [
-        "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, ERC, and export tools."
+        "KiCad CLI 10.0.x available on PATH for file-backed DRC, ERC, and export tools. KiCad 8.x is deprecated and limited to file-level read and migration workflows."
       ],
       "supportedMcpProtocolVersions": [
         "2025-11-25"

--- a/tests/unit/test_mcp_manifest.py
+++ b/tests/unit/test_mcp_manifest.py
@@ -76,7 +76,8 @@ def test_checked_mcp_manifest_has_public_registry_listing_metadata() -> None:
     assert "KiCad CLI" in registry_meta["longDescription"]
     assert len(registry_meta["screenshots"]) == 5
     assert registry_meta["prerequisites"] == [
-        "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, ERC, and export tools."
+        "KiCad CLI 10.0.x available on PATH for file-backed DRC, ERC, and export tools. "
+        "KiCad 8.x is deprecated and limited to file-level read and migration workflows."
     ]
     assert registry_meta["supportedMcpProtocolVersions"] == ["2025-11-25"]
     assert registry_meta["license"] == "MIT"

--- a/tests/unit/test_public_metadata.py
+++ b/tests/unit/test_public_metadata.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+from packaging.version import Version
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_metadata_sync_module() -> object:
+    script = ROOT / "scripts" / "sync_mcp_metadata.py"
+    spec = importlib.util.spec_from_file_location("sync_mcp_metadata_public", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repository_identity_is_loaded_from_pyproject() -> None:
+    module = _load_metadata_sync_module()
+
+    metadata = module._project_metadata()
+
+    assert metadata["repository_url"] == "https://github.com/oaslananka/kicad-mcp-pro"
+    assert metadata["repository_id"] == "R_kgDOStXTag"
+
+
+def test_server_manifest_uses_canonical_repository_identity() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+
+    assert server["repository"]["url"] == pyproject["project"]["urls"]["Repository"]
+    assert (
+        server["repository"]["id"]
+        == pyproject["tool"]["kicad-mcp"]["public-metadata"]["repository-id"]
+    )
+
+
+def test_public_support_docs_match_compatibility_policy() -> None:
+    matrix = yaml.safe_load((ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
+    faq = (ROOT / "docs" / "faq.md").read_text(encoding="utf-8")
+
+    dropped_ranges = {entry["range"] for entry in matrix["kicad"]["dropped"]}
+    assert "9.x" in dropped_ranges
+    assert "KiCad 9 is supported" not in faq
+    assert "KiCad 9.x has been dropped and is not supported." in faq
+    assert f"KiCad {matrix['kicad']['primary']} is the primary supported target." in faq
+
+
+def test_upcoming_roadmap_does_not_list_published_versions() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    current = Version(pyproject["project"]["version"])
+    roadmap = (ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+    upcoming = roadmap.split("## Upcoming", maxsplit=1)[1].split("\n## ", maxsplit=1)[0]
+    versions = [
+        Version(match) for match in re.findall(r"^###\s+(\d+\.\d+(?:\.\d+)?)\b", upcoming, re.M)
+    ]
+
+    assert versions
+    assert all(version > current for version in versions)
+
+
+def test_roadmap_validator_rejects_published_version_in_upcoming_section() -> None:
+    module = _load_metadata_sync_module()
+    roadmap = """# Roadmap
+
+## Upcoming
+
+### 3.18 (Target: July 2026)
+- stale
+
+### 4.0 (Target: TBD)
+- future
+
+## Ownership
+"""
+
+    errors = module._roadmap_version_errors(roadmap, "3.27.0")
+
+    assert errors == [
+        "ROADMAP.md upcoming section lists already-published version 3.18 "
+        "while the current package version is 3.27.0"
+    ]
+
+
+def test_faq_support_block_is_rendered_from_compatibility_policy() -> None:
+    module = _load_metadata_sync_module()
+    matrix = {
+        "kicad": {
+            "primary": "10.0.x",
+            "supported": [
+                {"range": "10.0.x", "state": "primary"},
+                {"range": "8.x", "state": "deprecated"},
+            ],
+            "dropped": [{"range": "9.x"}],
+            "preview": [{"range": "11.x"}],
+        }
+    }
+
+    rendered = module._render_faq_support_block(matrix)
+
+    assert "KiCad 10.0.x is the primary supported target." in rendered
+    assert "KiCad 8.x remains deprecated" in rendered
+    assert "KiCad 9.x has been dropped and is not supported." in rendered
+    assert "KiCad 11.x is preview-only." in rendered
+
+
+def test_registry_prerequisite_excludes_dropped_kicad_lines() -> None:
+    module = _load_metadata_sync_module()
+    matrix = {
+        "kicad": {
+            "primary": "10.0.x",
+            "supported": [
+                {"range": "10.0.x", "state": "primary"},
+                {"range": "8.x", "state": "deprecated"},
+            ],
+            "dropped": [{"range": "9.x"}],
+        }
+    }
+
+    prerequisite = module._registry_prerequisite(matrix)
+
+    assert "10.0.x" in prerequisite
+    assert "8.x" in prerequisite
+    assert "deprecated" in prerequisite
+    assert "9.x" not in prerequisite
+
+
+def test_registry_metadata_uses_compatibility_protocol_contract() -> None:
+    module = _load_metadata_sync_module()
+    metadata = module._project_metadata()
+    matrix = module._compatibility_metadata()
+    matrix["mcp"]["protocolVersion"] = "2099-01-01"
+
+    registry = module._registry_metadata(metadata, matrix)
+    registry_meta = registry["_meta"]["io.github.oaslananka/kicad-mcp-pro"]
+
+    assert registry_meta["supportedMcpProtocolVersions"] == ["2099-01-01"]
+    assert registry_meta["serverInfo"]["mcpProtocolVersion"] == "2099-01-01"
+
+
+def test_release_validation_runs_public_metadata_gate() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert '      - "compatibility.yaml"' in workflow
+    assert '      - "ROADMAP.md"' in workflow
+    assert '      - "docs/faq.md"' in workflow
+    assert '      - "scripts/sync_mcp_metadata.py"' in workflow
+    assert "- run: corepack pnpm run metadata:check" in workflow
+
+
+def test_current_policy_docs_do_not_advertise_dropped_kicad_lines() -> None:
+    runtime_matrix = (ROOT / "docs" / "status" / "runtime-policy-matrix.md").read_text(
+        encoding="utf-8"
+    )
+    capability_levels = (ROOT / "docs" / "status" / "capability-levels.md").read_text(
+        encoding="utf-8"
+    )
+    high_speed = (ROOT / "docs" / "workflows" / "high-speed-review.md").read_text(encoding="utf-8")
+    time_domain = (ROOT / "docs" / "kicad10" / "time-domain.md").read_text(encoding="utf-8")
+
+    normalized_runtime_matrix = " ".join(runtime_matrix.split())
+    assert "KiCad 9.x is dropped and excluded from runtime coverage." in normalized_runtime_matrix
+    assert "| KiCad 9.x" not in runtime_matrix
+    assert "On KiCad 9.x" not in runtime_matrix
+    assert "Requires KiCad 9+" not in capability_levels
+    assert "KiCad 9 keeps" not in high_speed
+    assert "mixed KiCad 9/10" not in time_domain
+
+
+def test_public_docs_distinguish_canonical_inputs_from_registry_payload() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    registry = (ROOT / "docs" / "registry.md").read_text(encoding="utf-8")
+    submission = (ROOT / "docs" / "submission" / "openai-mcp-registry.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "canonical metadata source of truth is `server.json`" not in readme
+    assert "generated registry manifest" in readme
+    assert "generated registry payload" in registry
+    assert "generated registry payload" in submission

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -55,6 +55,9 @@ description = "Test metadata"
 [project.urls]
 Repository = "https://github.com/oaslananka/kicad-mcp-pro"
 Documentation = "https://docs.example.test"
+
+[tool.kicad-mcp.public-metadata]
+repository-id = "R_test"
 """.lstrip(),
         encoding="utf-8",
     )
@@ -110,6 +113,10 @@ def test_release_metadata_is_synchronised() -> None:
     assert mcp_json["version"] == version
     assert server_json["name"] == "io.github.oaslananka/kicad-mcp-pro"
     assert server_json["repository"]["url"] == "https://github.com/oaslananka/kicad-mcp-pro"
+    assert (
+        server_json["repository"]["id"]
+        == pyproject["tool"]["kicad-mcp"]["public-metadata"]["repository-id"]
+    )
     assert mcp_json["repository"]["url"] == "https://github.com/oaslananka/kicad-mcp-pro"
     assert npm_wrapper["version"] == version
     assert npm_wrapper["homepage"] == "https://oaslananka.github.io/kicad-mcp-pro"


### PR DESCRIPTION
## Summary

- define canonical public metadata inputs in `pyproject.toml` and `compatibility.yaml`;
- generate and validate registry identity, KiCad support wording, MCP protocol metadata, and roadmap runtime policy through `scripts/sync_mcp_metadata.py`;
- replace the stale GitHub repository node ID and remove dropped KiCad 9.x from current support surfaces;
- reject already-published semantic versions under the roadmap `Upcoming` section;
- add release-validation path filters and a required metadata drift gate;
- document the source mapping in ADR-0005 and align registry/submission documentation.

Closes #433

/claim #433

## Type of change

- [x] Fix
- [ ] Feature
- [x] Documentation
- [x] Tests / fixtures
- [x] Refactor / maintenance
- [x] Release / packaging / supply chain

## Validation

- [x] `corepack pnpm run format:check`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm run typecheck`
- [x] `corepack pnpm run test:unit`
- [x] `corepack pnpm run metadata:check`
- [x] `corepack pnpm run check:meta`
- [x] `corepack pnpm run check:release`
- [x] `corepack pnpm run check:workflows`
- [x] `corepack pnpm run check:build`
- [x] `uv run --all-extras mkdocs build --strict`

Local unit result: 1,500+ unit tests passed with the existing `test_start_daemon_windows_fallback` un-awaited `AsyncMock` warning unchanged from `main`.

## Safety and compatibility

- [x] Public tool contracts, generated docs, metadata, and compatibility matrices are updated when needed.
- [x] Destructive or KiCad-driving behavior is explicit, test-covered, and documented.
- [x] Logs, fixtures, screenshots, and generated artifacts do not contain secrets or private board data.
- [x] Approximate / heuristic behavior is described honestly in docs and verdicts.

This change does not modify tool behavior or the actual compatibility policy. It makes public surfaces reflect the existing policy in `compatibility.yaml`.

## Evidence

Canonical source mapping:

| Public value | Canonical source |
| --- | --- |
| Package version | `pyproject.toml` → `project.version` |
| Repository URL | `pyproject.toml` → `project.urls.Repository` |
| GitHub repository node ID | `pyproject.toml` → `tool.kicad-mcp.public-metadata.repository-id` |
| KiCad support states | `compatibility.yaml` |
| MCP protocol contract | `compatibility.yaml` |
| Future roadmap commitments | `ROADMAP.md` → `Upcoming` |

The new regression suite verifies intentional drift cases for repository identity, support-policy rendering, dropped-version registry prerequisites, MCP protocol derivation, stale roadmap versions, current-policy documentation, and release workflow coverage.

## Release notes

Fixed public metadata drift: registry identity now uses the current repository node ID, KiCad 9.x is consistently described as dropped, and release validation rejects stale generated metadata and already-published roadmap targets.
