### PR TITLE
feat(mcp): add the 2026 stateless compatibility lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,10 @@ jobs:
           tests/unit/test_protocol_compat.py
           tests/unit/test_mcp_protocol_2026_contract.py -q
 
+      - name: Run supported-host MCP 2026 smoke cases
+        if: env.skip_ci != 'true'
+        run: uv run pytest tests/integration/test_mcp_2026_host_smoke.py -q
+
   mcp-npm:
     needs: [changes]
     if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,37 @@ jobs:
           echo "Full Python suite failed; Codecov uploads were attempted before failing the job."
           exit 1
 
+  mcp-2026-compat:
+    name: MCP 2026 Compatibility
+    needs: [changes]
+    if: >-
+      always() &&
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Skip candidate protocol lane for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: |
+          echo "::notice::Skipping MCP 2026 compatibility — docs-only PR detected"
+          echo "skip_ci=true" >> "$GITHUB_ENV"
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        if: env.skip_ci != 'true'
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        if: env.skip_ci != 'true'
+        with:
+          enable-cache: true
+          version-file: uv.toml
+      - run: uv sync --all-extras --frozen
+        if: env.skip_ci != 'true'
+      - name: Run stable-independent MCP 2026 compatibility contracts
+        if: env.skip_ci != 'true'
+        run: >-
+          uv run pytest tests/unit/test_mcp_2026_config.py
+          tests/unit/test_protocol_compat.py
+          tests/unit/test_mcp_protocol_2026_contract.py -q
+
   mcp-npm:
     needs: [changes]
     if: >-
@@ -358,7 +389,7 @@ jobs:
 
   required-pr-gate:
     name: Required PR Gate
-    needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, workflow-policy, security]
+    needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, mcp-2026-compat, workflow-policy, security]
     if: always()
     runs-on: ubuntu-24.04
     steps:
@@ -372,6 +403,7 @@ jobs:
             [coverage]="${{ needs.coverage.result }}"
             [mcp-npm]="${{ needs.mcp-npm.result }}"
             [protocol-schemas]="${{ needs.protocol-schemas.result }}"
+            [mcp-2026-compat]="${{ needs.mcp-2026-compat.result }}"
             [workflow-policy]="${{ needs.workflow-policy.result }}"
             [security]="${{ needs.security.result }}"
           )
@@ -387,7 +419,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=0
-          for job in changes mcp-server coverage mcp-npm protocol-schemas workflow-policy security; do
+          for job in changes mcp-server coverage mcp-npm protocol-schemas mcp-2026-compat workflow-policy security; do
             result="${results[$job]}"
             echo "| $job | $result |" >> "$GITHUB_STEP_SUMMARY"
             case "$result" in

