### PR TITLE
refactor(schematic): extract topology domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-topology-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-topology-service.md
@@ -24,11 +24,11 @@
 - Create: `tests/unit/test_schematic_topology_service.py`
 - Create: `src/kicad_mcp/schematic/topology.py`
 
-- [ ] Write failing direct tests for hierarchy listing, sheet details, connectivity summaries, net tracing, diagnostics, warnings, and missing results.
-- [ ] Run the tests and verify they fail because the module is absent.
-- [ ] Implement `SchematicTopologyService` with injected loader, diagnostics, connectivity, child discovery, parser, and warning callables.
-- [ ] Run the tests and verify they pass.
-- [ ] Commit the service and tests.
+- [x] Write failing direct tests for hierarchy listing, sheet details, connectivity summaries, net tracing, diagnostics, warnings, and missing results.
+- [x] Run the tests and verify they fail because the module is absent.
+- [x] Implement `SchematicTopologyService` with injected loader, diagnostics, connectivity, child discovery, parser, and warning callables.
+- [x] Run the tests and verify they pass.
+- [x] Commit the service and tests.
 
 ### Task 2: Add the thin registration adapter
 
@@ -37,11 +37,11 @@
 - Create: `src/kicad_mcp/tools/schematic_topology.py`
 - Modify: `src/kicad_mcp/tools/schematic.py`
 
-- [ ] Write failing registration tests for exact names, descriptions, schemas, validation, and delegation.
-- [ ] Implement the adapter and wire it from the composition root.
-- [ ] Remove the four legacy nested tool bodies.
-- [ ] Run focused registration and schematic integration tests.
-- [ ] Commit the adapter tranche.
+- [x] Write failing registration tests for exact names, descriptions, schemas, validation, and delegation.
+- [x] Implement the adapter and wire it from the composition root.
+- [x] Remove the four legacy nested tool bodies.
+- [x] Run focused registration and schematic integration tests.
+- [x] Commit the adapter tranche.
 
 ### Task 3: Enforce architecture and surface stability
 
@@ -49,15 +49,25 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_topology_architecture.py`
 
-- [ ] Write failing architecture tests for module tracking, purity, monolith-import prevention, and the 300-line limit.
-- [ ] Extend the architecture checker.
-- [ ] Verify the public snapshot and generated tool docs remain unchanged.
-- [ ] Commit the architecture guard.
+- [x] Write failing architecture tests for module tracking, purity, monolith-import prevention, and the 300-line limit.
+- [x] Extend the architecture checker.
+- [x] Verify the public snapshot and generated tool docs remain unchanged.
+- [x] Commit the architecture guard.
 
 ### Task 4: Verify, publish, and review
 
-- [ ] Run metadata, format, lint, mypy, scoped Pyright, full unit, workflow-security, strict docs, snapshot, and representative performance gates.
-- [ ] Record line-count and exact public-surface evidence.
+- [x] Run metadata, format, lint, mypy, scoped Pyright, full unit, workflow-security, strict docs, snapshot, and representative performance gates.
+- [x] Record line-count and exact public-surface evidence.
 - [ ] Push and open a professional English PR referencing #434.
 - [ ] Inspect all bot/agent comments, reviews, and review threads; resolve actionable findings.
 - [ ] Merge only after all required checks pass.
+
+## Verification Evidence
+
+- The exact public metadata for all four extracted tools is identical to `main`: names, descriptions, input schemas, and annotations all match.
+- `tests/integration/test_tool_surface_snapshot.py` passes without snapshot regeneration.
+- The main schematic `register()` span decreased from 3,273 to 3,145 lines; the new topology adapter `register()` spans 31 lines.
+- Direct service, registration, architecture, and schematic integration coverage passes.
+- The full unit suite completed successfully with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, and the committed MCP latency benchmark all pass.
+- No runtime dependency, mutation behavior, connectivity algorithm, or backend-selection behavior changed.

--- a/docs/superpowers/plans/2026-07-23-schematic-topology-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-topology-service.md
@@ -1,0 +1,63 @@
+# Schematic Topology Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extract four sheet-hierarchy and connectivity tools into a FastMCP-free topology service and a sub-300-line registration adapter without changing the public MCP surface.
+
+**Architecture:** `kicad_mcp.schematic.topology` owns deterministic result construction behind injected callables. `kicad_mcp.tools.schematic_topology` owns public decorators and Pydantic argument validation. `tools.schematic.register()` only supplies existing private dependencies.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, pytest, Ruff, mypy, existing architecture and public-surface gates.
+
+## Global Constraints
+
+- Preserve all public names, schemas, descriptions, annotations, messages, ordering, and validation behavior.
+- Keep the domain service free of FastMCP, connection state, GUI dependencies, and `tools.schematic` imports.
+- Keep `tools.schematic_topology.register()` at or below 300 lines.
+- Do not change connectivity algorithms or mutation behavior.
+- Do not close #434.
+
+---
+
+### Task 1: Extract the pure topology service
+
+**Files:**
+- Create: `tests/unit/test_schematic_topology_service.py`
+- Create: `src/kicad_mcp/schematic/topology.py`
+
+- [ ] Write failing direct tests for hierarchy listing, sheet details, connectivity summaries, net tracing, diagnostics, warnings, and missing results.
+- [ ] Run the tests and verify they fail because the module is absent.
+- [ ] Implement `SchematicTopologyService` with injected loader, diagnostics, connectivity, child discovery, parser, and warning callables.
+- [ ] Run the tests and verify they pass.
+- [ ] Commit the service and tests.
+
+### Task 2: Add the thin registration adapter
+
+**Files:**
+- Create: `tests/unit/test_schematic_topology_registration.py`
+- Create: `src/kicad_mcp/tools/schematic_topology.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+- [ ] Write failing registration tests for exact names, descriptions, schemas, validation, and delegation.
+- [ ] Implement the adapter and wire it from the composition root.
+- [ ] Remove the four legacy nested tool bodies.
+- [ ] Run focused registration and schematic integration tests.
+- [ ] Commit the adapter tranche.
+
+### Task 3: Enforce architecture and surface stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_topology_architecture.py`
+
+- [ ] Write failing architecture tests for module tracking, purity, monolith-import prevention, and the 300-line limit.
+- [ ] Extend the architecture checker.
+- [ ] Verify the public snapshot and generated tool docs remain unchanged.
+- [ ] Commit the architecture guard.
+
+### Task 4: Verify, publish, and review
+
+- [ ] Run metadata, format, lint, mypy, scoped Pyright, full unit, workflow-security, strict docs, snapshot, and representative performance gates.
+- [ ] Record line-count and exact public-surface evidence.
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect all bot/agent comments, reviews, and review threads; resolve actionable findings.
+- [ ] Merge only after all required checks pass.

