### PR TITLE
refactor(schematic): extract symbol mutation domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-symbol-mutation-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-symbol-mutation-service.md
@@ -1,6 +1,6 @@
 # Schematic Symbol Mutation Service Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Extract four non-destructive symbol property and placement tools into a FastMCP-free service and a sub-300-line registration adapter without changing the public MCP surface.
 
@@ -29,11 +29,11 @@
 - Produces methods: `update_properties`, `set_dnp`, and `move_symbol`.
 - Consumes injected property update, DNP update, reload, snap, transaction, lookup, and block-shift callables.
 
-- [ ] **Step 1: Write failing direct service tests**
+- [x] **Step 1: Write failing direct service tests**
 
 Cover exact update/DNP output composition, move success with and without a snap notice, missing references, shift deltas, transaction flags, and reload ordering.
 
-- [ ] **Step 2: Run the service tests and verify RED**
+- [x] **Step 2: Run the service tests and verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_symbol_mutation_service.py
@@ -41,15 +41,15 @@ uv run --all-extras pytest -q tests/unit/test_schematic_symbol_mutation_service.
 
 Expected: collection failure because `kicad_mcp.schematic.symbol_mutation` does not exist.
 
-- [ ] **Step 3: Implement the injected service**
+- [x] **Step 3: Implement the injected service**
 
 Add typed protocols and an immutable service class. Copy only the observable orchestration currently present in the four nested tool bodies.
 
-- [ ] **Step 4: Run the service tests and verify GREEN**
+- [x] **Step 4: Run the service tests and verify GREEN**
 
 Run the command from Step 2. Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/schematic/symbol_mutation.py \
@@ -69,11 +69,11 @@ git commit -m "refactor(schematic): extract symbol mutation service"
 - Produces: `SchematicSymbolMutationDependencies(service)`.
 - Produces: `register(mcp, dependencies) -> None`.
 
-- [ ] **Step 1: Write failing registration tests**
+- [x] **Step 1: Write failing registration tests**
 
 Assert the four exact public names, descriptions, schemas, headless metadata, Pydantic validation, alias behavior, and argument delegation.
 
-- [ ] **Step 2: Run and verify RED**
+- [x] **Step 2: Run and verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_symbol_mutation_registration.py
@@ -81,11 +81,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_symbol_mutation_registra
 
 Expected: collection failure because the adapter does not exist.
 
-- [ ] **Step 3: Implement and wire the adapter**
+- [x] **Step 3: Implement and wire the adapter**
 
 Construct the service in `tools.schematic.register()`, register the adapter once, and remove the four legacy nested functions.
 
-- [ ] **Step 4: Run focused behavior tests**
+- [x] **Step 4: Run focused behavior tests**
 
 ```bash
 uv run --all-extras pytest -q \
@@ -97,7 +97,7 @@ uv run --all-extras pytest -q \
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/tools/schematic.py \
@@ -115,15 +115,15 @@ git commit -m "refactor(schematic): delegate symbol mutation registration"
 **Interfaces:**
 - Produces architecture failures for forbidden imports, cycles, adapter-to-monolith imports, or a registration function over 300 lines.
 
-- [ ] **Step 1: Write failing architecture tests**
+- [x] **Step 1: Write failing architecture tests**
 
 Assert domain/adapter tracking, domain purity, adapter isolation, and the 300-line limit.
 
-- [ ] **Step 2: Extend the architecture checker**
+- [x] **Step 2: Extend the architecture checker**
 
 Add both modules, keep only the service in `PURE_HELPERS`, add the adapter import guard, and register the line limit.
 
-- [ ] **Step 3: Verify public-surface stability**
+- [x] **Step 3: Verify public-surface stability**
 
 ```bash
 uv run --all-extras python scripts/check_architecture_boundaries.py
@@ -133,7 +133,7 @@ corepack pnpm run docs:tools:check
 
 Expected: all pass without snapshot regeneration.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add scripts/check_architecture_boundaries.py \
@@ -143,8 +143,19 @@ git commit -m "test(architecture): guard symbol mutation boundaries"
 
 ### Task 4: Verify, publish, and review
 
-- [ ] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, and representative performance gates.
-- [ ] Record exact public-surface and registration line-count evidence.
+- [x] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, and representative performance gates.
+- [x] Record exact public-surface and registration line-count evidence.
 - [ ] Push and open a professional English PR referencing #434.
 - [ ] Inspect every bot/agent comment, review, and review thread; resolve actionable findings.
 - [ ] Merge only after all required checks pass.