--- a/docs/adr/0006-mcp-2026-stateless-compatibility-lane.md
+++ b/docs/adr/0006-mcp-2026-stateless-compatibility-lane.md
@@ -1,0 +1,76 @@
+# ADR-0006: MCP 2026 Stateless Compatibility Lane
+
+**Status:** Accepted
+**Date:** 2026-07-22
+**Deciders:** @oaslananka
+
+## Context
+
+The public server and registry metadata currently target MCP `2025-11-25` through the stable MCP Python SDK. The MCP `2026-07-28` release candidate removes protocol sessions and the initialize lifecycle, introduces mandatory per-request metadata and transport headers, requires `server/discover`, adds cache metadata, and moves Tasks back behind an extension boundary.
+
+Adopting the draft globally before the specification, SDK, and supported hosts are stable would make the public contract misleading and could break existing clients. Ignoring the candidate until final release would leave transport, authorization, and response-shape risks untested.
+
+## Decision
+
+Maintain `2025-11-25` as the production default and public registry contract. Add an explicitly opt-in `2026-07-28-rc` compatibility lane at the Streamable HTTP boundary.
+
+The candidate lane:
+
+- is selected only with `KICAD_MCP_PROTOCOL_LANE=2026-07-28-rc`,
+- requires stateless Streamable HTTP,
+- rejects `Mcp-Session-Id`, `initialize`, and `notifications/initialized`,
+- validates `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and required request `_meta`,
+- serves `server/discover` directly,
+- adapts supported requests to the installed stable SDK internally,
+- adds candidate `resultType`, server metadata, and cache metadata to successful responses,
+- advertises no Tasks or Apps extension until those contracts are implemented,
+- does not change `server.json` or the stable dependency range.
+
+The draft fixtures are pinned to modelcontextprotocol/modelcontextprotocol commit `73720340e7c42ddaf4b303b86e81663e9a2796d0`.
+
+## Component state inventory
+
+| Component | Existing state assumption | Candidate-lane decision |
+| --- | --- | --- |
+| Streamable HTTP | Optional process-local session tracking after initialize | Candidate requests are independent, include protocol/client metadata on every call, and never create a session |
+| Tasks | Legacy experimental SDK Tasks handlers | Disabled and not advertised; the redesigned Tasks extension requires separate implementation |
+| Apps | Host-specific Apps/UI integrations can depend on negotiated host behavior | Not advertised as a candidate extension until supported-host contract tests pass |
+| Authorization | Bearer authentication is enforced by the existing FastMCP auth layer | Authentication remains before protocol diagnostics; candidate metadata never bypasses authorization |
+| Caching | Clients receive no explicit MCP cache policy | Candidate list/read results receive bounded `ttlMs` and private `cacheScope` where visibility or content is authorization-dependent |
+| Telemetry and benchmarks | Request telemetry can associate lifecycle/session fields | Candidate telemetry records protocol method without persisting client metadata or session state; benchmark fixtures remain sanitized |
+| Registry metadata | `server.json` advertises stable protocol support | Registry metadata remains `2025-11-25` until the release gates below pass |
+
+## Release decision gates
+
+`server.json` may advertise `2026-07-28` only after all of these are true:
+
+1. The final MCP 2026-07-28 specification is published and the pinned fixtures are reconciled.
+2. A stable MCP Python SDK supports the required transport and schema surface without the compatibility bridge.
+3. supported host smoke tests pass for direct discovery, listing, calling, authorization, and error behavior.
+4. Tasks and Apps extension parity is implemented or explicitly excluded from advertised capabilities.
+5. A tested rollback to the `2025-11-25` runtime and metadata contract is documented and verified.
+
+Changing public metadata is a separate reviewed release decision, not an automatic consequence of this ADR.
+
+## Rollout
+
+1. Enable the lane only in an isolated canary deployment.
+2. Run the independent MCP 2026 contract job and representative host smoke tests.
+3. Compare authorization failures, tool visibility, latency, and response size with the stable lane.
+4. Expand canary traffic only after no destructive-call or data-isolation regression is observed.
+5. Keep stable clients and production registry traffic on `2025-11-25` throughout the evaluation.
+
+## Rollback
+
+Unset `KICAD_MCP_PROTOCOL_LANE`, restart the server, and verify `server/discover` is no longer accepted while the normal `initialize` flow negotiates `2025-11-25`. No data migration is required because the candidate bridge persists no protocol session or client metadata.
+
+## Consequences
+
+The repository gains early, deterministic evidence for the candidate protocol without introducing a prerelease production dependency. The temporary bridge adds maintenance cost and must be removed when a stable SDK natively implements the final contract. Candidate support is intentionally narrower than the full draft and must not be described as general availability.
+
+## Verification
+
+- `uv run pytest tests/unit/test_mcp_2026_config.py tests/unit/test_protocol_compat.py tests/unit/test_mcp_protocol_2026_contract.py -q`
+- `uv run pytest tests/unit/test_mcp_protocol_contract.py tests/unit/test_mcp_manifest.py -q`
+- The CI job named `MCP 2026 Compatibility` passes independently.
+- `server.json` continues to advertise only `2025-11-25`.

--- a/docs/adr/0006-mcp-2026-stateless-compatibility-lane.md
+++ b/docs/adr/0006-mcp-2026-stateless-compatibility-lane.md
@@ -72,5 +72,6 @@ The repository gains early, deterministic evidence for the candidate protocol wi
 
 - `uv run pytest tests/unit/test_mcp_2026_config.py tests/unit/test_protocol_compat.py tests/unit/test_mcp_protocol_2026_contract.py -q`
 - `uv run pytest tests/unit/test_mcp_protocol_contract.py tests/unit/test_mcp_manifest.py -q`
+- `uv run pytest tests/integration/test_mcp_2026_host_smoke.py -q` runs loopback HTTP request-profile smoke cases for ChatGPT Connector and VS Code MCP clients. These cases verify wire behavior but do not claim certification of external host binaries.
 - The CI job named `MCP 2026 Compatibility` passes independently.
 - `server.json` continues to advertise only `2025-11-25`.

--- a/docs/mcp/api-reference.md
+++ b/docs/mcp/api-reference.md
@@ -62,3 +62,15 @@ and `compatibility.yaml`. Refresh with `corepack pnpm run docs:generate`.
 | optional | `export_odb` |
 | optional | `pcb_export_3d_pdf` |
 | optional | `dfm_run_manufacturer_check` |
+
+## Protocol rollout status
+
+### Current public contract
+
+The supported and advertised public MCP contract is `2025-11-25`. `server.json`, generated server information, stable client examples, and the production MCP Python SDK remain aligned to that version.
+
+### Candidate compatibility lane
+
+An opt-in Streamable HTTP compatibility lane validates a constrained subset of `2026-07-28` for canary testing. It covers per-request protocol/client metadata, `Mcp-Method`, `Mcp-Name`, mandatory `server/discover`, stateless tool/prompt/resource requests, structured negotiation errors, `resultType`, and cache metadata.
+
+The lane does not advertise the redesigned Tasks extension, Apps extensions, subscriptions, or other draft-only capabilities that are not implemented by the stable runtime. server.json remains on `2025-11-25` until every release gate in [ADR-0006](../adr/0006-mcp-2026-stateless-compatibility-lane.md) passes.

--- a/docs/mcp/transport.md
+++ b/docs/mcp/transport.md
@@ -57,3 +57,35 @@ uv run --project packages/mcp-server --all-extras kicad-mcp-pro --transport stdi
 
 Protocol and capability expectations are generated in [MCP API reference](api-reference.md). Runtime
 support boundaries are tracked in the [runtime matrix](../status/runtime-policy-matrix.md).
+
+## MCP 2026 release-candidate compatibility lane
+
+> **Experimental:** This is a release-candidate compatibility lane for controlled canary testing. It is not a general-availability protocol advertisement, and public registry metadata remains on MCP `2025-11-25`.
+
+Start an isolated stateless Streamable HTTP canary with:
+
+```bash
+export KICAD_MCP_TRANSPORT=streamable-http
+export KICAD_MCP_PROTOCOL_LANE=2026-07-28-rc
+export KICAD_MCP_STATEFUL_HTTP=0
+uv run --all-extras kicad-mcp-pro
+```
+
+The candidate lane requires `MCP-Protocol-Version: 2026-07-28` and `Mcp-Method` on every JSON-RPC POST. `tools/call`, `prompts/get`, and `resources/read` also require `Mcp-Name` matching `params.name` or `params.uri`. Every request must include these values in `params._meta`:
+
+- `io.modelcontextprotocol/protocolVersion`
+- `io.modelcontextprotocol/clientCapabilities`
+- `io.modelcontextprotocol/clientInfo` is recommended for diagnostics but is not persisted
+
+Call `server/discover` directly; do not send `initialize` or `notifications/initialized`. The lane is stateless and rejects `Mcp-Session-Id`. Tasks and Apps extensions are intentionally not advertised.
+
+Authentication is unchanged. When bearer authentication is configured, an unauthenticated request receives the existing authorization response before any protocol-specific diagnostic. Tool and resource visibility therefore remains scoped to the authenticated deployment, selected profile, operating mode, and live KiCad capabilities.
+
+To roll back:
+
+```bash
+unset KICAD_MCP_PROTOCOL_LANE
+# Restart the server, then use the normal MCP 2025-11-25 initialize flow.
+```
+
+The compatibility lane and migration decision are recorded in [ADR-0006](../adr/0006-mcp-2026-stateless-compatibility-lane.md).

--- a/docs/superpowers/plans/2026-07-22-mcp-2026-compatibility-lane.md
+++ b/docs/superpowers/plans/2026-07-22-mcp-2026-compatibility-lane.md
@@ -1,0 +1,117 @@
+# MCP 2026-07-28 Compatibility Lane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, fail-closed MCP `2026-07-28` stateless Streamable HTTP compatibility lane while preserving the stable `2025-11-25` runtime and registry contract.
+
+**Architecture:** A pure protocol compatibility module validates and adapts candidate envelopes at the ASGI boundary. Configuration keeps the lane non-default, fixtures pin the draft contract, and an independent CI job proves candidate behavior without upgrading the production MCP SDK.
+
+**Tech Stack:** Python 3.13, Pydantic Settings, Starlette ASGI, FastMCP/MCP Python SDK 1.x, pytest, JSON fixtures, GitHub Actions.
+
+## Global Constraints
+
+- Default protocol lane remains `stable` and `MCP_PROTOCOL_VERSION` remains `2025-11-25`.
+- Candidate protocol version is exactly `2026-07-28` and config selector is exactly `2026-07-28-rc`.
+- Candidate mode supports only stateless Streamable HTTP.
+- Candidate mode must reject legacy SSE, stateful sessions, and the legacy Tasks implementation.
+- `server.json` must continue advertising only `2025-11-25`.
+- Do not upgrade the production `mcp[cli]>=1.27.1,<2.0.0` dependency range.
+- Preserve authentication failures before protocol-specific validation.
+
+---
+
+### Task 1: Pin the candidate contract and fail-closed configuration
+
+**Files:**
+- Create: `tests/contracts/mcp/2026-07-28/provenance.json`
+- Create: `tests/contracts/mcp/2026-07-28/server-discover.request.json`
+- Create: `tests/contracts/mcp/2026-07-28/server-discover.response.json`
+- Create: `tests/contracts/mcp/2026-07-28/tools-list.request.json`
+- Create: `tests/contracts/mcp/2026-07-28/tools-list.response.json`
+- Modify: `src/kicad_mcp/config.py`
+- Create: `tests/unit/test_mcp_2026_config.py`
+
+**Interfaces:**
+- Produces: `KiCadMCPConfig.protocol_lane: Literal["stable", "2026-07-28-rc"]`.
+
+- [ ] Write fixture and config tests requiring exact draft provenance, stable default, environment/config selection, and rejection of candidate mode with stdio, SSE, stateful HTTP, legacy SSE, or legacy Tasks.
+- [ ] Run `uv run pytest tests/unit/test_mcp_2026_config.py -q` and confirm the configuration tests fail because `protocol_lane` does not exist.
+- [ ] Add the minimal config field, normalization, and after-validator checks.
+- [ ] Re-run focused tests and confirm success.
+- [ ] Commit with `feat(mcp): gate the 2026 compatibility lane`.
+
+### Task 2: Implement pure candidate protocol contracts
+
+**Files:**
+- Create: `src/kicad_mcp/protocol_compat.py`
+- Create: `tests/unit/test_protocol_compat.py`
+
+**Interfaces:**
+- Produces: `ProtocolValidationError`, `validate_candidate_request(headers, payload)`, `candidate_discover_result(...)`, `stable_sdk_request(payload)`, and `decorate_candidate_response(method, payload, ...)`.
+
+- [ ] Write failing unit tests for protocol/header/meta agreement, required `Mcp-Method`/`Mcp-Name`, session rejection, discovery output, stable-envelope translation, server identity, `resultType`, `ttlMs`, `cacheScope`, and error codes `-32020`, `-32021`, `-32022`.
+- [ ] Run the focused tests and confirm failure because the module is absent.
+- [ ] Implement pure functions with no FastMCP or ASGI dependency.
+- [ ] Re-run focused tests and confirm success.
+- [ ] Commit with `feat(mcp): define 2026 stateless protocol contracts`.
+
+### Task 3: Bridge candidate Streamable HTTP requests
+
+**Files:**
+- Modify: `src/kicad_mcp/server.py`
+- Create: `tests/unit/test_mcp_protocol_2026_contract.py`
+- Modify: `tests/unit/test_mcp_protocol_contract.py` only for explicit stable non-regression assertions.
+
+**Interfaces:**
+- Consumes: pure contract functions from Task 2.
+- Produces: live candidate `server/discover`, `tools/list`, and `tools/call` behavior over Streamable HTTP.
+
+- [ ] Write failing ASGI tests for direct discovery/list/call without initialize, candidate metadata, missing/mismatched headers, rejected sessions/initialize, auth preservation, and stable-lane non-regression.
+- [ ] Confirm the tests fail against the current middleware.
+- [ ] Add a candidate-only middleware branch that buffers and rewrites request/response bodies while preserving the stable path.
+- [ ] Re-run stable and candidate protocol suites.
+- [ ] Commit with `feat(mcp): bridge 2026 requests at the HTTP boundary`.
+
+### Task 4: Add independent CI and registry guards
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `tests/unit/test_mcp_manifest.py`
+- Modify: `tests/unit/test_release_hardening.py`
+
+**Interfaces:**
+- Produces: required CI job `mcp-2026-compat` independent from the stable matrix.
+
+- [ ] Add failing policy tests requiring the candidate job and proving `server.json` advertises only `2025-11-25`.
+- [ ] Implement the SHA-policy-compliant CI job and include it in `required-pr-gate` dependencies/status checks.
+- [ ] Run workflow policy, actionlint, Zizmor, manifest tests, and the candidate lane.
+- [ ] Commit with `ci(mcp): verify the 2026 compatibility lane`.
+
+### Task 5: Document migration, rollout, and rollback
+
+**Files:**
+- Create: `docs/adr/0006-mcp-2026-stateless-compatibility-lane.md`
+- Modify: `docs/mcp/transport.md`
+- Modify: `docs/mcp/api-reference.md`
+- Modify: `mkdocs.yml` if explicit navigation requires it.
+- Modify: `tests/unit/test_release_hardening.py`.
+
+**Interfaces:**
+- Documents configuration, component state inventory, unsupported candidate features, host rollout, release gates, and rollback to stable.
+
+- [ ] Add a failing documentation contract test requiring the selector, warnings, component inventory, release-decision gates, and rollback command.
+- [ ] Write the ADR and operator-facing docs without describing the candidate lane as generally available.
+- [ ] Run strict docs build and link checks.
+- [ ] Commit with `docs(mcp): document the 2026 migration lane`.
+
+### Task 6: Verification, PR, and bot review
+
+**Files:** All files changed in Tasks 1–5.
+
+- [ ] Run candidate config, pure contract, live candidate, and stable MCP suites.
+- [ ] Run metadata, formatting, lint, type, security, workflow policy, protocol schemas, unit tests, and strict docs build.
+- [ ] Confirm the production dependency remains `<2.0.0` and public metadata remains `2025-11-25`.
+- [ ] Push the branch and open a professional English PR closing #410.
+- [ ] Inspect every bot/agent comment, review, inline thread, Codecov report, CodeQL result, dependency review, Semgrep result, Socket report, and required check.
+- [ ] Address all actionable findings and rerun affected checks.
+- [ ] Squash merge only when the final HEAD is green and review-thread gate reports zero blockers.

--- a/docs/superpowers/specs/2026-07-22-mcp-2026-compatibility-lane-design.md
+++ b/docs/superpowers/specs/2026-07-22-mcp-2026-compatibility-lane-design.md
@@ -1,0 +1,83 @@
+# MCP 2026-07-28 Compatibility Lane Design
+
+## Goal
+
+Add an explicitly opt-in compatibility lane that exercises the MCP `2026-07-28` stateless request/response contract without changing the production default, dependency floor, or public registry advertisement from `2025-11-25`.
+
+## Source baseline
+
+The lane is based on the MCP draft repository at commit `73720340e7c42ddaf4b303b86e81663e9a2796d0` (2026-07-21). The committed fixtures record the source commit and intentionally cover only the subset implemented by KiCad MCP Pro: discovery, tools, prompts, resources, Streamable HTTP headers, protocol negotiation, caching metadata, and authorization boundaries.
+
+## Scope and constraints
+
+- `2025-11-25` remains the default and continues to use the installed stable MCP Python SDK.
+- `2026-07-28` is selected only with `KICAD_MCP_PROTOCOL_LANE=2026-07-28-rc` or the equivalent config value.
+- The candidate lane is Streamable HTTP only, always stateless, and rejects `MCP-Session-Id`.
+- The candidate lane does not advertise Tasks or Apps extensions until their release-candidate SDK contracts are implemented and host-smoke-tested.
+- `server.json` continues to advertise only `2025-11-25` until a separately reviewed release decision is satisfied.
+- No production dependency is upgraded to MCP Python SDK v2 in this change.
+
+## Architecture
+
+### Protocol contract module
+
+`src/kicad_mcp/protocol_compat.py` owns protocol-lane constants and pure functions. It validates candidate request headers and request `_meta`, builds `server/discover`, rewrites candidate requests into the stable SDK envelope where required, and decorates successful JSON-RPC results with candidate response metadata.
+
+This module contains no ASGI, FastMCP, authentication, or KiCad domain logic. It is independently unit-testable and acts as the compatibility boundary while the upstream Python SDK v2 remains prerelease.
+
+### Configuration gate
+
+`KiCadMCPConfig.protocol_lane` accepts `stable` or `2026-07-28-rc`. The existing `stable` default is behaviorally unchanged. Validation rejects candidate mode with non-Streamable-HTTP transports, `stateful_http=true`, legacy SSE, or the legacy experimental Tasks implementation.
+
+### Streamable HTTP bridge
+
+`_StreamableHttpContractMiddleware` branches only when the candidate lane is selected:
+
+1. Preserve the existing bearer-token authorization boundary before protocol parsing.
+2. Require `MCP-Protocol-Version: 2026-07-28`, `Mcp-Method`, and `Mcp-Name` for named operations.
+3. Require per-request `_meta` protocol version and client capabilities; reject header/body or method/header mismatches with candidate error codes.
+4. Handle `server/discover` directly.
+5. Reject legacy initialization, session headers, and unsupported candidate methods.
+6. Translate supported candidate requests to the installed stable SDK contract.
+7. Decorate JSON responses with `resultType`, server identity metadata, and cache metadata where the candidate schema requires them.
+
+The bridge never weakens authentication or exposes a session cache. Stable requests continue through the existing code path unchanged.
+
+### Contract fixtures and CI lane
+
+Focused fixtures under `tests/contracts/mcp/2026-07-28/` capture representative request and response envelopes plus provenance. `tests/unit/test_mcp_protocol_2026_contract.py` validates both fixture shape and live ASGI behavior. A separate CI job runs the candidate tests independently from the stable MCP contract suite and contributes to the required PR gate.
+
+### Documentation and release decision
+
+An ADR records component-level state assumptions and the migration boundary for transport, Tasks, Apps, authorization, caching, telemetry, benchmarks, and registry metadata. The release decision requires all of the following before `server.json` changes:
+
+- the MCP `2026-07-28` specification is final,
+- a stable MCP Python SDK supports the required surface,
+- representative supported hosts pass smoke tests,
+- Tasks/Apps extension advertisement matches implemented behavior,
+- rollback to `2025-11-25` is documented and tested.
+
+## Error handling
+
+Candidate validation returns JSON-RPC errors with the request ID when available. Header mismatch uses `-32020`, missing required client capability uses `-32021`, and unsupported protocol version uses `-32022`. Malformed JSON remains a JSON-RPC parse error. Authentication failures retain the existing 401/403 response shape and are never converted into protocol diagnostics.
+
+## Security and privacy
+
+`tools/list`, prompts, and discovery are marked private when their visibility depends on authentication, profile, operating mode, or live KiCad state. Resource reads are always private. No authorization token, client metadata, or project content is persisted by the bridge. Public cache scope is used only for invariant unauthenticated discovery data.
+
+## Testing
+
+- Stable contract tests prove no behavior drift for `2025-11-25`.
+- Candidate config tests prove fail-closed combinations.
+- Pure contract tests cover metadata, headers, method/name matching, discovery, response decoration, and error codes.
+- ASGI tests cover authenticated and unauthenticated candidate requests, direct tool discovery without initialization, rejected sessions, and cache metadata.
+- Metadata tests prove `server.json` still advertises only `2025-11-25`.
+- CI runs stable and candidate suites independently.
+
+## Out of scope
+
+- Replacing the stable Python SDK with MCP v2 prereleases.
+- Implementing `subscriptions/listen`, MRTR, or the redesigned Tasks extension.
+- Advertising MCP Apps or Tasks extensions in candidate discovery.
+- Changing tool schemas solely to adopt new JSON Schema 2020-12 keywords.
+- Changing the public registry protocol version before the release-decision gates pass.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,7 @@ nav:
           - Version Single Source: adr/0002-version-single-source.md
           - Export Tool Naming: adr/0003-export-tool-naming.md
           - Public Metadata Sources: adr/0005-public-metadata-sources.md
+          - MCP 2026 Stateless Compatibility Lane: adr/0006-mcp-2026-stateless-compatibility-lane.md
       - Regression Fixtures: development/contributing-fixtures.md
       - Production Principles: development/principles.md
       - 2026 Roadmap: development/roadmap-2026.md

--- a/src/kicad_mcp/config.py
+++ b/src/kicad_mcp/config.py
@@ -76,6 +76,10 @@ class KiCadMCPConfig(BaseSettings):
     footprint_library_dir: Path | None = Field(default=None)
 
     transport: Literal["stdio", "http", "sse", "streamable-http"] = Field(default="stdio")
+    protocol_lane: Literal["stable", "2026-07-28-rc"] = Field(
+        default="stable",
+        description="MCP protocol compatibility lane. Release-candidate lanes are opt-in.",
+    )
     host: str = Field(default="127.0.0.1")
     port: int = Field(default=3334)
     mount_path: str = Field(default="/mcp")
@@ -329,7 +333,23 @@ class KiCadMCPConfig(BaseSettings):
         )
         self._refresh_paths()
         self._validate_http_transport_security()
+        self._validate_protocol_lane()
         return self
+
+    def _validate_protocol_lane(self) -> None:
+        """Reject incompatible runtime modes for non-default protocol lanes."""
+        if self.protocol_lane == "stable":
+            return
+        if self.transport != "streamable-http":
+            raise ValueError("MCP protocol lane 2026-07-28-rc requires transport='streamable-http'")
+        if self.stateful_http:
+            raise ValueError("MCP protocol lane 2026-07-28-rc requires stateful_http=false")
+        if self.legacy_sse:
+            raise ValueError("MCP protocol lane 2026-07-28-rc does not support legacy_sse")
+        if self.enable_tasks:
+            raise ValueError(
+                "MCP protocol lane 2026-07-28-rc does not support the legacy Tasks implementation"
+            )
 
     def _validate_http_transport_security(self) -> None:
         """Fail closed before exposing HTTP transports on non-loopback interfaces."""
@@ -473,6 +493,7 @@ class KiCadMCPConfig(BaseSettings):
             "otel_protocol": self.otel_protocol,
             "telemetry_buffer_max_events": self.telemetry_buffer_max_events,
             "transport": self.transport,
+            "protocol_lane": self.protocol_lane,
             "host": self.host,
             "port": self.port,
             "mount_path": self.mount_path,

--- a/src/kicad_mcp/protocol_compat.py
+++ b/src/kicad_mcp/protocol_compat.py
@@ -99,12 +99,17 @@ def validate_candidate_request(
     """Validate candidate transport headers and required per-request metadata."""
 
     normalized = _normalized_headers(headers)
+
+    if payload.get("jsonrpc") != "2.0":
+        raise ProtocolValidationError(-32600, "JSON-RPC request jsonrpc must be '2.0'")
+
     raw_request_id = payload.get("id")
-    request_id: JSONRPCID = (
-        raw_request_id
-        if isinstance(raw_request_id, (str, int)) and not isinstance(raw_request_id, bool)
-        else None
-    )
+    if not isinstance(raw_request_id, (str, int)) or isinstance(raw_request_id, bool):
+        raise ProtocolValidationError(
+            -32600,
+            "JSON-RPC request id must be a string or integer",
+        )
+    request_id: JSONRPCID = raw_request_id
 
     if "mcp-session-id" in normalized:
         raise ProtocolValidationError(
@@ -296,7 +301,7 @@ def decorate_candidate_response(
         tools_raw = result.get("tools")
         if isinstance(tools_raw, list):
             tools: list[dict[str, Any]] = []
-            for item in cast(list[Any], tools_raw):
+            for item in tools_raw:
                 if not isinstance(item, dict):
                     break
                 tools.append(cast(dict[str, Any], item))

--- a/src/kicad_mcp/protocol_compat.py
+++ b/src/kicad_mcp/protocol_compat.py
@@ -1,0 +1,320 @@
+"""Protocol compatibility helpers for opt-in MCP release-candidate lanes.
+
+The production server remains on the stable MCP Python SDK. This module owns
+only pure request/response envelope validation and adaptation so candidate
+contracts can be exercised without leaking prerelease SDK behavior into the
+stable runtime.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, cast
+
+CANDIDATE_PROTOCOL_LANE = "2026-07-28-rc"
+CANDIDATE_PROTOCOL_VERSION = "2026-07-28"
+SERVER_NAME = "kicad-mcp-pro"
+JSONRPCID = str | int | None
+SERVER_INSTRUCTIONS = (
+    "KiCad MCP Pro provides bounded tools, prompts, and resources for inspecting, "
+    "authoring, validating, and releasing KiCad projects. Tool visibility remains "
+    "subject to authentication, profile, operating mode, and live KiCad capabilities."
+)
+
+_NAMED_METHOD_FIELDS = {
+    "tools/call": "name",
+    "prompts/get": "name",
+    "resources/read": "uri",
+}
+_LEGACY_LIFECYCLE_METHODS = {"initialize", "notifications/initialized"}
+_CACHE_POLICY = {
+    "tools/list": (300_000, "private"),
+    "prompts/list": (300_000, "private"),
+    "resources/list": (300_000, "private"),
+    "resources/templates/list": (300_000, "private"),
+    "resources/read": (60_000, "private"),
+}
+
+
+class ProtocolValidationError(ValueError):
+    """A JSON-RPC error raised while validating a candidate protocol request."""
+
+    def __init__(
+        self,
+        code: int,
+        message: str,
+        *,
+        data: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = dict(data) if data is not None else None
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateRequest:
+    """Validated routing metadata extracted from a candidate request."""
+
+    method: str
+    name: str | None
+    request_id: JSONRPCID
+
+
+def _normalized_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {str(key).casefold(): str(value) for key, value in headers.items()}
+
+
+def _decode_header_value(value: str, *, header: str) -> str:
+    prefix = "=?base64?"
+    suffix = "?="
+    if not value.startswith(prefix):
+        return value
+    if not value.endswith(suffix):
+        raise ProtocolValidationError(
+            -32020,
+            f"Invalid Base64 sentinel encoding for {header}",
+            data={"header": header},
+        )
+    encoded = value[len(prefix) : -len(suffix)]
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+        return raw.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as exc:
+        raise ProtocolValidationError(
+            -32020,
+            f"Invalid Base64 sentinel encoding for {header}",
+            data={"header": header},
+        ) from exc
+
+
+def validate_candidate_request(
+    headers: Mapping[str, str],
+    payload: Mapping[str, Any],
+) -> CandidateRequest:
+    """Validate candidate transport headers and required per-request metadata."""
+
+    normalized = _normalized_headers(headers)
+    raw_request_id = payload.get("id")
+    request_id: JSONRPCID = (
+        raw_request_id
+        if isinstance(raw_request_id, (str, int)) and not isinstance(raw_request_id, bool)
+        else None
+    )
+
+    if "mcp-session-id" in normalized:
+        raise ProtocolValidationError(
+            -32020,
+            "Mcp-Session-Id is not permitted by the stateless 2026-07-28 contract",
+            data={"header": "Mcp-Session-Id"},
+        )
+
+    header_version = normalized.get("mcp-protocol-version")
+    if header_version != CANDIDATE_PROTOCOL_VERSION:
+        raise ProtocolValidationError(
+            -32022,
+            f"Unsupported protocol version: {header_version or '<missing>'}",
+            data={
+                "supportedVersions": [CANDIDATE_PROTOCOL_VERSION],
+                "receivedVersion": header_version,
+            },
+        )
+
+    method = payload.get("method")
+    if not isinstance(method, str) or not method:
+        raise ProtocolValidationError(-32600, "JSON-RPC request method must be a non-empty string")
+
+    method_header = normalized.get("mcp-method")
+    if method_header != method:
+        raise ProtocolValidationError(
+            -32020,
+            (
+                f"Header mismatch: Mcp-Method value {method_header!r} "
+                f"does not match body method {method!r}"
+            ),
+            data={"header": "Mcp-Method", "expected": method, "received": method_header},
+        )
+
+    if method in _LEGACY_LIFECYCLE_METHODS:
+        raise ProtocolValidationError(
+            -32601,
+            f"Method {method!r} is not available in MCP 2026-07-28",
+            data={"method": method},
+        )
+
+    params_raw = payload.get("params")
+    if not isinstance(params_raw, Mapping):
+        raise ProtocolValidationError(-32602, "Request params must be an object")
+    params = cast(Mapping[str, Any], params_raw)
+    meta_raw = params.get("_meta")
+    if not isinstance(meta_raw, Mapping):
+        raise ProtocolValidationError(-32602, "Request params._meta must be an object")
+    meta = cast(Mapping[str, Any], meta_raw)
+
+    body_version = meta.get("io.modelcontextprotocol/protocolVersion")
+    if body_version != header_version:
+        raise ProtocolValidationError(
+            -32020,
+            "Header/body protocol version mismatch",
+            data={"headerVersion": header_version, "bodyVersion": body_version},
+        )
+
+    if "io.modelcontextprotocol/clientCapabilities" not in meta:
+        raise ProtocolValidationError(
+            -32021,
+            (
+                "Missing required client capability metadata: "
+                "io.modelcontextprotocol/clientCapabilities"
+            ),
+            data={"capability": "io.modelcontextprotocol/clientCapabilities"},
+        )
+    capabilities = meta["io.modelcontextprotocol/clientCapabilities"]
+    if not isinstance(capabilities, Mapping):
+        raise ProtocolValidationError(
+            -32021,
+            "Client capability metadata must be an object",
+            data={"capability": "io.modelcontextprotocol/clientCapabilities"},
+        )
+
+    name: str | None = None
+    source_field = _NAMED_METHOD_FIELDS.get(method)
+    if source_field is not None:
+        source_value = params.get(source_field)
+        if not isinstance(source_value, str) or not source_value:
+            raise ProtocolValidationError(
+                -32602,
+                f"{method} requires params.{source_field}",
+                data={"field": f"params.{source_field}"},
+            )
+        encoded_name = normalized.get("mcp-name")
+        decoded_name = (
+            _decode_header_value(encoded_name, header="Mcp-Name")
+            if encoded_name is not None
+            else None
+        )
+        if decoded_name != source_value:
+            raise ProtocolValidationError(
+                -32020,
+                (
+                    f"Header mismatch: Mcp-Name value {decoded_name!r} "
+                    f"does not match body value {source_value!r}"
+                ),
+                data={
+                    "header": "Mcp-Name",
+                    "expected": source_value,
+                    "received": decoded_name,
+                },
+            )
+        name = source_value
+
+    return CandidateRequest(method=method, name=name, request_id=request_id)
+
+
+def candidate_discover_result(*, server_version: str) -> dict[str, Any]:
+    """Build the mandatory candidate `server/discover` result."""
+
+    return {
+        "resultType": "complete",
+        "supportedVersions": [CANDIDATE_PROTOCOL_VERSION],
+        "capabilities": {
+            "tools": {},
+            "prompts": {},
+            "resources": {},
+            "extensions": {},
+        },
+        "_meta": {
+            "io.modelcontextprotocol/serverInfo": {
+                "name": SERVER_NAME,
+                "version": server_version,
+            }
+        },
+        "instructions": SERVER_INSTRUCTIONS,
+        "ttlMs": 3_600_000,
+        "cacheScope": "private",
+    }
+
+
+def stable_sdk_request(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove candidate-only request metadata before invoking the stable SDK."""
+
+    translated: dict[str, Any] = deepcopy(dict(payload))
+    params_raw = translated.get("params")
+    if not isinstance(params_raw, dict):
+        return translated
+    params = cast(dict[str, Any], params_raw)
+    meta_raw = params.get("_meta")
+    if isinstance(meta_raw, dict):
+        meta = cast(dict[str, Any], meta_raw)
+        for key in (
+            "io.modelcontextprotocol/protocolVersion",
+            "io.modelcontextprotocol/clientCapabilities",
+            "io.modelcontextprotocol/clientInfo",
+        ):
+            meta.pop(key, None)
+        if not meta:
+            params.pop("_meta", None)
+    return translated
+
+
+def decorate_candidate_response(
+    method: str,
+    payload: Mapping[str, Any],
+    *,
+    server_version: str,
+) -> dict[str, Any]:
+    """Decorate a stable SDK JSON-RPC response for the candidate contract."""
+
+    decorated: dict[str, Any] = deepcopy(dict(payload))
+    result_raw = decorated.get("result")
+    if not isinstance(result_raw, dict):
+        return decorated
+    result = cast(dict[str, Any], result_raw)
+
+    result.setdefault("resultType", "complete")
+    meta_raw = result.setdefault("_meta", {})
+    if isinstance(meta_raw, dict):
+        meta = cast(dict[str, Any], meta_raw)
+    else:
+        meta = {}
+        result["_meta"] = meta
+    meta["io.modelcontextprotocol/serverInfo"] = {
+        "name": SERVER_NAME,
+        "version": server_version,
+    }
+
+    cache_policy = _CACHE_POLICY.get(method)
+    if cache_policy is not None:
+        ttl_ms, scope = cache_policy
+        result.setdefault("ttlMs", ttl_ms)
+        result.setdefault("cacheScope", scope)
+
+    if method == "tools/list":
+        tools_raw = result.get("tools")
+        if isinstance(tools_raw, list):
+            tools: list[dict[str, Any]] = []
+            for item in cast(list[Any], tools_raw):
+                if not isinstance(item, dict):
+                    break
+                tools.append(cast(dict[str, Any], item))
+            else:
+                tools.sort(key=lambda tool: str(tool.get("name", "")))
+                result["tools"] = tools
+
+    return decorated
+
+
+def jsonrpc_error_response(
+    error: ProtocolValidationError,
+    *,
+    request_id: JSONRPCID = None,
+) -> dict[str, Any]:
+    """Render a candidate protocol validation error as JSON-RPC."""
+
+    error_payload: dict[str, Any] = {"code": error.code, "message": error.message}
+    if error.data is not None:
+        error_payload["data"] = deepcopy(error.data)
+    return {"jsonrpc": "2.0", "id": request_id, "error": error_payload}

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -98,6 +98,15 @@ from .operating_modes import (
     filter_tools_for_mode,
     is_tool_allowed_in_mode,
 )
+from .protocol_compat import (
+    CANDIDATE_PROTOCOL_LANE,
+    ProtocolValidationError,
+    candidate_discover_result,
+    decorate_candidate_response,
+    jsonrpc_error_response,
+    stable_sdk_request,
+    validate_candidate_request,
+)
 from .tools import footprint as _footprint
 from .tools import jobset as _jobset
 from .tools import router
@@ -862,6 +871,8 @@ class KiCadFastMCP(FastMCP):
                     "Content-Type",
                     "MCP-Protocol-Version",
                     "MCP-Session-Id",
+                    "Mcp-Method",
+                    "Mcp-Name",
                 ],
             )
         app.add_middleware(_OriginValidationMiddleware)
@@ -1123,7 +1134,7 @@ class _StreamableHttpContractMiddleware:
             await original_send(message)
 
         send = post_request_send
-        if rpc_method == "initialize":
+        if rpc_method == "initialize" and cfg.protocol_lane == "stable":
             logger.info(
                 "mcp_transport_initialize",
                 request_id=rpc_id,
@@ -1167,6 +1178,27 @@ class _StreamableHttpContractMiddleware:
                 receive=replay_receive,
                 send=send,
             )
+            return
+
+        if cfg.protocol_lane == CANDIDATE_PROTOCOL_LANE:
+            with otel.mcp_request_span(
+                http_method=str(method),
+                mount_path=cfg.mount_path,
+                session_present=False,
+            ) as request_span:
+                otel.annotate_mcp_request(request_span, rpc_method=rpc_method)
+                with structlog.contextvars.bound_contextvars(
+                    request_id=rpc_id,
+                    mcp_session_id=None,
+                ):
+                    await self._handle_candidate_post(
+                        scope=scope,
+                        body=body,
+                        headers=headers,
+                        rpc_id=rpc_id,
+                        send=send,
+                    )
+                otel.finish_mcp_request_span(request_span, status_code=post_response_status)
             return
 
         protocol_version = headers.get("mcp-protocol-version")
@@ -1235,6 +1267,76 @@ class _StreamableHttpContractMiddleware:
                 await self.app(scope, replay_receive, send_wrapper)
             otel.finish_mcp_request_span(request_span, status_code=post_response_status)
 
+    async def _handle_candidate_post(
+        self,
+        *,
+        scope: Scope,
+        body: bytes,
+        headers: dict[str, str],
+        rpc_id: object | None,
+        send: Send,
+    ) -> None:
+        """Validate and adapt one opt-in MCP 2026-07-28 request."""
+        payload = _json_rpc_payload(body)
+        if payload is None:
+            await _candidate_json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": rpc_id,
+                    "error": {"code": -32700, "message": "Parse error"},
+                },
+                status_code=400,
+                scope=scope,
+                send=send,
+            )
+            return
+
+        try:
+            candidate_request = validate_candidate_request(headers, payload)
+        except ProtocolValidationError as exc:
+            await _candidate_json_response(
+                jsonrpc_error_response(exc, request_id=_json_rpc_id(payload)),
+                status_code=400,
+                scope=scope,
+                send=send,
+            )
+            return
+
+        if candidate_request.method == "server/discover":
+            await _candidate_json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": candidate_request.request_id,
+                    "result": candidate_discover_result(server_version=__version__),
+                },
+                status_code=200,
+                scope=scope,
+                send=send,
+            )
+            return
+
+        stable_body = json.dumps(
+            stable_sdk_request(payload),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        stable_scope = _scope_with_header(
+            scope,
+            "mcp-protocol-version",
+            MCP_PROTOCOL_VERSION,
+        )
+        downstream_messages: list[Message] = []
+
+        async def capture_send(message: Message) -> None:
+            downstream_messages.append(message)
+
+        await self.app(stable_scope, _receive_from_body(stable_body), capture_send)
+        await _send_candidate_downstream_response(
+            downstream_messages,
+            method=candidate_request.method,
+            send=send,
+        )
+
     def _has_session(self, session_id: str) -> bool:
         return session_id in self._session_ids
 
@@ -1276,6 +1378,135 @@ async def _buffer_request_body(receive: Receive) -> tuple[bytes, Receive]:
         return next(iterator, {"type": "http.request", "body": b"", "more_body": False})
 
     return b"".join(chunks), replay_receive
+
+
+def _json_rpc_payload(body: bytes) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _json_rpc_id(payload: dict[str, Any]) -> str | int | None:
+    request_id = payload.get("id")
+    if isinstance(request_id, bool):
+        return None
+    return request_id if isinstance(request_id, (str, int)) else None
+
+
+def _receive_from_body(body: bytes) -> Receive:
+    delivered = False
+
+    async def receive() -> Message:
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        delivered = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+def _scope_with_header(scope: Scope, header_name: str, value: str) -> Scope:
+    expected = header_name.casefold().encode("latin-1")
+    headers: list[tuple[bytes, bytes]] = []
+    replaced = False
+    for key, header_value in scope.get("headers", []):
+        if key.lower() == expected:
+            headers.append((key, value.encode("latin-1")))
+            replaced = True
+        else:
+            headers.append((key, header_value))
+    if not replaced:
+        headers.append((expected, value.encode("latin-1")))
+    updated = dict(scope)
+    updated["headers"] = headers
+    return cast(Scope, updated)
+
+
+async def _candidate_json_response(
+    payload: dict[str, Any],
+    *,
+    status_code: int,
+    scope: Scope,
+    send: Send,
+) -> None:
+    await JSONResponse(payload, status_code=status_code)(
+        scope,
+        _receive_from_body(b""),
+        send,
+    )
+
+
+def _response_headers_without_session(
+    headers: list[tuple[bytes, bytes]],
+    *,
+    content_length: int | None = None,
+) -> list[tuple[bytes, bytes]]:
+    filtered: list[tuple[bytes, bytes]] = []
+    has_content_length = False
+    for key, value in headers:
+        lowered = key.lower()
+        if lowered == b"mcp-session-id":
+            continue
+        if lowered == b"content-length" and content_length is not None:
+            filtered.append((key, str(content_length).encode("ascii")))
+            has_content_length = True
+            continue
+        filtered.append((key, value))
+    if content_length is not None and not has_content_length:
+        filtered.append((b"content-length", str(content_length).encode("ascii")))
+    return filtered
+
+
+async def _send_candidate_downstream_response(
+    messages: list[Message],
+    *,
+    method: str,
+    send: Send,
+) -> None:
+    start = next(
+        (message for message in messages if message["type"] == "http.response.start"), None
+    )
+    if start is None:
+        for message in messages:
+            await send(message)
+        return
+
+    chunks = [
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body" and isinstance(message.get("body", b""), bytes)
+    ]
+    body = b"".join(cast(list[bytes], chunks))
+    raw_headers = start.get("headers", [])
+    headers = cast(list[tuple[bytes, bytes]], raw_headers if isinstance(raw_headers, list) else [])
+    content_type = ""
+    for key, value in headers:
+        if key.lower() == b"content-type":
+            content_type = value.decode("latin-1")
+            break
+
+    status = start.get("status", 200)
+    status_code = status if isinstance(status, int) else 200
+    if 200 <= status_code < 300 and _content_type_header_is(content_type, "application/json"):
+        payload = _json_rpc_payload(body)
+        if payload is not None:
+            decorated = decorate_candidate_response(
+                method,
+                payload,
+                server_version=__version__,
+            )
+            body = json.dumps(decorated, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+    response_start = dict(start)
+    response_start["headers"] = _response_headers_without_session(
+        headers,
+        content_length=len(body),
+    )
+    await send(cast(Message, response_start))
+    await send({"type": "http.response.body", "body": body, "more_body": False})
 
 
 def _scope_headers(scope: Scope) -> dict[str, str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ def reset_globals(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.delenv("KICAD_MCP_HEADLESS", raising=False)
     monkeypatch.delenv("KICAD_MCP_WORKSPACE_ROOT", raising=False)
     monkeypatch.delenv("KICAD_MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("KICAD_MCP_PROTOCOL_LANE", raising=False)
     monkeypatch.delenv("KICAD_MCP_LEGACY_SSE", raising=False)
     monkeypatch.delenv("KICAD_MCP_STATEFUL_HTTP", raising=False)
     monkeypatch.delenv("KICAD_MCP_ENABLE_METRICS", raising=False)

--- a/tests/contracts/mcp/2026-07-28/provenance.json
+++ b/tests/contracts/mcp/2026-07-28/provenance.json
@@ -1,0 +1,7 @@
+{
+  "source": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+  "commit": "73720340e7c42ddaf4b303b86e81663e9a2796d0",
+  "protocolVersion": "2026-07-28",
+  "capturedAt": "2026-07-22",
+  "status": "release-candidate-draft"
+}

--- a/tests/contracts/mcp/2026-07-28/server-discover.request.json
+++ b/tests/contracts/mcp/2026-07-28/server-discover.request.json
@@ -1,0 +1,15 @@
+{
+  "jsonrpc": "2.0",
+  "id": "discover-1",
+  "method": "server/discover",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "ExampleClient",
+        "version": "1.0.0"
+      },
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}

--- a/tests/contracts/mcp/2026-07-28/server-discover.response.json
+++ b/tests/contracts/mcp/2026-07-28/server-discover.response.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "id": "discover-1",
+  "result": {
+    "resultType": "complete",
+    "supportedVersions": ["2026-07-28"],
+    "capabilities": {
+      "tools": {},
+      "resources": {}
+    },
+    "_meta": {
+      "io.modelcontextprotocol/serverInfo": {
+        "name": "ExampleServer",
+        "version": "1.0.0"
+      }
+    },
+    "ttlMs": 3600000,
+    "cacheScope": "public"
+  }
+}

--- a/tests/contracts/mcp/2026-07-28/tools-list.request.json
+++ b/tests/contracts/mcp/2026-07-28/tools-list.request.json
@@ -1,0 +1,15 @@
+{
+  "jsonrpc": "2.0",
+  "id": "list-tools-example",
+  "method": "tools/list",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "ExampleClient",
+        "version": "1.0.0"
+      },
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}

--- a/tests/contracts/mcp/2026-07-28/tools-list.response.json
+++ b/tests/contracts/mcp/2026-07-28/tools-list.response.json
@@ -1,0 +1,34 @@
+{
+  "jsonrpc": "2.0",
+  "id": "list-tools-example",
+  "result": {
+    "resultType": "complete",
+    "tools": [
+      {
+        "name": "get_weather",
+        "title": "Weather Information Provider",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        },
+        "icons": [
+          {
+            "src": "https://example.com/weather-icon.png",
+            "mimeType": "image/png",
+            "sizes": ["48x48"]
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor",
+    "ttlMs": 3600000,
+    "cacheScope": "public"
+  }
+}

--- a/tests/integration/test_mcp_2026_host_smoke.py
+++ b/tests/integration/test_mcp_2026_host_smoke.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from starlette.types import ASGIApp
+
+from kicad_mcp.config import get_config
+from kicad_mcp.protocol_compat import CANDIDATE_PROTOCOL_VERSION
+from kicad_mcp.server import build_server
+
+BASE_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+    "MCP-Protocol-Version": CANDIDATE_PROTOCOL_VERSION,
+}
+
+
+def _request(
+    method: str,
+    *,
+    request_id: int,
+    client_name: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    request_params = dict(params or {})
+    request_params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": CANDIDATE_PROTOCOL_VERSION,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": client_name,
+            "version": "smoke",
+        },
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": request_params,
+    }
+
+
+def _headers(method: str, *, name: str | None = None) -> dict[str, str]:
+    headers = {**BASE_HEADERS, "Mcp-Method": method}
+    if name is not None:
+        headers["Mcp-Name"] = name
+    return headers
+
+
+@contextmanager
+def _running_http_server(app: ASGIApp) -> Iterator[str]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(128)
+    port = int(listener.getsockname()[1])
+
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="error",
+            lifespan="on",
+        )
+    )
+    thread = threading.Thread(
+        target=server.run,
+        kwargs={"sockets": [listener]},
+        name="mcp-2026-host-smoke",
+        daemon=True,
+    )
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while not server.started and thread.is_alive() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=2.0)
+        listener.close()
+        raise RuntimeError("candidate MCP host-smoke server did not start")
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10.0)
+        listener.close()
+        if thread.is_alive():
+            raise RuntimeError("candidate MCP host-smoke server did not stop")
+
+
+@pytest.mark.parametrize("client_name", ["chatgpt-connector", "vscode-mcp"])
+def test_supported_host_profile_smoke_over_real_http(
+    sample_project: Path,
+    client_name: str,
+) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.protocol_lane = "2026-07-28-rc"
+    cfg.stateful_http = False
+    cfg.enable_tasks = False
+    server = build_server("minimal")
+
+    with _running_http_server(server.streamable_http_app()) as base_url:
+        with httpx.Client(base_url=base_url, timeout=10.0) as client:
+            discovered = client.post(
+                "/mcp",
+                headers=_headers("server/discover"),
+                json=_request("server/discover", request_id=1, client_name=client_name),
+            )
+            listed = client.post(
+                "/mcp",
+                headers=_headers("tools/list"),
+                json=_request("tools/list", request_id=2, client_name=client_name),
+            )
+            called = client.post(
+                "/mcp",
+                headers=_headers("tools/call", name="kicad_get_version"),
+                json=_request(
+                    "tools/call",
+                    request_id=3,
+                    client_name=client_name,
+                    params={"name": "kicad_get_version", "arguments": {}},
+                ),
+            )
+
+    assert discovered.status_code == 200
+    assert listed.status_code == 200
+    assert called.status_code == 200
+    assert "mcp-session-id" not in discovered.headers
+    assert "mcp-session-id" not in listed.headers
+    assert "mcp-session-id" not in called.headers
+    assert discovered.json()["result"]["supportedVersions"] == [CANDIDATE_PROTOCOL_VERSION]
+    assert "kicad_get_version" in {tool["name"] for tool in listed.json()["result"]["tools"]}
+    assert "KiCad MCP Pro Server" in called.json()["result"]["content"][0]["text"]

--- a/tests/unit/test_mcp_2026_ci_contract.py
+++ b/tests/unit/test_mcp_2026_ci_contract.py
@@ -17,6 +17,10 @@ def test_candidate_protocol_contract_runs_in_an_independent_required_ci_job() ->
         "tests/unit/test_protocol_compat.py "
         "tests/unit/test_mcp_protocol_2026_contract.py -q"
     ) in " ".join(workflow.split())
+    assert "Run supported-host MCP 2026 smoke cases" in workflow
+    assert "uv run pytest tests/integration/test_mcp_2026_host_smoke.py -q" in " ".join(
+        workflow.split()
+    )
     assert (
         "needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, "
         "mcp-2026-compat, workflow-policy, security]"

--- a/tests/unit/test_mcp_2026_ci_contract.py
+++ b/tests/unit/test_mcp_2026_ci_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_candidate_protocol_contract_runs_in_an_independent_required_ci_job() -> None:
+    workflow = CI.read_text(encoding="utf-8")
+
+    assert "  mcp-2026-compat:" in workflow
+    assert "name: MCP 2026 Compatibility" in workflow
+    assert "uv sync --all-extras --frozen" in workflow
+    assert (
+        "uv run pytest tests/unit/test_mcp_2026_config.py "
+        "tests/unit/test_protocol_compat.py "
+        "tests/unit/test_mcp_protocol_2026_contract.py -q"
+    ) in " ".join(workflow.split())
+    assert (
+        "needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, "
+        "mcp-2026-compat, workflow-policy, security]"
+    ) in workflow
+    assert '[mcp-2026-compat]="${{ needs.mcp-2026-compat.result }}"' in workflow
+    assert (
+        "for job in changes mcp-server coverage mcp-npm protocol-schemas "
+        "mcp-2026-compat workflow-policy security"
+    ) in " ".join(workflow.split())

--- a/tests/unit/test_mcp_2026_config.py
+++ b/tests/unit/test_mcp_2026_config.py
@@ -60,6 +60,7 @@ def test_candidate_protocol_lane_can_be_selected_explicitly(fake_cli: Path) -> N
 
     assert config.protocol_lane == "2026-07-28-rc"
     assert config.stateful_http is False
+    assert config.safe_diagnostics()["protocol_lane"] == "2026-07-28-rc"
 
 
 def test_candidate_protocol_lane_loads_from_environment(

--- a/tests/unit/test_mcp_2026_config.py
+++ b/tests/unit/test_mcp_2026_config.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from kicad_mcp.config import KiCadMCPConfig
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_ROOT = ROOT / "tests" / "contracts" / "mcp" / "2026-07-28"
+
+
+def test_candidate_contract_fixtures_pin_the_release_candidate_source() -> None:
+    provenance = json.loads((CONTRACT_ROOT / "provenance.json").read_text(encoding="utf-8"))
+    discover_request = json.loads(
+        (CONTRACT_ROOT / "server-discover.request.json").read_text(encoding="utf-8")
+    )
+    discover_response = json.loads(
+        (CONTRACT_ROOT / "server-discover.response.json").read_text(encoding="utf-8")
+    )
+    tools_request = json.loads(
+        (CONTRACT_ROOT / "tools-list.request.json").read_text(encoding="utf-8")
+    )
+    tools_response = json.loads(
+        (CONTRACT_ROOT / "tools-list.response.json").read_text(encoding="utf-8")
+    )
+
+    assert provenance == {
+        "source": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+        "commit": "73720340e7c42ddaf4b303b86e81663e9a2796d0",
+        "protocolVersion": "2026-07-28",
+        "capturedAt": "2026-07-22",
+        "status": "release-candidate-draft",
+    }
+    for request in (discover_request, tools_request):
+        meta = request["params"]["_meta"]
+        assert meta["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
+        assert meta["io.modelcontextprotocol/clientCapabilities"] == {}
+    for response in (discover_response, tools_response):
+        assert response["result"]["resultType"] == "complete"
+        assert response["result"]["ttlMs"] >= 0
+        assert response["result"]["cacheScope"] in {"public", "private"}
+
+
+def test_protocol_lane_defaults_to_stable(fake_cli: Path) -> None:
+    config = KiCadMCPConfig(kicad_cli=fake_cli)
+
+    assert config.protocol_lane == "stable"
+
+
+def test_candidate_protocol_lane_can_be_selected_explicitly(fake_cli: Path) -> None:
+    config = KiCadMCPConfig(
+        kicad_cli=fake_cli,
+        transport="streamable-http",
+        protocol_lane="2026-07-28-rc",
+    )
+
+    assert config.protocol_lane == "2026-07-28-rc"
+    assert config.stateful_http is False
+
+
+def test_candidate_protocol_lane_loads_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_cli: Path,
+) -> None:
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("KICAD_MCP_PROTOCOL_LANE", "2026-07-28-rc")
+    monkeypatch.setenv("KICAD_MCP_KICAD_CLI", str(fake_cli))
+
+    config = KiCadMCPConfig()
+
+    assert config.protocol_lane == "2026-07-28-rc"
+
+
+def test_candidate_protocol_lane_accepts_http_alias(fake_cli: Path) -> None:
+    config = KiCadMCPConfig(
+        kicad_cli=fake_cli,
+        transport="http",
+        protocol_lane="2026-07-28-rc",
+    )
+
+    assert config.transport == "streamable-http"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"transport": "stdio"}, "requires transport='streamable-http'"),
+        ({"transport": "sse"}, "requires transport='streamable-http'"),
+        (
+            {"transport": "streamable-http", "stateful_http": True},
+            "requires stateful_http=false",
+        ),
+        (
+            {"transport": "streamable-http", "legacy_sse": True},
+            "does not support legacy_sse",
+        ),
+        (
+            {"transport": "streamable-http", "enable_tasks": True},
+            "does not support the legacy Tasks implementation",
+        ),
+    ],
+)
+def test_candidate_protocol_lane_rejects_incompatible_runtime_modes(
+    overrides: dict[str, Any],
+    message: str,
+    fake_cli: Path,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        KiCadMCPConfig(
+            kicad_cli=fake_cli,
+            protocol_lane="2026-07-28-rc",
+            **overrides,
+        )

--- a/tests/unit/test_mcp_2026_docs_contract.py
+++ b/tests/unit/test_mcp_2026_docs_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ADR = ROOT / "docs" / "adr" / "0006-mcp-2026-stateless-compatibility-lane.md"
+TRANSPORT = ROOT / "docs" / "mcp" / "transport.md"
+API_REFERENCE = ROOT / "docs" / "mcp" / "api-reference.md"
+MKDOCS = ROOT / "mkdocs.yml"
+
+
+def test_candidate_protocol_operator_documentation_is_explicitly_release_gated() -> None:
+    adr = ADR.read_text(encoding="utf-8")
+    transport = TRANSPORT.read_text(encoding="utf-8")
+    api_reference = API_REFERENCE.read_text(encoding="utf-8")
+    navigation = MKDOCS.read_text(encoding="utf-8")
+
+    assert "**Status:** Accepted" in adr
+    assert "## Component state inventory" in adr
+    for component in (
+        "Streamable HTTP",
+        "Tasks",
+        "Apps",
+        "Authorization",
+        "Caching",
+        "Telemetry and benchmarks",
+        "Registry metadata",
+    ):
+        assert component in adr
+
+    assert "KICAD_MCP_PROTOCOL_LANE=2026-07-28-rc" in transport
+    assert "release-candidate compatibility lane" in transport
+    assert "not a general-availability protocol advertisement" in transport
+    assert "Mcp-Method" in transport
+    assert "Mcp-Name" in transport
+    assert "server/discover" in transport
+    assert "Mcp-Session-Id" in transport
+    assert "unset KICAD_MCP_PROTOCOL_LANE" in transport
+
+    assert "Current public contract" in api_reference
+    assert "`2025-11-25`" in api_reference
+    assert "Candidate compatibility lane" in api_reference
+    assert "`2026-07-28`" in api_reference
+    assert "server.json remains on `2025-11-25`" in api_reference
+
+    for gate in (
+        "final MCP 2026-07-28 specification",
+        "stable MCP Python SDK",
+        "supported host smoke tests",
+        "Tasks and Apps extension parity",
+        "tested rollback",
+    ):
+        assert gate in adr
+
+    assert "MCP 2026 Stateless Compatibility Lane" in navigation
+    assert "adr/0006-mcp-2026-stateless-compatibility-lane.md" in navigation

--- a/tests/unit/test_mcp_manifest.py
+++ b/tests/unit/test_mcp_manifest.py
@@ -280,3 +280,13 @@ def test_validator_rejects_malformed_oci_identifier(identifier: str) -> None:
         "packages[2] OCI identifier must be registry/repository:tag "
         "or registry/repository@algorithm:digest."
     ) in errors
+
+
+def test_candidate_protocol_is_not_advertised_before_release_gates_pass() -> None:
+    module = _load_validator()
+    manifest = module.validate_manifest_file(ROOT / "server.json")
+    registry_meta = manifest["_meta"][REGISTRY_META_KEY]
+
+    assert registry_meta["supportedMcpProtocolVersions"] == ["2025-11-25"]
+    assert "2026-07-28" not in registry_meta["supportedMcpProtocolVersions"]
+    assert registry_meta["serverInfo"]["mcpProtocolVersion"] == "2025-11-25"

--- a/tests/unit/test_mcp_protocol_2026_contract.py
+++ b/tests/unit/test_mcp_protocol_2026_contract.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+from typing import Any
+
+from starlette.testclient import TestClient
+
+from kicad_mcp.config import get_config
+from kicad_mcp.protocol_compat import CANDIDATE_PROTOCOL_VERSION
+from kicad_mcp.server import build_server
+
+BASE_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+    "MCP-Protocol-Version": CANDIDATE_PROTOCOL_VERSION,
+}
+
+
+def _request(
+    method: str,
+    *,
+    request_id: int = 1,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    request_params = dict(params or {})
+    request_params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": CANDIDATE_PROTOCOL_VERSION,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "mcp-2026-contract-test",
+            "version": "1.0.0",
+        },
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": request_params,
+    }
+
+
+def _headers(method: str, *, name: str | None = None, token: str | None = None) -> dict[str, str]:
+    headers = {**BASE_HEADERS, "Mcp-Method": method}
+    if name is not None:
+        headers["Mcp-Name"] = name
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _candidate_server(sample_project: Path, *, auth_token: str | None = None):
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.protocol_lane = "2026-07-28-rc"
+    cfg.stateful_http = False
+    cfg.enable_tasks = False
+    cfg.auth_token = auth_token
+    return build_server("minimal")
+
+
+def test_candidate_discovery_is_available_without_initialize(sample_project: Path) -> None:
+    server = _candidate_server(sample_project)
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers=_headers("server/discover"),
+            json=_request("server/discover"),
+        )
+
+    assert response.status_code == 200
+    assert "mcp-session-id" not in response.headers
+    result = response.json()["result"]
+    assert result["resultType"] == "complete"
+    assert result["supportedVersions"] == [CANDIDATE_PROTOCOL_VERSION]
+    assert result["capabilities"]["extensions"] == {}
+    assert result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"] == "kicad-mcp-pro"
+    assert result["cacheScope"] == "private"
+
+
+def test_candidate_tools_list_is_direct_stateless_and_cache_annotated(
+    sample_project: Path,
+) -> None:
+    server = _candidate_server(sample_project)
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers=_headers("tools/list"),
+            json=_request("tools/list", request_id=2),
+        )
+
+    assert response.status_code == 200
+    assert "mcp-session-id" not in response.headers
+    result = response.json()["result"]
+    names = [tool["name"] for tool in result["tools"]]
+    assert names == sorted(names)
+    assert "kicad_get_version" in names
+    assert result["resultType"] == "complete"
+    assert result["ttlMs"] == 300_000
+    assert result["cacheScope"] == "private"
+
+
+def test_candidate_tool_call_is_direct_and_has_server_metadata(sample_project: Path) -> None:
+    server = _candidate_server(sample_project)
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers=_headers("tools/call", name="kicad_get_version"),
+            json=_request(
+                "tools/call",
+                request_id=3,
+                params={"name": "kicad_get_version", "arguments": {}},
+            ),
+        )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["resultType"] == "complete"
+    assert result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"] == "kicad-mcp-pro"
+    assert "KiCad MCP Pro Server" in result["content"][0]["text"]
+
+
+def test_candidate_rejects_legacy_session_header(sample_project: Path) -> None:
+    server = _candidate_server(sample_project)
+    headers = _headers("tools/list")
+    headers["Mcp-Session-Id"] = "legacy-session"
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post("/mcp", headers=headers, json=_request("tools/list", request_id=4))
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32020
+    assert "Mcp-Session-Id" in response.json()["error"]["message"]
+
+
+def test_candidate_rejects_legacy_initialize(sample_project: Path) -> None:
+    server = _candidate_server(sample_project)
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers=_headers("initialize"),
+            json=_request("initialize", request_id=5),
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32601
+
+
+def test_candidate_requires_method_header(sample_project: Path) -> None:
+    server = _candidate_server(sample_project)
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp", headers=BASE_HEADERS, json=_request("tools/list", request_id=6)
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32020
+
+
+def test_candidate_preserves_authentication_failure_before_protocol_diagnostics(
+    sample_project: Path,
+) -> None:
+    token = secrets.token_urlsafe(32)
+    server = _candidate_server(sample_project, auth_token=token)
+    invalid_request = _request("tools/list", request_id=7)
+    del invalid_request["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"]
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        unauthenticated = client.post(
+            "/mcp",
+            headers=_headers("tools/list"),
+            json=invalid_request,
+        )
+        authenticated = client.post(
+            "/mcp",
+            headers=_headers("tools/list", token=token),
+            json=invalid_request,
+        )
+
+    assert unauthenticated.status_code == 401
+    assert authenticated.status_code == 400
+    assert authenticated.json()["error"]["code"] == -32021

--- a/tests/unit/test_mcp_protocol_2026_contract.py
+++ b/tests/unit/test_mcp_protocol_2026_contract.py
@@ -22,12 +22,13 @@ def _request(
     *,
     request_id: int = 1,
     params: dict[str, Any] | None = None,
+    client_name: str = "mcp-2026-contract-test",
 ) -> dict[str, Any]:
     request_params = dict(params or {})
     request_params["_meta"] = {
         "io.modelcontextprotocol/protocolVersion": CANDIDATE_PROTOCOL_VERSION,
         "io.modelcontextprotocol/clientInfo": {
-            "name": "mcp-2026-contract-test",
+            "name": client_name,
             "version": "1.0.0",
         },
         "io.modelcontextprotocol/clientCapabilities": {},
@@ -101,6 +102,20 @@ def test_candidate_tools_list_is_direct_stateless_and_cache_annotated(
     assert result["resultType"] == "complete"
     assert result["ttlMs"] == 300_000
     assert result["cacheScope"] == "private"
+    assert all(isinstance(tool["inputSchema"], dict) for tool in result["tools"])
+    assert all(tool["inputSchema"].get("type") == "object" for tool in result["tools"])
+
+
+def test_candidate_rejects_invalid_json_rpc_envelope(sample_project: Path) -> None:
+    server = _candidate_server(sample_project)
+    request = _request("tools/list", request_id=8)
+    request["jsonrpc"] = "1.0"
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post("/mcp", headers=_headers("tools/list"), json=request)
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32600
 
 
 def test_candidate_tool_call_is_direct_and_has_server_metadata(sample_project: Path) -> None:

--- a/tests/unit/test_protocol_compat.py
+++ b/tests/unit/test_protocol_compat.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from kicad_mcp.protocol_compat import (
+    CANDIDATE_PROTOCOL_VERSION,
+    ProtocolValidationError,
+    candidate_discover_result,
+    decorate_candidate_response,
+    jsonrpc_error_response,
+    stable_sdk_request,
+    validate_candidate_request,
+)
+
+
+def candidate_request(
+    method: str = "tools/list",
+    *,
+    params: dict[str, object] | None = None,
+    request_id: object = 1,
+) -> dict[str, object]:
+    request_params = dict(params or {})
+    request_params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": CANDIDATE_PROTOCOL_VERSION,
+        "io.modelcontextprotocol/clientInfo": {"name": "test-client", "version": "1.0"},
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": request_params,
+    }
+
+
+def candidate_headers(method: str = "tools/list", *, name: str | None = None) -> dict[str, str]:
+    headers = {
+        "MCP-Protocol-Version": CANDIDATE_PROTOCOL_VERSION,
+        "Mcp-Method": method,
+    }
+    if name is not None:
+        headers["Mcp-Name"] = name
+    return headers
+
+
+def assert_protocol_error(
+    error: ProtocolValidationError,
+    *,
+    code: int,
+    fragment: str,
+) -> None:
+    assert error.code == code
+    assert fragment in error.message
+
+
+def test_validate_candidate_request_accepts_stateless_list_request() -> None:
+    request = candidate_request()
+
+    validated = validate_candidate_request(candidate_headers(), request)
+
+    assert validated.method == "tools/list"
+    assert validated.name is None
+    assert validated.request_id == 1
+
+
+def test_validate_candidate_request_requires_candidate_protocol_version() -> None:
+    headers = candidate_headers()
+    headers["MCP-Protocol-Version"] = "2025-11-25"
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(headers, candidate_request())
+
+    assert_protocol_error(raised.value, code=-32022, fragment="Unsupported protocol version")
+
+
+def test_validate_candidate_request_rejects_header_body_protocol_mismatch() -> None:
+    request = candidate_request()
+    request["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"] = "2025-11-25"  # type: ignore[index]
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(candidate_headers(), request)
+
+    assert_protocol_error(raised.value, code=-32020, fragment="protocol version")
+
+
+def test_validate_candidate_request_requires_client_capabilities() -> None:
+    request = candidate_request()
+    del request["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"]  # type: ignore[index]
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(candidate_headers(), request)
+
+    assert_protocol_error(raised.value, code=-32021, fragment="clientCapabilities")
+
+
+def test_validate_candidate_request_rejects_session_header() -> None:
+    headers = candidate_headers()
+    headers["Mcp-Session-Id"] = "legacy-session"
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(headers, candidate_request())
+
+    assert_protocol_error(raised.value, code=-32020, fragment="Mcp-Session-Id")
+
+
+def test_validate_candidate_request_requires_matching_method_header() -> None:
+    headers = candidate_headers("resources/list")
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(headers, candidate_request("tools/list"))
+
+    assert_protocol_error(raised.value, code=-32020, fragment="Mcp-Method")
+
+
+@pytest.mark.parametrize(
+    ("method", "params", "name"),
+    [
+        ("tools/call", {"name": "kicad_help", "arguments": {}}, "kicad_help"),
+        ("prompts/get", {"name": "review_board"}, "review_board"),
+        ("resources/read", {"uri": "kicad://project/current"}, "kicad://project/current"),
+    ],
+)
+def test_validate_candidate_request_requires_matching_name_header(
+    method: str,
+    params: dict[str, object],
+    name: str,
+) -> None:
+    request = candidate_request(method, params=params)
+
+    validated = validate_candidate_request(candidate_headers(method, name=name), request)
+
+    assert validated.name == name
+
+
+def test_validate_candidate_request_decodes_base64_name_header() -> None:
+    request = candidate_request(
+        "resources/read",
+        params={"uri": "kicad://project/ölçüm"},
+    )
+    headers = candidate_headers(
+        "resources/read",
+        name="=?base64?a2ljYWQ6Ly9wcm9qZWN0L8O2bMOnw7xt?=",
+    )
+
+    validated = validate_candidate_request(headers, request)
+
+    assert validated.name == "kicad://project/ölçüm"
+
+
+def test_validate_candidate_request_rejects_legacy_initialization_methods() -> None:
+    request = candidate_request("initialize")
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(candidate_headers("initialize"), request)
+
+    assert_protocol_error(raised.value, code=-32601, fragment="not available")
+
+
+def test_candidate_discovery_uses_no_unimplemented_extensions() -> None:
+    result = candidate_discover_result(server_version="3.28.0")
+
+    assert result["resultType"] == "complete"
+    assert result["supportedVersions"] == ["2026-07-28"]
+    assert result["capabilities"] == {
+        "tools": {},
+        "prompts": {},
+        "resources": {},
+        "extensions": {},
+    }
+    assert result["_meta"]["io.modelcontextprotocol/serverInfo"] == {
+        "name": "kicad-mcp-pro",
+        "version": "3.28.0",
+    }
+    assert result["ttlMs"] == 3_600_000
+    assert result["cacheScope"] == "private"
+    assert "KiCad" in result["instructions"]
+
+
+def test_stable_sdk_request_removes_candidate_only_metadata_without_mutating_input() -> None:
+    request = candidate_request(
+        "tools/call",
+        params={"name": "kicad_help", "arguments": {}, "requestState": "resume-1"},
+    )
+    original = deepcopy(request)
+
+    translated = stable_sdk_request(request)
+
+    assert request == original
+    assert translated["params"] == {
+        "name": "kicad_help",
+        "arguments": {},
+        "requestState": "resume-1",
+    }
+
+
+def test_decorate_candidate_response_adds_result_and_private_cache_metadata() -> None:
+    response = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "tools": [
+                {"name": "zeta", "inputSchema": {"type": "object"}},
+                {"name": "alpha", "inputSchema": {"type": "object"}},
+            ]
+        },
+    }
+    original = deepcopy(response)
+
+    decorated = decorate_candidate_response("tools/list", response, server_version="3.28.0")
+
+    assert response == original
+    assert [tool["name"] for tool in decorated["result"]["tools"]] == ["alpha", "zeta"]
+    assert decorated["result"]["resultType"] == "complete"
+    assert decorated["result"]["ttlMs"] == 300_000
+    assert decorated["result"]["cacheScope"] == "private"
+    assert decorated["result"]["_meta"]["io.modelcontextprotocol/serverInfo"] == {
+        "name": "kicad-mcp-pro",
+        "version": "3.28.0",
+    }
+
+
+def test_decorate_candidate_response_marks_resource_reads_private() -> None:
+    response = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {"contents": [{"uri": "kicad://project/current", "text": "secret"}]},
+    }
+
+    decorated = decorate_candidate_response("resources/read", response, server_version="3.28.0")
+
+    assert decorated["result"]["ttlMs"] == 60_000
+    assert decorated["result"]["cacheScope"] == "private"
+
+
+def test_decorate_candidate_response_does_not_modify_errors() -> None:
+    response = {"jsonrpc": "2.0", "id": 2, "error": {"code": -32601, "message": "missing"}}
+
+    assert decorate_candidate_response("tools/call", response, server_version="3.28.0") == response
+
+
+def test_jsonrpc_error_response_preserves_request_id_and_candidate_error_data() -> None:
+    error = ProtocolValidationError(
+        -32020,
+        "Header mismatch",
+        data={"header": "Mcp-Method"},
+    )
+
+    response = jsonrpc_error_response(error, request_id="req-7")
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "req-7",
+        "error": {
+            "code": -32020,
+            "message": "Header mismatch",
+            "data": {"header": "Mcp-Method"},
+        },
+    }

--- a/tests/unit/test_protocol_compat.py
+++ b/tests/unit/test_protocol_compat.py
@@ -65,6 +65,26 @@ def test_validate_candidate_request_accepts_stateless_list_request() -> None:
     assert validated.request_id == 1
 
 
+def test_validate_candidate_request_requires_jsonrpc_2_0() -> None:
+    request = candidate_request()
+    request["jsonrpc"] = "1.0"
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(candidate_headers(), request)
+
+    assert_protocol_error(raised.value, code=-32600, fragment="jsonrpc")
+
+
+@pytest.mark.parametrize("request_id", [None, True, 1.5, {"nested": "id"}])
+def test_validate_candidate_request_requires_a_json_rpc_request_id(request_id: object) -> None:
+    request = candidate_request(request_id=request_id)
+
+    with pytest.raises(ProtocolValidationError) as raised:
+        validate_candidate_request(candidate_headers(), request)
+
+    assert_protocol_error(raised.value, code=-32600, fragment="id")
+
+
 def test_validate_candidate_request_requires_candidate_protocol_version() -> None:
     headers = candidate_headers()
     headers["MCP-Protocol-Version"] = "2025-11-25"

--- a/tests/unit/test_workflow_tooling.py
+++ b/tests/unit/test_workflow_tooling.py
@@ -49,7 +49,7 @@ def test_workflow_policy_runs_actionlint_and_zizmor_in_required_gate() -> None:
     assert "scripts/workflow_security.py --min-severity high" in workflow
     assert (
         "needs: [changes, mcp-server, coverage, mcp-npm, protocol-schemas, "
-        "workflow-policy, security]" in workflow
+        "mcp-2026-compat, workflow-policy, security]" in workflow
     )
 
 


### PR DESCRIPTION
## Summary

- keep MCP `2025-11-25` as the stable default and public registry contract
- add an explicitly opt-in `2026-07-28-rc` compatibility lane at the Streamable HTTP boundary
- validate the candidate protocol version, `Mcp-Method`, `Mcp-Name`, JSON-RPC envelopes, and required per-request metadata
- provide direct stateless `server/discover`, tool discovery, and tool-call support while adapting internally to the stable MCP Python SDK
- add candidate `resultType`, server identity, and private cache metadata without advertising unimplemented Tasks or Apps extensions
- fail closed for legacy initialization, protocol sessions, stateful HTTP, legacy SSE, and the legacy Tasks implementation
- preserve authentication before protocol diagnostics and retain existing profile, operating-mode, and runtime capability filtering
- add pinned release-candidate contract fixtures, actual HTTP host smoke tests, an independent required CI job, ADR-0006, and operator rollout/rollback documentation

## Compatibility and rollout

The production default is unchanged. `server.json` continues to advertise only MCP `2025-11-25`, and no prerelease MCP SDK dependency is introduced.

The candidate lane requires all of the following:

```bash
KICAD_MCP_TRANSPORT=streamable-http
KICAD_MCP_PROTOCOL_LANE=2026-07-28-rc
KICAD_MCP_STATEFUL_HTTP=0
```

Public metadata may move to `2026-07-28` only after the final specification, stable SDK support, supported-host smoke tests, extension decisions, and rollback verification satisfy the release gates in ADR-0006.

## Verification

- `corepack pnpm run check:meta`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `uv run --all-extras python scripts/run_pytest.py unit`
- candidate protocol unit and HTTP contract suites
- actual Uvicorn HTTP smoke tests for ChatGPT-style and VS Code-style clients
- stable MCP `2025-11-25` protocol and manifest regression suites
- `corepack pnpm run package:check`
- GitHub Actions policy, actionlint, and Zizmor checks
- `mkdocs build --strict`

Closes #410