--- a/docs/superpowers/specs/2026-07-23-schematic-topology-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-topology-service-design.md
@@ -1,0 +1,58 @@
+# Schematic Topology Service Extraction Design
+
+**Status:** Accepted
+**Date:** 2026-07-23
+**Tracking issue:** #434
+
+## Context
+
+PR #443 established a pure schematic inspection service and a thin FastMCP adapter. The next bounded tranche from the accepted #434 rollout is sheet hierarchy and connectivity inspection, which remains embedded in `tools.schematic.register()`.
+
+## Decision
+
+Create:
+
+- `kicad_mcp.schematic.topology.SchematicTopologyService` for deterministic hierarchy and connectivity result construction;
+- `kicad_mcp.tools.schematic_topology` for the unchanged FastMCP declarations and argument validation.
+
+The composition root injects the existing schematic loader, diagnostics formatter, connectivity builder, child-sheet iterator, parser, and structured warning callback. The service does not import FastMCP, server state, KiCad connection state, GUI libraries, or the schematic monolith.
+
+## Tool Boundary
+
+This tranche moves four read-only tools:
+
+- `sch_list_sheets`
+- `sch_get_sheet_info`
+- `sch_get_connectivity_graph`
+- `sch_trace_net`
+
+## Compatibility Rules
+
+- Preserve names, signatures, descriptions, schemas, annotations, output strings, ordering, and error transformation.
+- Preserve warning emission for hierarchy and sheet-detail loader failures.
+- Do not modify connectivity construction, file parsing, child discovery, or any mutation path.
+- Do not regenerate the public tool-surface snapshot.
+- Keep the new registration function at or below 300 lines.
+- Reference but do not close #434.
+
+## Interfaces
+
+`SchematicTopologyService` receives typed callables for:
+
+- loading a schematic object with a sheet manager;
+- decorating diagnostic messages;
+- building normalized connectivity groups;
+- enumerating child-sheet paths;
+- parsing a schematic path;
+- emitting structured warning events.
+
+Its methods are `list_sheets`, `sheet_info`, `connectivity_graph`, and `trace_net`.
+
+`SchematicTopologyDependencies` carries the active schematic path provider and service. The adapter retains `GetSheetInfoInput` and `TraceNetInput` validation before delegation.
+
+## Testing
+
+- direct service tests without FastMCP;
+- registration tests for exact names, schemas, descriptions, validation, and delegation;
+- architecture checks for purity, no adapter-to-monolith import, and the 300-line limit;
+- existing schematic integration, snapshot, generated docs, type, coverage, security, and performance gates.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -24,6 +24,11 @@ DOMAIN_MODULES = {
     "kicad_mcp.models.sch_transaction": SRC_ROOT / "kicad_mcp" / "models" / "sch_transaction.py",
     "kicad_mcp.models.visual_qa": SRC_ROOT / "kicad_mcp" / "models" / "visual_qa.py",
     "kicad_mcp.schematic.inspection": SRC_ROOT / "kicad_mcp" / "schematic" / "inspection.py",
+    "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
+    "kicad_mcp.tools.schematic_topology": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_topology.py",
     "kicad_mcp.tools.schematic_inspection": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -45,6 +50,7 @@ PURE_HELPERS = {
     "kicad_mcp.models.sch_transaction",
     "kicad_mcp.models.visual_qa",
     "kicad_mcp.schematic.inspection",
+    "kicad_mcp.schematic.topology",
     "kicad_mcp.tools.schematic_constants",
 }
 
@@ -61,10 +67,12 @@ FORBIDDEN_PURE_IMPORT_PREFIXES = (
 
 ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
 }
 
 REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_inspection": 300,
+    "kicad_mcp.tools.schematic_topology": 300,
 }
 
 