+
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_update_properties`, `sch_set_dnp`, `sch_modify_property`, and `sch_move_symbol` matches `main`: names, descriptions, input schemas, annotations, and profiles are unchanged.
+- `tests/integration/test_tool_surface_snapshot.py` passes without regeneration.
+- The main schematic `register()` span decreased from 3,145 to 3,093 lines; the new adapter `register()` spans 52 lines.
+- The focused service, registration, population, and schematic integration suite completed with 148 passing tests.
+- The full unit suite completed successfully with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright for the pure service, architecture, generated tool documentation, workflow policy/security, strict MkDocs, and the committed MCP latency benchmark all pass.
+- Backend selection, transaction/checkpoint behavior, reload ordering, validation, and output strings remain unchanged.

--- a/docs/superpowers/plans/2026-07-23-schematic-symbol-mutation-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-symbol-mutation-service.md
@@ -1,0 +1,150 @@
+# Schematic Symbol Mutation Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract four non-destructive symbol property and placement tools into a FastMCP-free service and a sub-300-line registration adapter without changing the public MCP surface.
+
+**Architecture:** `kicad_mcp.schematic.symbol_mutation` owns result composition and move orchestration behind injected callables. `kicad_mcp.tools.schematic_symbol_mutation` owns MCP decorators and `MoveSymbolInput` validation. `tools.schematic.register()` remains the composition root.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, pytest, Ruff, mypy, Pyright, existing architecture and tool-surface checks.
+
+## Global Constraints
+
+- Preserve exact public names, descriptions, schemas, annotations, profiles, validation, and output strings.
+- Preserve backend selection, transaction/checkpoint behavior, and reload ordering.
+- Keep the domain service free of FastMCP, connection state, GUI dependencies, and `tools.schematic` imports.
+- Keep `tools.schematic_symbol_mutation.register()` at or below 300 lines.
+- Do not add runtime dependencies or close #434.
+
+---
+
+### Task 1: Extract the pure symbol mutation service
+
+**Files:**
+- Create: `tests/unit/test_schematic_symbol_mutation_service.py`
+- Create: `src/kicad_mcp/schematic/symbol_mutation.py`
+
+**Interfaces:**
+- Produces: `SchematicSymbolMutationService`.
+- Produces methods: `update_properties`, `set_dnp`, and `move_symbol`.
+- Consumes injected property update, DNP update, reload, snap, transaction, lookup, and block-shift callables.
+
+- [ ] **Step 1: Write failing direct service tests**
+
+Cover exact update/DNP output composition, move success with and without a snap notice, missing references, shift deltas, transaction flags, and reload ordering.
+
+- [ ] **Step 2: Run the service tests and verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_symbol_mutation_service.py
+```
+
+Expected: collection failure because `kicad_mcp.schematic.symbol_mutation` does not exist.
+
+- [ ] **Step 3: Implement the injected service**
+
+Add typed protocols and an immutable service class. Copy only the observable orchestration currently present in the four nested tool bodies.
+
+- [ ] **Step 4: Run the service tests and verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/schematic/symbol_mutation.py \
+  tests/unit/test_schematic_symbol_mutation_service.py
+git commit -m "refactor(schematic): extract symbol mutation service"
+```
+
+### Task 2: Add the thin registration adapter
+
+**Files:**
+- Create: `tests/unit/test_schematic_symbol_mutation_registration.py`
+- Create: `src/kicad_mcp/tools/schematic_symbol_mutation.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicSymbolMutationService`.
+- Produces: `SchematicSymbolMutationDependencies(service)`.
+- Produces: `register(mcp, dependencies) -> None`.
+
+- [ ] **Step 1: Write failing registration tests**
+
+Assert the four exact public names, descriptions, schemas, headless metadata, Pydantic validation, alias behavior, and argument delegation.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_symbol_mutation_registration.py
+```
+
+Expected: collection failure because the adapter does not exist.
+
+- [ ] **Step 3: Implement and wire the adapter**
+
+Construct the service in `tools.schematic.register()`, register the adapter once, and remove the four legacy nested functions.
+
+- [ ] **Step 4: Run focused behavior tests**
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_symbol_mutation_registration.py \
+  tests/unit/test_schematic_population_status.py \
+  tests/integration/test_schematic_tools.py \
+  tests/integration/test_schematic_extended.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/tools/schematic.py \
+  src/kicad_mcp/tools/schematic_symbol_mutation.py \
+  tests/unit/test_schematic_symbol_mutation_registration.py
+git commit -m "refactor(schematic): delegate symbol mutation registration"
+```
+
+### Task 3: Enforce architecture and surface stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_symbol_mutation_architecture.py`
+
+**Interfaces:**
+- Produces architecture failures for forbidden imports, cycles, adapter-to-monolith imports, or a registration function over 300 lines.
+
+- [ ] **Step 1: Write failing architecture tests**
+
+Assert domain/adapter tracking, domain purity, adapter isolation, and the 300-line limit.
+
+- [ ] **Step 2: Extend the architecture checker**
+
+Add both modules, keep only the service in `PURE_HELPERS`, add the adapter import guard, and register the line limit.
+
+- [ ] **Step 3: Verify public-surface stability**
+
+```bash
+uv run --all-extras python scripts/check_architecture_boundaries.py
+uv run --all-extras pytest -q tests/integration/test_tool_surface_snapshot.py
+corepack pnpm run docs:tools:check
+```
+
+Expected: all pass without snapshot regeneration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check_architecture_boundaries.py \
+  tests/unit/test_schematic_symbol_mutation_architecture.py
+git commit -m "test(architecture): guard symbol mutation boundaries"
+```
+
+### Task 4: Verify, publish, and review
+
+- [ ] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, and representative performance gates.
+- [ ] Record exact public-surface and registration line-count evidence.
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect every bot/agent comment, review, and review thread; resolve actionable findings.
+- [ ] Merge only after all required checks pass.

--- a/docs/superpowers/specs/2026-07-23-schematic-symbol-mutation-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-symbol-mutation-service-design.md
@@ -1,0 +1,84 @@
+# Schematic Symbol Mutation Service Design
+
+**Status:** Accepted under the approved incremental #434 architecture
+**Date:** 2026-07-23
+**Tracking issue:** #434
+
+## Context
+
+The first two #434 tranches extracted read-only inspection and topology behavior from `src/kicad_mcp/tools/schematic.py`. The remaining registration function still combines MCP decorators with mutation orchestration. The next bounded tranche addresses non-destructive symbol property and placement mutations while preserving the current backend, transaction, checkpoint, and approval behavior.
+
+## Decision
+
+Create two focused modules:
+
+- `kicad_mcp.schematic.symbol_mutation`: a FastMCP-free service that owns result composition and deterministic move orchestration behind injected callables.
+- `kicad_mcp.tools.schematic_symbol_mutation`: a thin registration adapter that owns the unchanged MCP decorators, descriptions, and Pydantic input adaptation.
+
+The existing `tools.schematic.register()` function remains the composition root and injects the current backend functions and text helpers.
+
+## Tool Boundary
+
+This tranche moves exactly four public tools:
+
+- `sch_update_properties`
+- `sch_set_dnp`
+- `sch_modify_property`
+- `sch_move_symbol`
+
+Destructive deletion, wire/label editing, authoring, rendering, layout, and template operations remain separate future tranches.
+
+## Service Interface
+
+`SchematicSymbolMutationService` receives injected callables for:
+
+- backend property updates;
+- native DNP updates;
+- schematic reload;
+- schematic-grid snapping and snap notices;
+- transactional writes;
+- placed-symbol lookup;
+- placed-symbol block shifting.
+
+Service methods return the exact strings currently produced by the public tools. The move method preserves the existing transaction boundary, missing-reference conversion to a result string, reload ordering, coordinate formatting, and optional snap notice.
+
+## Dependency Direction
+
+```text
+FastMCP
+  -> tools.schematic.register
+      -> tools.schematic_symbol_mutation.register
+          -> schematic.symbol_mutation.SchematicSymbolMutationService
+```
+
+The domain service must not import FastMCP, connection state, backend modules, GUI libraries, or `tools.schematic`.
+
+## Compatibility Rules
+
+- Public names, descriptions, input schemas, annotations, profiles, and output strings remain unchanged.
+- `sch_modify_property` remains an observable alias of `sch_update_properties`.
+- Existing `MoveSymbolInput` validation remains in the adapter.
+- Existing backend selection and transaction/checkpoint behavior remain injected and unchanged.
+- No runtime dependency is added.
+- The tool-surface snapshot and generated documentation must remain unchanged.
+
+## Error Handling
+
+- Backend property and DNP exceptions propagate exactly as before.
+- A missing move reference remains a normal result string rather than an MCP error.
+- Transaction failures other than the existing missing-reference `ValueError` continue to propagate.
+- Reload is performed only after a successful update or move.
+
+## Testing
+
+The tranche requires:
+
+1. direct service tests without FastMCP;
+2. adapter tests for exact names, descriptions, schemas, headless metadata, validation, and delegation;
+3. existing schematic integration and population-status tests;
+4. unchanged tool-surface and generated-documentation checks;
+5. architecture, type, coverage, and representative performance gates.
+
+## Rollout
+
+The PR references #434 and does not close it. The next bounded tranche should handle explicit destructive edits (`sch_delete_wire`, `sch_delete_symbol`, and label deletion/movement) separately because those operations opt into structural node loss and warrant an isolated review.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -24,7 +24,15 @@ DOMAIN_MODULES = {
     "kicad_mcp.models.sch_transaction": SRC_ROOT / "kicad_mcp" / "models" / "sch_transaction.py",
     "kicad_mcp.models.visual_qa": SRC_ROOT / "kicad_mcp" / "models" / "visual_qa.py",
     "kicad_mcp.schematic.inspection": SRC_ROOT / "kicad_mcp" / "schematic" / "inspection.py",
+    "kicad_mcp.schematic.symbol_mutation": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "symbol_mutation.py",
     "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
+    "kicad_mcp.tools.schematic_symbol_mutation": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_symbol_mutation.py",
     "kicad_mcp.tools.schematic_topology": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -50,6 +58,7 @@ PURE_HELPERS = {
     "kicad_mcp.models.sch_transaction",
     "kicad_mcp.models.visual_qa",
     "kicad_mcp.schematic.inspection",
+    "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.topology",
     "kicad_mcp.tools.schematic_constants",
 }
@@ -67,11 +76,13 @@ FORBIDDEN_PURE_IMPORT_PREFIXES = (
 
 ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
 }
 
 REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_inspection": 300,
+    "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_topology": 300,
 }
 

--- a/src/kicad_mcp/schematic/symbol_mutation.py
+++ b/src/kicad_mcp/schematic/symbol_mutation.py
@@ -1,0 +1,99 @@
+"""Pure orchestration for non-destructive schematic symbol mutations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+type SymbolMatch = tuple[str, int, int, Mapping[str, Any]]
+type UpdateSymbolProperty = Callable[[str, str, str], str]
+type SetSymbolDnp = Callable[[str, bool, str | None], str]
+type ReloadSchematic = Callable[[], str]
+type SnapPoint = Callable[[float, float, bool], tuple[float, float]]
+type SnapNotice = Callable[[tuple[float, ...], tuple[float, ...]], str]
+type FindPlacedSymbolBlock = Callable[[str, str], SymbolMatch | None]
+
+
+class TransactionalWrite(Protocol):
+    """Transaction boundary used by symbol move orchestration."""
+
+    def __call__(
+        self,
+        mutator: Callable[[str], str],
+        *,
+        allow_node_loss: bool = False,
+    ) -> str: ...
+
+
+class ShiftSymbolBlock(Protocol):
+    """Callable contract for moving one placed-symbol block."""
+
+    def __call__(
+        self,
+        block: str,
+        *,
+        dx_mm: float,
+        dy_mm: float,
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class SchematicSymbolMutationService:
+    """Compose symbol property and placement mutations from injected operations."""
+
+    update_symbol_property: UpdateSymbolProperty
+    set_symbol_dnp: SetSymbolDnp
+    reload_schematic: ReloadSchematic
+    snap_point: SnapPoint
+    snap_notice: SnapNotice
+    transactional_write: TransactionalWrite
+    find_placed_symbol_block: FindPlacedSymbolBlock
+    shift_symbol_block: ShiftSymbolBlock
+
+    def update_properties(self, reference: str, field: str, value: str) -> str:
+        """Update one symbol property and reload the schematic."""
+        result = self.update_symbol_property(reference, field, value)
+        return f"{result}\n{self.reload_schematic()}"
+
+    def set_dnp(self, reference: str, enabled: bool, reason: str | None) -> str:
+        """Update native DNP state and reload the schematic."""
+        result = self.set_symbol_dnp(reference, enabled, reason)
+        return f"{result}\n{self.reload_schematic()}"
+
+    def move_symbol(
+        self,
+        reference: str,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool,
+    ) -> str:
+        """Move one placed symbol while preserving transaction and result behavior."""
+        target_x, target_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (target_x, target_y))
+
+        def mutator(current: str) -> str:
+            match = self.find_placed_symbol_block(current, reference)
+            if match is None:
+                raise ValueError(f"Reference '{reference}' was not found in the schematic.")
+            block, start, end, parsed = match
+            shifted = self.shift_symbol_block(
+                block,
+                dx_mm=target_x - float(parsed["x"]),
+                dy_mm=target_y - float(parsed["y"]),
+            )
+            return current[:start] + shifted + current[end:]
+
+        try:
+            self.transactional_write(mutator)
+        except ValueError as exc:
+            return str(exc)
+
+        result = self.reload_schematic()
+        lines = [
+            result,
+            f"Moved symbol '{reference}' to ({target_x:.2f}, {target_y:.2f}) mm.",
+        ]
+        if snap_note:
+            lines.append(snap_note)
+        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -41,7 +41,6 @@ from ..models.schematic import (
     GlobalLabelInput,
     HierarchicalLabelInput,
     ModifyLabelInput,
-    MoveSymbolInput,
     PowerSymbolInput,
     RouteWireBetweenPinsInput,
     UpdatePropertiesInput,
@@ -50,6 +49,7 @@ from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
 from ..schematic.inspection import SchematicInspectionService
+from ..schematic.symbol_mutation import SchematicSymbolMutationService
 from ..schematic.topology import SchematicTopologyService
 from ..utils.cache import clear_ttl_cache, ttl_cache
 from ..utils.field_placer import FieldSpec, autoplace_fields
@@ -63,7 +63,7 @@ from ..utils.sexpr import (
     _sexpr_string,
     _unescape_sexpr_string,
 )
-from . import schematic_inspection, schematic_topology
+from . import schematic_inspection, schematic_symbol_mutation, schematic_topology
 from .metadata import headless_compatible
 from .schematic_constants import (
     _SCHEMATIC_STATE_DIRNAME,
@@ -5466,6 +5466,23 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    symbol_mutation_service = SchematicSymbolMutationService(
+        update_symbol_property=update_symbol_property,
+        set_symbol_dnp=set_symbol_dnp,
+        reload_schematic=_reload_schematic,
+        snap_point=_snap_point,
+        snap_notice=_snap_notice,
+        transactional_write=transactional_write,
+        find_placed_symbol_block=_find_placed_symbol_block,
+        shift_symbol_block=_shift_symbol_block,
+    )
+    schematic_symbol_mutation.register(
+        mcp,
+        schematic_symbol_mutation.SchematicSymbolMutationDependencies(
+            service=symbol_mutation_service,
+        ),
+    )
+
     @mcp.tool()
     @headless_compatible
     def sch_add_symbol(
@@ -6133,75 +6150,6 @@ def register(mcp: FastMCP) -> None:
         result = _reload_schematic()
         detail = f"Added jumper '{reference}' ({value}) at ({target_x:.2f}, {target_y:.2f}) mm."
         return f"{detail}\n{result}\n{snap_note}" if snap_note else f"{detail}\n{result}"
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_update_properties(reference: str, field: str, value: str) -> str:
-        """Update a property on a placed symbol."""
-        result = update_symbol_property(reference, field, value)
-        return f"{result}\n{_reload_schematic()}"
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_set_dnp(reference: str, enabled: bool = True, reason: str | None = None) -> str:
-        """Set KiCad's native Do Not Populate flag on a placed symbol.
-
-        When ``reason`` is given it is stored in the ``DNP Reason`` property so
-        ``sch_get_population_status`` and variant BOMs can report why the part
-        is unpopulated.
-        """
-        result = set_symbol_dnp(reference, enabled, reason)
-        return f"{result}\n{_reload_schematic()}"
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_modify_property(reference: str, field: str, value: str) -> str:
-        """Modify a schematic symbol property by reference."""
-        return str(sch_update_properties(reference, field, value))
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_move_symbol(
-        reference: str,
-        x_mm: float,
-        y_mm: float,
-        snap_to_grid: bool = True,
-    ) -> str:
-        """Move an existing symbol instance to a new absolute coordinate."""
-        payload = MoveSymbolInput(
-            reference=reference,
-            x_mm=x_mm,
-            y_mm=y_mm,
-            snap_to_grid=snap_to_grid,
-        )
-        target_x, target_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (target_x, target_y))
-
-        def mutator(current: str) -> str:
-            match = _find_placed_symbol_block(current, payload.reference)
-            if match is None:
-                raise ValueError(f"Reference '{payload.reference}' was not found in the schematic.")
-            block, start, end, parsed = match
-            shifted = _shift_symbol_block(
-                block,
-                dx_mm=target_x - float(parsed["x"]),
-                dy_mm=target_y - float(parsed["y"]),
-            )
-            return current[:start] + shifted + current[end:]
-
-        try:
-            transactional_write(mutator)
-        except ValueError as exc:
-            return str(exc)
-
-        result = _reload_schematic()
-        lines = [
-            result,
-            f"Moved symbol '{payload.reference}' to ({target_x:.2f}, {target_y:.2f}) mm.",
-        ]
-        if snap_note:
-            lines.append(snap_note)
-        return "\n".join(lines)
 
     @mcp.tool()
     def sch_delete_wire(wire_id: str) -> str:

--- a/src/kicad_mcp/tools/schematic_symbol_mutation.py
+++ b/src/kicad_mcp/tools/schematic_symbol_mutation.py
@@ -1,0 +1,72 @@
+"""Thin FastMCP adapters for schematic symbol property and placement mutations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..models.schematic import MoveSymbolInput
+from ..schematic.symbol_mutation import SchematicSymbolMutationService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicSymbolMutationDependencies:
+    """Symbol mutation service injected by the schematic composition root."""
+
+    service: SchematicSymbolMutationService
+
+
+def register(mcp: FastMCP, dependencies: SchematicSymbolMutationDependencies) -> None:
+    """Register non-destructive schematic symbol mutation tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_update_properties(reference: str, field: str, value: str) -> str:
+        """Update a property on a placed symbol."""
+        return service.update_properties(reference, field, value)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_set_dnp(
+        reference: str,
+        enabled: bool = True,
+        reason: str | None = None,
+    ) -> str:
+        """Set KiCad's native Do Not Populate flag on a placed symbol.
+
+        When ``reason`` is given it is stored in the ``DNP Reason`` property so
+        ``sch_get_population_status`` and variant BOMs can report why the part
+        is unpopulated.
+        """
+        return service.set_dnp(reference, enabled, reason)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_modify_property(reference: str, field: str, value: str) -> str:
+        """Modify a schematic symbol property by reference."""
+        return str(service.update_properties(reference, field, value))
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_move_symbol(
+        reference: str,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool = True,
+    ) -> str:
+        """Move an existing symbol instance to a new absolute coordinate."""
+        payload = MoveSymbolInput(
+            reference=reference,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            snap_to_grid=snap_to_grid,
+        )
+        return service.move_symbol(
+            payload.reference,
+            payload.x_mm,
+            payload.y_mm,
+            payload.snap_to_grid,
+        )

--- a/tests/unit/test_schematic_symbol_mutation_architecture.py
+++ b/tests/unit/test_schematic_symbol_mutation_architecture.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_symbol_mutation_modules() -> None:
+    assert "kicad_mcp.schematic.symbol_mutation" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.symbol_mutation" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_symbol_mutation" in boundaries.DOMAIN_MODULES
+
+
+def test_symbol_mutation_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_symbol_mutation.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+
+
+def test_symbol_mutation_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_symbol_mutation.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_symbol_mutation"] == 300

--- a/tests/unit/test_schematic_symbol_mutation_registration.py
+++ b/tests/unit/test_schematic_symbol_mutation_registration.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_symbol_mutation import (
+    SchematicSymbolMutationDependencies,
+    register,
+)
+
+
+class FakeSymbolMutationService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def update_properties(self, reference: str, field: str, value: str) -> str:
+        self.calls.append(("update_properties", (reference, field, value)))
+        return "updated"
+
+    def set_dnp(self, reference: str, enabled: bool, reason: str | None) -> str:
+        self.calls.append(("set_dnp", (reference, enabled, reason)))
+        return "dnp"
+
+    def move_symbol(
+        self,
+        reference: str,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool,
+    ) -> str:
+        self.calls.append(("move_symbol", (reference, x_mm, y_mm, snap_to_grid)))
+        return "moved"
+
+
+def _registered() -> tuple[FastMCP, FakeSymbolMutationService]:
+    server = FastMCP("schematic-symbol-mutation-test")
+    service = FakeSymbolMutationService()
+    register(server, SchematicSymbolMutationDependencies(service=service))
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_update_properties",
+        "sch_set_dnp",
+        "sch_modify_property",
+        "sch_move_symbol",
+    }
+    assert tools["sch_update_properties"].description == ("Update a property on a placed symbol.")
+    assert tools["sch_set_dnp"].description == (
+        "Set KiCad's native Do Not Populate flag on a placed symbol.\n\n"
+        "When ``reason`` is given it is stored in the ``DNP Reason`` property so\n"
+        "``sch_get_population_status`` and variant BOMs can report why the part\n"
+        "is unpopulated.\n"
+    )
+    assert tools["sch_modify_property"].description == (
+        "Modify a schematic symbol property by reference."
+    )
+    assert tools["sch_move_symbol"].description == (
+        "Move an existing symbol instance to a new absolute coordinate."
+    )
+    assert tools["sch_update_properties"].parameters["required"] == [
+        "reference",
+        "field",
+        "value",
+    ]
+    assert tools["sch_set_dnp"].parameters["required"] == ["reference"]
+    assert tools["sch_set_dnp"].parameters["properties"]["enabled"]["default"] is True
+    assert tools["sch_set_dnp"].parameters["properties"]["reason"]["default"] is None
+    assert tools["sch_move_symbol"].parameters["required"] == [
+        "reference",
+        "x_mm",
+        "y_mm",
+    ]
+    assert tools["sch_move_symbol"].parameters["properties"]["snap_to_grid"]["default"] is True
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    _server, _service = _registered()
+
+    for name in (
+        "sch_update_properties",
+        "sch_set_dnp",
+        "sch_modify_property",
+        "sch_move_symbol",
+    ):
+        metadata = get_tool_metadata(name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+
+
+def test_registration_delegates_and_preserves_modify_alias() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_update_properties"].fn("R1", "Value", "10k") == "updated"
+    assert tools["sch_set_dnp"].fn("R2", False, "variant") == "dnp"
+    assert tools["sch_modify_property"].fn("R3", "MPN", "ABC") == "updated"
+    assert tools["sch_move_symbol"].fn("U1", 10.0, 20.0, False) == "moved"
+    assert service.calls == [
+        ("update_properties", ("R1", "Value", "10k")),
+        ("set_dnp", ("R2", False, "variant")),
+        ("update_properties", ("R3", "MPN", "ABC")),
+        ("move_symbol", ("U1", 10.0, 20.0, False)),
+    ]
+
+
+def test_registration_preserves_move_validation() -> None:
+    server, _service = _registered()
+    tool = {tool.name: tool for tool in server._tool_manager.list_tools()}["sch_move_symbol"]
+
+    with pytest.raises(ValidationError):
+        tool.fn("", 10.0, 20.0, True)

--- a/tests/unit/test_schematic_symbol_mutation_service.py
+++ b/tests/unit/test_schematic_symbol_mutation_service.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from kicad_mcp.schematic.symbol_mutation import SchematicSymbolMutationService
+
+
+class _TransactionRecorder:
+    def __init__(self, current: str = "aaSYMBOLzz") -> None:
+        self.current = current
+        self.calls: list[bool] = []
+        self.updated: str | None = None
+
+    def __call__(
+        self,
+        mutator: Callable[[str], str],
+        *,
+        allow_node_loss: bool = False,
+    ) -> str:
+        self.calls.append(allow_node_loss)
+        self.updated = mutator(self.current)
+        return self.updated
+
+
+def _service(
+    *,
+    events: list[tuple[str, tuple[object, ...]]] | None = None,
+    transaction: _TransactionRecorder | None = None,
+    match: tuple[str, int, int, dict[str, Any]] | None = (
+        "SYMBOL",
+        2,
+        8,
+        {"x": 1.0, "y": 2.0},
+    ),
+    snap_result: tuple[float, float] = (10.16, 20.32),
+    snap_message: str = "Snapped to the schematic grid.",
+) -> SchematicSymbolMutationService:
+    records = events if events is not None else []
+    tx = transaction or _TransactionRecorder()
+
+    def update_property(reference: str, field: str, value: str) -> str:
+        records.append(("update_property", (reference, field, value)))
+        return f"Updated {reference}.{field}."
+
+    def set_dnp(reference: str, enabled: bool, reason: str | None) -> str:
+        records.append(("set_dnp", (reference, enabled, reason)))
+        return f"Set {reference} DNP={enabled}."
+
+    def reload_schematic() -> str:
+        records.append(("reload", ()))
+        return "Reloaded schematic."
+
+    def snap_point(x_mm: float, y_mm: float, enabled: bool) -> tuple[float, float]:
+        records.append(("snap_point", (x_mm, y_mm, enabled)))
+        return snap_result
+
+    def snap_notice(
+        original: tuple[float, float],
+        snapped: tuple[float, float],
+    ) -> str:
+        records.append(("snap_notice", (original, snapped)))
+        return snap_message
+
+    def find_symbol(
+        current: str,
+        reference: str,
+    ) -> tuple[str, int, int, dict[str, Any]] | None:
+        records.append(("find_symbol", (current, reference)))
+        return match
+
+    def shift_symbol(block: str, *, dx_mm: float, dy_mm: float) -> str:
+        records.append(("shift_symbol", (block, dx_mm, dy_mm)))
+        return "SHIFTED"
+
+    return SchematicSymbolMutationService(
+        update_symbol_property=update_property,
+        set_symbol_dnp=set_dnp,
+        reload_schematic=reload_schematic,
+        snap_point=snap_point,
+        snap_notice=snap_notice,
+        transactional_write=tx,
+        find_placed_symbol_block=find_symbol,
+        shift_symbol_block=shift_symbol,
+    )
+
+
+def test_update_properties_preserves_backend_then_reload_result() -> None:
+    events: list[tuple[str, tuple[object, ...]]] = []
+    service = _service(events=events)
+
+    assert service.update_properties("R1", "Value", "10k") == (
+        "Updated R1.Value.\nReloaded schematic."
+    )
+    assert events == [
+        ("update_property", ("R1", "Value", "10k")),
+        ("reload", ()),
+    ]
+
+
+def test_set_dnp_preserves_reason_and_reload_order() -> None:
+    events: list[tuple[str, tuple[object, ...]]] = []
+    service = _service(events=events)
+
+    assert service.set_dnp("R2", False, "variant") == ("Set R2 DNP=False.\nReloaded schematic.")
+    assert events == [
+        ("set_dnp", ("R2", False, "variant")),
+        ("reload", ()),
+    ]
+
+
+def test_move_symbol_preserves_transaction_shift_and_snap_notice() -> None:
+    events: list[tuple[str, tuple[object, ...]]] = []
+    transaction = _TransactionRecorder()
+    service = _service(events=events, transaction=transaction)
+
+    assert service.move_symbol("U1", 10.0, 20.0, True) == (
+        "Reloaded schematic.\n"
+        "Moved symbol 'U1' to (10.16, 20.32) mm.\n"
+        "Snapped to the schematic grid."
+    )
+    assert transaction.calls == [False]
+    assert transaction.updated == "aaSHIFTEDzz"
+    assert events == [
+        ("snap_point", (10.0, 20.0, True)),
+        ("snap_notice", ((10.0, 20.0), (10.16, 20.32))),
+        ("find_symbol", ("aaSYMBOLzz", "U1")),
+        ("shift_symbol", ("SYMBOL", 9.16, 18.32)),
+        ("reload", ()),
+    ]
+
+
+def test_move_symbol_omits_empty_snap_notice() -> None:
+    service = _service(snap_result=(5.0, 6.0), snap_message="")
+
+    assert service.move_symbol("U1", 5.0, 6.0, False) == (
+        "Reloaded schematic.\nMoved symbol 'U1' to (5.00, 6.00) mm."
+    )
+
+
+def test_move_symbol_preserves_missing_reference_as_result_without_reload() -> None:
+    events: list[tuple[str, tuple[object, ...]]] = []
+    transaction = _TransactionRecorder()
+    service = _service(events=events, transaction=transaction, match=None)
+
+    assert service.move_symbol("R404", 1.0, 2.0, True) == (
+        "Reference 'R404' was not found in the schematic."
+    )
+    assert transaction.calls == [False]
+    assert transaction.updated is None
+    assert ("reload", ()) not in events


### PR DESCRIPTION
## Summary

- extract non-destructive symbol property and placement orchestration into a typed, FastMCP-free `SchematicSymbolMutationService`
- add a 52-line registration adapter for `sch_update_properties`, `sch_set_dnp`, `sch_modify_property`, and `sch_move_symbol`
- reduce the main schematic registration function from 3,145 to 3,093 lines
- add architecture policy for service purity, adapter isolation, and the 300-line registration limit
- document the bounded design, implementation plan, verification evidence, and the next destructive-edit tranche

## Compatibility and safety

- public tool names, descriptions, input schemas, annotations, profiles, validation, and outputs are unchanged
- exact full-server metadata comparison against `main` is identical for all four tools
- the committed tool-surface snapshot remains unchanged
- backend selection, transaction/checkpoint behavior, reload ordering, and error behavior remain unchanged
- no runtime dependency is added
- this is the third bounded tranche of #434 and does not close the parent task

## Verification

- focused service, registration, population, and schematic integration suite: 148 passed
- full unit suite passed with five expected skips
- committed MCP `tools/list` latency benchmark passed
- metadata, formatting, Ruff, mypy, scoped strict Pyright for the pure service, architecture, generated documentation, workflow policy/security, and strict MkDocs checks passed
- main schematic `register()` span: 3,145 → 3,093 lines
- adapter `register()` span: 52 lines

## Review notes

Repository-wide strict Pyright findings outside the extracted pure service remain pre-existing; the new pure service reports zero scoped strict Pyright findings. CI continues to enforce the configured mypy gate.

Refs #434