--- a/src/kicad_mcp/schematic/topology.py
+++ b/src/kicad_mcp/schematic/topology.py
@@ -1,0 +1,178 @@
+"""Pure result construction for schematic hierarchy and connectivity inspection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class SheetManagerLike(Protocol):
+    """Sheet-manager surface consumed by topology inspection."""
+
+    def get_sheet_hierarchy(self) -> Mapping[str, Any]: ...
+
+    def get_sheet_by_name(self, sheet_name: str) -> Mapping[str, Any] | None: ...
+
+
+class LoadedSchematicLike(Protocol):
+    """Loaded schematic surface consumed by topology inspection."""
+
+    @property
+    def sheets(self) -> SheetManagerLike: ...
+
+
+class Warn(Protocol):
+    """Structured warning callback supplied by the composition root."""
+
+    def __call__(self, event: str, **context: object) -> None: ...
+
+
+type LoadSchematic = Callable[[Path], LoadedSchematicLike]
+type WithDiagnostics = Callable[[str, Path], str]
+type BuildConnectivityGroups = Callable[[Path], list[dict[str, Any]]]
+type IterChildSheetPaths = Callable[[Path], list[tuple[str, Path]]]
+type ParseSchematic = Callable[[Path], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class SchematicTopologyService:
+    """Format hierarchy and connectivity results from injected dependencies."""
+
+    load_schematic: LoadSchematic
+    with_diagnostics: WithDiagnostics
+    build_connectivity_groups: BuildConnectivityGroups
+    iter_child_sheet_paths: IterChildSheetPaths
+    parse_schematic: ParseSchematic
+    warn: Warn
+
+    def list_sheets(self, schematic_file: Path) -> str:
+        """List direct child sheets from the active top-level schematic."""
+        try:
+            schematic = self.load_schematic(schematic_file)
+            hierarchy = schematic.sheets.get_sheet_hierarchy()
+        except Exception as exc:
+            self.warn(
+                "schematic_list_sheets_failed",
+                schematic_file=str(schematic_file),
+                error=str(exc),
+            )
+            return self.with_diagnostics(
+                f"Could not inspect sheet hierarchy: {exc}",
+                schematic_file,
+            )
+
+        children = hierarchy.get("root", {}).get("children", [])
+        if not children:
+            return self.with_diagnostics(
+                "The active schematic has no child sheets.",
+                schematic_file,
+            )
+
+        lines = [f"Child sheets ({len(children)} total):"]
+        for child in children:
+            position = child.get("position")
+            size = child.get("size")
+            lines.append(
+                f"- {child.get('name')} -> {child.get('filename')} "
+                f"@ ({float(position.x):.2f}, {float(position.y):.2f}) "
+                f"size=({float(size.x):.2f}, {float(size.y):.2f})"
+            )
+        return "\n".join(lines)
+
+    def sheet_info(self, schematic_file: Path, sheet_name: str) -> str:
+        """Return metadata for one direct child sheet."""
+        try:
+            schematic = self.load_schematic(schematic_file)
+            info = schematic.sheets.get_sheet_by_name(sheet_name)
+        except Exception as exc:
+            self.warn(
+                "schematic_get_sheet_info_failed",
+                schematic_file=str(schematic_file),
+                sheet_name=sheet_name,
+                error=str(exc),
+            )
+            return f"Could not inspect sheet '{sheet_name}': {exc}"
+
+        if info is None:
+            return f"Sheet '{sheet_name}' was not found."
+
+        pins = info.get("pins", [])
+        position = info.get("position", {})
+        size = info.get("size", {})
+        lines = [f"Sheet '{sheet_name}'"]
+        lines.append(f"- File: {info.get('filename')}")
+        lines.append(
+            "- Position: "
+            f"({float(position.get('x', 0.0)):.2f}, {float(position.get('y', 0.0)):.2f}) mm"
+        )
+        lines.append(
+            "- Size: "
+            f"({float(size.get('width', 0.0)):.2f}, {float(size.get('height', 0.0)):.2f}) mm"
+        )
+        lines.append(f"- Page: {info.get('page_number', '?')}")
+        lines.append(f"- Pins: {len(pins)}")
+        return "\n".join(lines)
+
+    def connectivity_graph(self, schematic_file: Path) -> str:
+        """Summarize normalized connectivity groups."""
+        groups = self.build_connectivity_groups(schematic_file)
+        if not groups:
+            return self.with_diagnostics(
+                "The active schematic has no connectivity to summarize.",
+                schematic_file,
+            )
+
+        lines = [f"Connectivity groups ({len(groups)} total):"]
+        for index, group in enumerate(groups, start=1):
+            if group["names"]:
+                names = ", ".join(group["names"])
+            elif group.get("no_connect"):
+                names = "~no-connect"
+            else:
+                names = "~unnamed"
+            pins = (
+                ", ".join(f"{item['reference']}:{item['pin']}" for item in group["pins"]) or "none"
+            )
+            lines.append(f"- Group {index}: {names} | pins={pins} | points={len(group['points'])}")
+        return "\n".join(lines)
+
+    def trace_net(self, schematic_file: Path, net_name: str) -> str:
+        """Trace a named net through the active schematic and child sheets."""
+        local_matches = [
+            group
+            for group in self.build_connectivity_groups(schematic_file)
+            if net_name in group["names"]
+        ]
+
+        child_matches: list[str] = []
+        for display_name, child_path in self.iter_child_sheet_paths(schematic_file):
+            if not child_path.exists():
+                continue
+            child_data = self.parse_schematic(child_path)
+            matched_labels = [
+                label for label in child_data["labels"] if str(label["name"]) == net_name
+            ]
+            matched_power = [
+                symbol for symbol in child_data["power_symbols"] if str(symbol["value"]) == net_name
+            ]
+            if matched_labels or matched_power:
+                child_matches.append(
+                    f"- {display_name}: labels={len(matched_labels)} "
+                    f"power_symbols={len(matched_power)}"
+                )
+
+        if not local_matches and not child_matches:
+            return f"Net '{net_name}' was not found in the active schematic or child sheets."
+
+        lines = [f"Trace for net '{net_name}':"]
+        for index, group in enumerate(local_matches, start=1):
+            pins = (
+                ", ".join(f"{item['reference']}:{item['pin']}" for item in group["pins"]) or "none"
+            )
+            lines.append(f"- Top level match {index}: pins={pins} points={len(group['points'])}")
+        if child_matches:
+            lines.append("Child sheet matches:")
+            lines.extend(child_matches)
+        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -38,20 +38,19 @@ from ..models.schematic import (
     CreateSheetInput,
     DeleteSymbolInput,
     DeleteWireInput,
-    GetSheetInfoInput,
     GlobalLabelInput,
     HierarchicalLabelInput,
     ModifyLabelInput,
     MoveSymbolInput,
     PowerSymbolInput,
     RouteWireBetweenPinsInput,
-    TraceNetInput,
     UpdatePropertiesInput,
 )
 from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
 from ..schematic.inspection import SchematicInspectionService
+from ..schematic.topology import SchematicTopologyService
 from ..utils.cache import clear_ttl_cache, ttl_cache
 from ..utils.field_placer import FieldSpec, autoplace_fields
 from ..utils.geometry import Box as GeoBox
@@ -64,7 +63,7 @@ from ..utils.sexpr import (
     _sexpr_string,
     _unescape_sexpr_string,
 )
-from . import schematic_inspection
+from . import schematic_inspection, schematic_topology
 from .metadata import headless_compatible
 from .schematic_constants import (
     _SCHEMATIC_STATE_DIRNAME,
@@ -5451,6 +5450,22 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    topology_service = SchematicTopologyService(
+        load_schematic=_load_kicad_schematic,
+        with_diagnostics=_with_schematic_diagnostics,
+        build_connectivity_groups=_build_connectivity_groups,
+        iter_child_sheet_paths=_iter_child_sheet_paths,
+        parse_schematic=parse_schematic_file,
+        warn=logger.warning,
+    )
+    schematic_topology.register(
+        mcp,
+        schematic_topology.SchematicTopologyDependencies(
+            active_schematic_file=_get_schematic_file,
+            service=topology_service,
+        ),
+    )
+
     @mcp.tool()
     @headless_compatible
     def sch_add_symbol(
@@ -6998,79 +7013,6 @@ def register(mcp: FastMCP) -> None:
         return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
 
     @mcp.tool()
-    def sch_list_sheets() -> str:
-        """List child sheets from the active top-level schematic."""
-        sch_file = _get_schematic_file()
-        try:
-            schematic = _load_kicad_schematic(sch_file)
-            hierarchy = schematic.sheets.get_sheet_hierarchy()
-        except Exception as exc:
-            logger.warning(
-                "schematic_list_sheets_failed",
-                schematic_file=str(sch_file),
-                error=str(exc),
-            )
-            return _with_schematic_diagnostics(
-                f"Could not inspect sheet hierarchy: {exc}",
-                sch_file,
-            )
-
-        children = hierarchy.get("root", {}).get("children", [])
-        if not children:
-            return _with_schematic_diagnostics(
-                "The active schematic has no child sheets.",
-                sch_file,
-            )
-
-        lines = [f"Child sheets ({len(children)} total):"]
-        for child in children:
-            position = child.get("position")
-            size = child.get("size")
-            lines.append(
-                f"- {child.get('name')} -> {child.get('filename')} "
-                f"@ ({float(position.x):.2f}, {float(position.y):.2f}) "
-                f"size=({float(size.x):.2f}, {float(size.y):.2f})"
-            )
-        return "\n".join(lines)
-
-    @mcp.tool()
-    def sch_get_sheet_info(sheet_name: str) -> str:
-        """Return metadata for a specific child sheet."""
-        payload = GetSheetInfoInput(sheet_name=sheet_name)
-        sch_file = _get_schematic_file()
-        try:
-            schematic = _load_kicad_schematic(sch_file)
-            info = schematic.sheets.get_sheet_by_name(payload.sheet_name)
-        except Exception as exc:
-            logger.warning(
-                "schematic_get_sheet_info_failed",
-                schematic_file=str(sch_file),
-                sheet_name=payload.sheet_name,
-                error=str(exc),
-            )
-            return f"Could not inspect sheet '{payload.sheet_name}': {exc}"
-
-        if info is None:
-            return f"Sheet '{payload.sheet_name}' was not found."
-
-        pins = info.get("pins", [])
-        position = info.get("position", {})
-        size = info.get("size", {})
-        lines = [f"Sheet '{payload.sheet_name}'"]
-        lines.append(f"- File: {info.get('filename')}")
-        lines.append(
-            "- Position: "
-            f"({float(position.get('x', 0.0)):.2f}, {float(position.get('y', 0.0)):.2f}) mm"
-        )
-        lines.append(
-            "- Size: "
-            f"({float(size.get('width', 0.0)):.2f}, {float(size.get('height', 0.0)):.2f}) mm"
-        )
-        lines.append(f"- Page: {info.get('page_number', '?')}")
-        lines.append(f"- Pins: {len(pins)}")
-        return "\n".join(lines)
-
-    @mcp.tool()
     def sch_route_wire_between_pins(
         ref1: str,
         pin1: str,
@@ -7154,77 +7096,6 @@ def register(mcp: FastMCP) -> None:
         summary = run_auto_add_missing_junctions()
         result = _reload_schematic()
         return f"{result}\n{summary}"
-
-    @mcp.tool()
-    def sch_get_connectivity_graph() -> str:
-        """Summarize the active schematic as a textual net connectivity graph."""
-        sch_file = _get_schematic_file()
-        groups = _build_connectivity_groups(sch_file)
-        if not groups:
-            return _with_schematic_diagnostics(
-                "The active schematic has no connectivity to summarize.",
-                sch_file,
-            )
-
-        lines = [f"Connectivity groups ({len(groups)} total):"]
-        for index, group in enumerate(groups, start=1):
-            if group["names"]:
-                names = ", ".join(group["names"])
-            elif group.get("no_connect"):
-                names = "~no-connect"
-            else:
-                names = "~unnamed"
-            pins = (
-                ", ".join(f"{item['reference']}:{item['pin']}" for item in group["pins"]) or "none"
-            )
-            lines.append(f"- Group {index}: {names} | pins={pins} | points={len(group['points'])}")
-        return "\n".join(lines)
-
-    @mcp.tool()
-    def sch_trace_net(net_name: str) -> str:
-        """Trace a named net through the active schematic and matching child sheets."""
-        payload = TraceNetInput(net_name=net_name)
-        target = payload.net_name
-        local_matches = [
-            group
-            for group in _build_connectivity_groups(_get_schematic_file())
-            if target in group["names"]
-        ]
-
-        child_matches: list[str] = []
-        for display_name, child_path in _iter_child_sheet_paths(_get_schematic_file()):
-            if not child_path.exists():
-                continue
-            child_data = parse_schematic_file(child_path)
-            matched_labels = [
-                label for label in child_data["labels"] if str(label["name"]) == target
-            ]
-            matched_power = [
-                symbol for symbol in child_data["power_symbols"] if str(symbol["value"]) == target
-            ]
-            if matched_labels or matched_power:
-                child_matches.append(
-                    f"- {display_name}: labels={len(matched_labels)} "
-                    f"power_symbols={len(matched_power)}"
-                )
-
-        if not local_matches and not child_matches:
-            return f"Net '{target}' was not found in the active schematic or child sheets."
-
-        lines = [f"Trace for net '{target}':"]
-        if local_matches:
-            for index, group in enumerate(local_matches, start=1):
-                pins = (
-                    ", ".join(f"{item['reference']}:{item['pin']}" for item in group["pins"])
-                    or "none"
-                )
-                lines.append(
-                    f"- Top level match {index}: pins={pins} points={len(group['points'])}"
-                )
-        if child_matches:
-            lines.append("Child sheet matches:")
-            lines.extend(child_matches)
-        return "\n".join(lines)
 
     @mcp.tool()
     def sch_auto_place_symbols(

--- a/src/kicad_mcp/tools/schematic_topology.py
+++ b/src/kicad_mcp/tools/schematic_topology.py
@@ -1,0 +1,55 @@
+"""Thin FastMCP adapters for schematic hierarchy and connectivity inspection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from ..models.schematic import GetSheetInfoInput, TraceNetInput
+from ..schematic.topology import SchematicTopologyService
+
+type ActiveSchematicFile = Callable[[], Path]
+
+
+@dataclass(frozen=True)
+class SchematicTopologyDependencies:
+    """Existing topology dependencies injected by the composition root."""
+
+    active_schematic_file: ActiveSchematicFile
+    service: SchematicTopologyService
+
+
+def register(mcp: FastMCP, dependencies: SchematicTopologyDependencies) -> None:
+    """Register the read-only schematic topology tranche."""
+    service = dependencies.service
+
+    @mcp.tool()
+    def sch_list_sheets() -> str:
+        """List child sheets from the active top-level schematic."""
+        return service.list_sheets(dependencies.active_schematic_file())
+
+    @mcp.tool()
+    def sch_get_sheet_info(sheet_name: str) -> str:
+        """Return metadata for a specific child sheet."""
+        payload = GetSheetInfoInput(sheet_name=sheet_name)
+        return service.sheet_info(
+            dependencies.active_schematic_file(),
+            payload.sheet_name,
+        )
+
+    @mcp.tool()
+    def sch_get_connectivity_graph() -> str:
+        """Summarize the active schematic as a textual net connectivity graph."""
+        return service.connectivity_graph(dependencies.active_schematic_file())
+
+    @mcp.tool()
+    def sch_trace_net(net_name: str) -> str:
+        """Trace a named net through the active schematic and matching child sheets."""
+        payload = TraceNetInput(net_name=net_name)
+        return service.trace_net(
+            dependencies.active_schematic_file(),
+            payload.net_name,
+        )

--- a/tests/unit/test_schematic_topology_architecture.py
+++ b/tests/unit/test_schematic_topology_architecture.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_schematic_topology_modules() -> None:
+    assert "kicad_mcp.schematic.topology" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.topology" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_topology" in boundaries.DOMAIN_MODULES
+
+
+def test_schematic_topology_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_topology.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+
+
+def test_schematic_topology_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_topology.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_topology"] == 300

--- a/tests/unit/test_schematic_topology_registration.py
+++ b/tests/unit/test_schematic_topology_registration.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
+
+from kicad_mcp.tools.schematic_topology import (
+    SchematicTopologyDependencies,
+    register,
+)
+
+
+class FakeTopologyService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def list_sheets(self, path: Path) -> str:
+        self.calls.append(("list_sheets", (path,)))
+        return "sheets"
+
+    def sheet_info(self, path: Path, sheet_name: str) -> str:
+        self.calls.append(("sheet_info", (path, sheet_name)))
+        return "sheet-info"
+
+    def connectivity_graph(self, path: Path) -> str:
+        self.calls.append(("connectivity_graph", (path,)))
+        return "graph"
+
+    def trace_net(self, path: Path, net_name: str) -> str:
+        self.calls.append(("trace_net", (path, net_name)))
+        return "trace"
+
+
+def _registered() -> tuple[FastMCP, FakeTopologyService]:
+    server = FastMCP("schematic-topology-test")
+    service = FakeTopologyService()
+    register(
+        server,
+        SchematicTopologyDependencies(
+            active_schematic_file=lambda: Path("active.kicad_sch"),
+            service=service,
+        ),
+    )
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_list_sheets",
+        "sch_get_sheet_info",
+        "sch_get_connectivity_graph",
+        "sch_trace_net",
+    }
+    assert tools["sch_list_sheets"].description == (
+        "List child sheets from the active top-level schematic."
+    )
+    assert tools["sch_get_sheet_info"].description == (
+        "Return metadata for a specific child sheet."
+    )
+    assert tools["sch_get_connectivity_graph"].description == (
+        "Summarize the active schematic as a textual net connectivity graph."
+    )
+    assert tools["sch_trace_net"].description == (
+        "Trace a named net through the active schematic and matching child sheets."
+    )
+    assert tools["sch_list_sheets"].parameters["properties"] == {}
+    assert tools["sch_get_sheet_info"].parameters["required"] == ["sheet_name"]
+    assert tools["sch_trace_net"].parameters["required"] == ["net_name"]
+    assert tools["sch_get_sheet_info"].parameters["properties"]["sheet_name"] == {
+        "title": "Sheet Name",
+        "type": "string",
+    }
+    assert tools["sch_trace_net"].parameters["properties"]["net_name"] == {
+        "title": "Net Name",
+        "type": "string",
+    }
+
+
+def test_registration_delegates_to_active_schematic() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_list_sheets"].fn() == "sheets"
+    assert tools["sch_get_sheet_info"].fn(sheet_name="Power") == "sheet-info"
+    assert tools["sch_get_connectivity_graph"].fn() == "graph"
+    assert tools["sch_trace_net"].fn(net_name="VCC") == "trace"
+    assert service.calls == [
+        ("list_sheets", (Path("active.kicad_sch"),)),
+        ("sheet_info", (Path("active.kicad_sch"), "Power")),
+        ("connectivity_graph", (Path("active.kicad_sch"),)),
+        ("trace_net", (Path("active.kicad_sch"), "VCC")),
+    ]
+
+
+def test_registration_preserves_pydantic_validation() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    with pytest.raises(ValidationError):
+        tools["sch_get_sheet_info"].fn(sheet_name="")
+    with pytest.raises(ValidationError):
+        tools["sch_trace_net"].fn(net_name="")

--- a/tests/unit/test_schematic_topology_service.py
+++ b/tests/unit/test_schematic_topology_service.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from kicad_mcp.schematic.topology import SchematicTopologyService
+
+
+class _SheetManager:
+    def __init__(
+        self,
+        *,
+        children: list[dict[str, object]] | None = None,
+        sheet_info: dict[str, object] | None = None,
+    ) -> None:
+        self.children = children or []
+        self.sheet_info = sheet_info
+
+    def get_sheet_hierarchy(self) -> dict[str, object]:
+        return {"root": {"children": self.children}}
+
+    def get_sheet_by_name(self, sheet_name: str) -> dict[str, object] | None:
+        return self.sheet_info if sheet_name == "Power" else None
+
+
+class _LoadedSchematic:
+    def __init__(self, sheets: _SheetManager) -> None:
+        self.sheets = sheets
+
+
+def _service(
+    *,
+    loaded: _LoadedSchematic | Exception | None = None,
+    groups: list[dict[str, Any]] | None = None,
+    child_paths: list[tuple[str, Path]] | None = None,
+    parsed: dict[Path, dict[str, Any]] | None = None,
+    warnings: list[tuple[str, dict[str, object]]] | None = None,
+) -> SchematicTopologyService:
+    warning_records = warnings if warnings is not None else []
+
+    def load_schematic(_path: Path) -> _LoadedSchematic:
+        if isinstance(loaded, Exception):
+            raise loaded
+        return loaded or _LoadedSchematic(_SheetManager())
+
+    return SchematicTopologyService(
+        load_schematic=load_schematic,
+        with_diagnostics=lambda message, path: f"{message}\nDiagnostics: {path.name}",
+        build_connectivity_groups=lambda _path: groups or [],
+        iter_child_sheet_paths=lambda _path: child_paths or [],
+        parse_schematic=lambda path: (parsed or {})[path],
+        warn=lambda event, **context: warning_records.append((event, context)),
+    )
+
+
+def test_list_sheets_formats_hierarchy() -> None:
+    children = [
+        {
+            "name": "Power",
+            "filename": "power.kicad_sch",
+            "position": SimpleNamespace(x=10.0, y=20.0),
+            "size": SimpleNamespace(x=50.0, y=30.0),
+        }
+    ]
+    service = _service(loaded=_LoadedSchematic(_SheetManager(children=children)))
+
+    assert service.list_sheets(Path("demo.kicad_sch")) == (
+        "Child sheets (1 total):\n- Power -> power.kicad_sch @ (10.00, 20.00) size=(50.00, 30.00)"
+    )
+
+
+def test_list_sheets_preserves_diagnostics_and_warning_on_load_failure() -> None:
+    warnings: list[tuple[str, dict[str, object]]] = []
+    service = _service(loaded=RuntimeError("broken hierarchy"), warnings=warnings)
+    path = Path("demo.kicad_sch")
+
+    assert service.list_sheets(path) == (
+        "Could not inspect sheet hierarchy: broken hierarchy\nDiagnostics: demo.kicad_sch"
+    )
+    assert warnings == [
+        (
+            "schematic_list_sheets_failed",
+            {"schematic_file": "demo.kicad_sch", "error": "broken hierarchy"},
+        )
+    ]
+
+
+def test_list_sheets_preserves_empty_hierarchy_diagnostics() -> None:
+    service = _service()
+
+    assert service.list_sheets(Path("demo.kicad_sch")) == (
+        "The active schematic has no child sheets.\nDiagnostics: demo.kicad_sch"
+    )
+
+
+def test_sheet_info_formats_existing_sheet() -> None:
+    info: dict[str, object] = {
+        "filename": "power.kicad_sch",
+        "position": {"x": 10.0, "y": 20.0},
+        "size": {"width": 50.0, "height": 30.0},
+        "page_number": "2",
+        "pins": [{"name": "VIN"}, {"name": "GND"}],
+    }
+    service = _service(loaded=_LoadedSchematic(_SheetManager(sheet_info=info)))
+
+    assert service.sheet_info(Path("demo.kicad_sch"), "Power") == (
+        "Sheet 'Power'\n"
+        "- File: power.kicad_sch\n"
+        "- Position: (10.00, 20.00) mm\n"
+        "- Size: (50.00, 30.00) mm\n"
+        "- Page: 2\n"
+        "- Pins: 2"
+    )
+
+
+def test_sheet_info_preserves_missing_and_failure_results() -> None:
+    service = _service()
+    assert service.sheet_info(Path("demo.kicad_sch"), "Missing") == (
+        "Sheet 'Missing' was not found."
+    )
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+    failing = _service(loaded=RuntimeError("bad sheet"), warnings=warnings)
+    assert failing.sheet_info(Path("demo.kicad_sch"), "Power") == (
+        "Could not inspect sheet 'Power': bad sheet"
+    )
+    assert warnings[0][0] == "schematic_get_sheet_info_failed"
+    assert warnings[0][1]["sheet_name"] == "Power"
+
+
+def test_connectivity_graph_formats_named_no_connect_and_unnamed_groups() -> None:
+    groups = [
+        {
+            "names": ["VCC"],
+            "pins": [{"reference": "U1", "pin": "1"}],
+            "points": [(1.0, 2.0), (3.0, 4.0)],
+            "no_connect": False,
+        },
+        {"names": [], "pins": [], "points": [(5.0, 6.0)], "no_connect": True},
+        {"names": [], "pins": [], "points": [(7.0, 8.0)], "no_connect": False},
+    ]
+    service = _service(groups=groups)
+
+    assert service.connectivity_graph(Path("demo.kicad_sch")) == (
+        "Connectivity groups (3 total):\n"
+        "- Group 1: VCC | pins=U1:1 | points=2\n"
+        "- Group 2: ~no-connect | pins=none | points=1\n"
+        "- Group 3: ~unnamed | pins=none | points=1"
+    )
+
+
+def test_connectivity_graph_preserves_empty_diagnostics() -> None:
+    service = _service()
+
+    assert service.connectivity_graph(Path("demo.kicad_sch")) == (
+        "The active schematic has no connectivity to summarize.\nDiagnostics: demo.kicad_sch"
+    )
+
+
+def test_trace_net_combines_top_level_and_child_sheet_matches(tmp_path: Path) -> None:
+    child = tmp_path / "power.kicad_sch"
+    child.write_text("(kicad_sch)\n", encoding="utf-8")
+    groups = [
+        {
+            "names": ["VCC"],
+            "pins": [
+                {"reference": "U1", "pin": "1"},
+                {"reference": "C1", "pin": "1"},
+            ],
+            "points": [(1.0, 2.0), (3.0, 4.0)],
+            "no_connect": False,
+        }
+    ]
+    parsed = {
+        child: {
+            "labels": [{"name": "VCC"}],
+            "power_symbols": [{"value": "VCC"}, {"value": "GND"}],
+        }
+    }
+    service = _service(
+        groups=groups,
+        child_paths=[("Power", child)],
+        parsed=parsed,
+    )
+
+    assert service.trace_net(Path("demo.kicad_sch"), "VCC") == (
+        "Trace for net 'VCC':\n"
+        "- Top level match 1: pins=U1:1, C1:1 points=2\n"
+        "Child sheet matches:\n"
+        "- Power: labels=1 power_symbols=1"
+    )
+
+
+def test_trace_net_preserves_not_found_result(tmp_path: Path) -> None:
+    missing_child = tmp_path / "missing.kicad_sch"
+    service = _service(child_paths=[("Missing", missing_child)])
+
+    assert service.trace_net(Path("demo.kicad_sch"), "NOPE") == (
+        "Net 'NOPE' was not found in the active schematic or child sheets."
+    )


### PR DESCRIPTION
## Summary

- extract sheet-hierarchy and connectivity result construction into a typed, FastMCP-free `SchematicTopologyService`
- add a 31-line registration adapter for `sch_list_sheets`, `sch_get_sheet_info`, `sch_get_connectivity_graph`, and `sch_trace_net`
- reduce the main schematic registration function from 3,273 to 3,145 lines while preserving the current composition root
- add architecture policy that keeps the topology service pure, prevents the adapter from importing the schematic monolith, and enforces the 300-line registration limit
- document the bounded design, implementation plan, verification evidence, and remaining #434 work

## Compatibility and safety

- public tool names, descriptions, input schemas, annotations, ordering, and result messages are unchanged
- exact metadata comparison against `main` is identical for all four extracted tools
- the committed tool-surface snapshot remains unchanged
- connectivity algorithms, mutation behavior, backend selection, and error propagation remain unchanged
- no runtime dependency is added
- this is the second bounded tranche of #434 and does not close the parent task

## Verification

- full unit suite passed with five expected skips
- focused topology service, registration, architecture, schematic integration, and tool-surface tests passed
- committed MCP `tools/list` latency benchmark passed
- metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, and strict MkDocs checks passed
- main schematic `register()` span: 3,273 → 3,145 lines
- topology adapter `register()` span: 31 lines

## Review notes

Repository-wide strict Pyright findings outside the extracted pure service remain pre-existing; the new topology service reports zero scoped strict Pyright findings. CI continues to enforce the repository's configured mypy gate.

Refs #434