### PR TITLE
refactor(schematic): extract destructive edit domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-destructive-edit-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-destructive-edit-service.md
@@ -153,7 +153,7 @@ git commit -m "test(architecture): guard destructive edit boundaries"
 - Exact full-server metadata for all five extracted tools matches `main`: names, descriptions, input schemas, and annotations are identical.
 - `tests/integration/test_tool_surface_snapshot.py` passes without snapshot regeneration.
 - The main schematic `register()` span decreased from 3,093 to 2,807 lines; the destructive-edit adapter `register()` spans 69 lines.
-- Focused service, registration, and schematic integration coverage passed: 148 tests.
+- Focused service, registration, and schematic integration coverage passed: 150 tests; the extracted service and adapter have 100% focused line coverage.
 - The full unit suite passed with five expected skips and one pre-existing async-mock warning.
 - Deletion tests prove `allow_node_loss=True` remains limited to wire, symbol, and label deletion; label movement and justification keep the default structural-loss guard.
 - Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, and the committed MCP latency benchmark all pass.

--- a/docs/superpowers/plans/2026-07-23-schematic-destructive-edit-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-destructive-edit-service.md
@@ -30,11 +30,11 @@
 - Produces methods: `delete_wire`, `delete_symbol`, `delete_label`, `move_label`, and `modify_label`.
 - Consumes injected path, parser, formatting, grid, transaction, and reload callables.
 
-- [ ] **Step 1: Write failing direct service tests**
+- [x] **Step 1: Write failing direct service tests**
 
 Cover successful and missing/ambiguous wire deletion, symbol deletion with attached-wire counts, label deletion grid matching, label move snap/rotation behavior, label justification changes, and exact `allow_node_loss` flags.
 
-- [ ] **Step 2: Run and verify RED**
+- [x] **Step 2: Run and verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_destructive_edit_service.py
@@ -42,15 +42,15 @@ uv run --all-extras pytest -q tests/unit/test_schematic_destructive_edit_service
 
 Expected: collection failure because `kicad_mcp.schematic.destructive_edit` does not exist.
 
-- [ ] **Step 3: Implement the injected service**
+- [x] **Step 3: Implement the injected service**
 
 Move only observable orchestration and deterministic text-edit behavior. Preserve the current 0.05 mm label tolerance and first-match semantics.
 
-- [ ] **Step 4: Run and verify GREEN**
+- [x] **Step 4: Run and verify GREEN**
 
 Run the command from Step 2. Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/schematic/destructive_edit.py \
@@ -70,11 +70,11 @@ git commit -m "refactor(schematic): extract destructive edit service"
 - Produces: `SchematicDestructiveEditDependencies(service)`.
 - Produces: `register(mcp, dependencies) -> None`.
 
-- [ ] **Step 1: Write failing registration tests**
+- [x] **Step 1: Write failing registration tests**
 
 Assert exact public names, descriptions, schemas, annotations, validation, and argument delegation.
 
-- [ ] **Step 2: Run and verify RED**
+- [x] **Step 2: Run and verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_destructive_edit_registration.py
@@ -82,11 +82,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_destructive_edit_registr
 
 Expected: collection failure because the adapter does not exist.
 
-- [ ] **Step 3: Implement and wire the adapter**
+- [x] **Step 3: Implement and wire the adapter**
 
 Construct the service in the composition root, register the adapter once, and remove the five nested legacy functions.
 
-- [ ] **Step 4: Run focused behavior tests**
+- [x] **Step 4: Run focused behavior tests**
 
 ```bash
 uv run --all-extras pytest -q \
@@ -98,7 +98,7 @@ uv run --all-extras pytest -q \
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/tools/schematic.py \
@@ -113,15 +113,15 @@ git commit -m "refactor(schematic): delegate destructive edit registration"
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_destructive_edit_architecture.py`
 
-- [ ] **Step 1: Write failing architecture tests**
+- [x] **Step 1: Write failing architecture tests**
 
 Assert service/adapter tracking, domain purity, adapter isolation, and the 300-line limit.
 
-- [ ] **Step 2: Extend the architecture checker**
+- [x] **Step 2: Extend the architecture checker**
 
 Register both modules, keep only the service in `PURE_HELPERS`, add the adapter import guard, and enforce the line limit.
 
-- [ ] **Step 3: Verify public-surface stability**
+- [x] **Step 3: Verify public-surface stability**
 
 ```bash
 uv run --all-extras python scripts/check_architecture_boundaries.py
@@ -131,7 +131,7 @@ corepack pnpm run docs:tools:check
 
 Expected: all pass without snapshot regeneration.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add scripts/check_architecture_boundaries.py \
@@ -141,8 +141,20 @@ git commit -m "test(architecture): guard destructive edit boundaries"
 
 ### Task 4: Verify, publish, and review
 
-- [ ] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, and representative performance gates.
-- [ ] Record exact public-surface, transaction-flag, and registration line-count evidence.
+- [x] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, and representative performance gates.
+- [x] Record exact public-surface, transaction-flag, and registration line-count evidence.
 - [ ] Push and open a professional English PR referencing #434.
 - [ ] Inspect every bot/agent comment, review, and review thread; resolve actionable findings.
 - [ ] Merge only after all required checks pass.
+
+
+## Verification Evidence
+
+- Exact full-server metadata for all five extracted tools matches `main`: names, descriptions, input schemas, and annotations are identical.
+- `tests/integration/test_tool_surface_snapshot.py` passes without snapshot regeneration.
+- The main schematic `register()` span decreased from 3,093 to 2,807 lines; the destructive-edit adapter `register()` spans 69 lines.
+- Focused service, registration, and schematic integration coverage passed: 148 tests.
+- The full unit suite passed with five expected skips and one pre-existing async-mock warning.
+- Deletion tests prove `allow_node_loss=True` remains limited to wire, symbol, and label deletion; label movement and justification keep the default structural-loss guard.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, and the committed MCP latency benchmark all pass.
+- No runtime dependency, public tool contract, matching tolerance, reload order, transaction boundary, or backend-selection behavior changed.

--- a/docs/superpowers/plans/2026-07-23-schematic-destructive-edit-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-destructive-edit-service.md
@@ -1,0 +1,148 @@
+# Schematic Destructive Edit Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract five explicit wire, symbol, and label edit tools into a FastMCP-free service and a sub-300-line registration adapter without changing the public MCP surface or structural-loss policy.
+
+**Architecture:** `kicad_mcp.schematic.destructive_edit` owns deterministic edit orchestration behind injected parsers and transaction callables. `kicad_mcp.tools.schematic_destructive_edit` owns public decorators and Pydantic argument validation. `tools.schematic.register()` remains the composition root.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, pytest, Ruff, mypy, Pyright, existing architecture and tool-surface checks.
+
+## Global Constraints
+
+- Preserve exact names, descriptions, schemas, annotations, profiles, validation, matching tolerances, and result strings.
+- Preserve `allow_node_loss=True` only for wire, symbol, and label deletion.
+- Preserve transaction/checkpoint behavior, reload ordering, and exception behavior.
+- Keep the domain service free of FastMCP, server/connection state, GUI dependencies, and `tools.schematic` imports.
+- Keep `tools.schematic_destructive_edit.register()` at or below 300 lines.
+- Do not add runtime dependencies or close #434.
+
+---
+
+### Task 1: Extract the destructive edit service
+
+**Files:**
+- Create: `tests/unit/test_schematic_destructive_edit_service.py`
+- Create: `src/kicad_mcp/schematic/destructive_edit.py`
+
+**Interfaces:**
+- Produces: `SchematicDestructiveEditService`.
+- Produces methods: `delete_wire`, `delete_symbol`, `delete_label`, `move_label`, and `modify_label`.
+- Consumes injected path, parser, formatting, grid, transaction, and reload callables.
+
+- [ ] **Step 1: Write failing direct service tests**
+
+Cover successful and missing/ambiguous wire deletion, symbol deletion with attached-wire counts, label deletion grid matching, label move snap/rotation behavior, label justification changes, and exact `allow_node_loss` flags.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_destructive_edit_service.py
+```
+
+Expected: collection failure because `kicad_mcp.schematic.destructive_edit` does not exist.
+
+- [ ] **Step 3: Implement the injected service**
+
+Move only observable orchestration and deterministic text-edit behavior. Preserve the current 0.05 mm label tolerance and first-match semantics.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/schematic/destructive_edit.py \
+  tests/unit/test_schematic_destructive_edit_service.py
+git commit -m "refactor(schematic): extract destructive edit service"
+```
+
+### Task 2: Add the thin registration adapter
+
+**Files:**
+- Create: `tests/unit/test_schematic_destructive_edit_registration.py`
+- Create: `src/kicad_mcp/tools/schematic_destructive_edit.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicDestructiveEditService`.
+- Produces: `SchematicDestructiveEditDependencies(service)`.
+- Produces: `register(mcp, dependencies) -> None`.
+
+- [ ] **Step 1: Write failing registration tests**
+
+Assert exact public names, descriptions, schemas, annotations, validation, and argument delegation.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_destructive_edit_registration.py
+```
+
+Expected: collection failure because the adapter does not exist.
+
+- [ ] **Step 3: Implement and wire the adapter**
+
+Construct the service in the composition root, register the adapter once, and remove the five nested legacy functions.
+
+- [ ] **Step 4: Run focused behavior tests**
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_destructive_edit_service.py \
+  tests/unit/test_schematic_destructive_edit_registration.py \
+  tests/integration/test_schematic_tools.py \
+  tests/integration/test_schematic_extended.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/tools/schematic.py \
+  src/kicad_mcp/tools/schematic_destructive_edit.py \
+  tests/unit/test_schematic_destructive_edit_registration.py
+git commit -m "refactor(schematic): delegate destructive edit registration"
+```
+
+### Task 3: Enforce architecture and surface stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_destructive_edit_architecture.py`
+
+- [ ] **Step 1: Write failing architecture tests**
+
+Assert service/adapter tracking, domain purity, adapter isolation, and the 300-line limit.
+
+- [ ] **Step 2: Extend the architecture checker**
+
+Register both modules, keep only the service in `PURE_HELPERS`, add the adapter import guard, and enforce the line limit.
+
+- [ ] **Step 3: Verify public-surface stability**
+
+```bash
+uv run --all-extras python scripts/check_architecture_boundaries.py
+uv run --all-extras pytest -q tests/integration/test_tool_surface_snapshot.py
+corepack pnpm run docs:tools:check
+```
+
+Expected: all pass without snapshot regeneration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check_architecture_boundaries.py \
+  tests/unit/test_schematic_destructive_edit_architecture.py
+git commit -m "test(architecture): guard destructive edit boundaries"
+```
+
+### Task 4: Verify, publish, and review
+
+- [ ] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, and representative performance gates.
+- [ ] Record exact public-surface, transaction-flag, and registration line-count evidence.
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect every bot/agent comment, review, and review thread; resolve actionable findings.
+- [ ] Merge only after all required checks pass.

--- a/docs/superpowers/specs/2026-07-23-schematic-destructive-edit-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-destructive-edit-service-design.md
@@ -1,0 +1,83 @@
+# Schematic Destructive Edit Service Design
+
+**Status:** Accepted under the approved incremental #434 architecture
+**Date:** 2026-07-23
+**Tracking issue:** #434
+
+## Context
+
+Three bounded #434 tranches have already extracted read-only inspection, topology inspection, and non-destructive symbol mutation behavior from `src/kicad_mcp/tools/schematic.py`. The next cohesive responsibility is explicit destructive editing: operations that remove schematic nodes or edit label blocks and therefore require careful transaction and structural-loss handling.
+
+## Decision
+
+Create two focused modules:
+
+- `kicad_mcp.schematic.destructive_edit`: a FastMCP-free service containing deterministic wire, symbol, and label edit orchestration behind injected parsing and transaction callables.
+- `kicad_mcp.tools.schematic_destructive_edit`: a thin FastMCP adapter preserving public decorators and Pydantic validation.
+
+`tools.schematic.register()` remains the composition root. It injects the existing text parsers, symbol-connection resolver, grid helpers, transaction writer, label-justify helpers, and reload operation.
+
+## Tool Boundary
+
+This tranche moves exactly five public tools:
+
+- `sch_delete_wire`
+- `sch_delete_symbol`
+- `sch_delete_label`
+- `sch_move_label`
+- `sch_modify_label`
+
+Authoring, circuit building, rendering, preview, layout, templates, and sheet creation remain future tranches.
+
+## Service Interface
+
+`SchematicDestructiveEditService` receives injected callables for:
+
+- active schematic path resolution and file reading;
+- wire extraction, UUID matching, signatures, block extraction, and wire parsing;
+- placed-symbol discovery, symbol parsing, symbol connection-point calculation, and coordinate normalization;
+- label parsing, grid snapping, snap notices, justify normalization, and justify replacement;
+- transactional writes with the existing `allow_node_loss` flag;
+- formatting and schematic reload.
+
+The service preserves the existing exact output strings, matching tolerances, first-match behavior, UUID-prefix ambiguity handling, label grid-roundtrip behavior, and transaction flags.
+
+## Structural-Loss Policy
+
+- Wire deletion, symbol deletion, and label deletion continue to call the transaction boundary with `allow_node_loss=True`.
+- Label movement and justification changes continue to use the normal structural-loss guard.
+- Missing targets remain normal result strings by catching only the existing `ValueError` path.
+- Other transaction or parser failures propagate unchanged.
+
+## Dependency Direction
+
+```text
+FastMCP
+  -> tools.schematic.register
+      -> tools.schematic_destructive_edit.register
+          -> schematic.destructive_edit.SchematicDestructiveEditService
+```
+
+The domain service must not import FastMCP, server/connection state, GUI libraries, or `tools.schematic`.
+
+## Compatibility Rules
+
+- Public names, descriptions, schemas, annotations, profiles, validation, and outputs remain unchanged.
+- Existing `DeleteWireInput`, `DeleteSymbolInput`, and `ModifyLabelInput` validation remains in the adapter.
+- No transaction, approval, checkpoint, backend-selection, or structural-loss policy changes.
+- The committed tool-surface snapshot and generated tool documentation remain unchanged.
+- No runtime dependency is added.
+
+## Testing
+
+The tranche requires:
+
+1. direct service tests without FastMCP, including all destructive flags and error branches;
+2. adapter tests for exact public contracts and Pydantic validation;
+3. existing schematic integration and extended edit tests;
+4. unchanged tool-surface and generated-documentation checks;
+5. architecture, type, coverage, and representative performance gates.
+
+## Rollout
+
+The PR references #434 and does not close it. The next tranche should extract low-level authoring primitives (`sch_add_symbol`, `sch_add_wire`, `sch_add_label`, power/bus/no-connect tools) as a separate bounded service.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -23,12 +23,20 @@ DOMAIN_MODULES = {
     / "contract_verifier.py",
     "kicad_mcp.models.sch_transaction": SRC_ROOT / "kicad_mcp" / "models" / "sch_transaction.py",
     "kicad_mcp.models.visual_qa": SRC_ROOT / "kicad_mcp" / "models" / "visual_qa.py",
+    "kicad_mcp.schematic.destructive_edit": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "destructive_edit.py",
     "kicad_mcp.schematic.inspection": SRC_ROOT / "kicad_mcp" / "schematic" / "inspection.py",
     "kicad_mcp.schematic.symbol_mutation": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
     / "symbol_mutation.py",
     "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
+    "kicad_mcp.tools.schematic_destructive_edit": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_destructive_edit.py",
     "kicad_mcp.tools.schematic_symbol_mutation": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -57,6 +65,7 @@ PURE_HELPERS = {
     "kicad_mcp.models.contract_verifier",
     "kicad_mcp.models.sch_transaction",
     "kicad_mcp.models.visual_qa",
+    "kicad_mcp.schematic.destructive_edit",
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.topology",
@@ -75,12 +84,14 @@ FORBIDDEN_PURE_IMPORT_PREFIXES = (
 )
 
 ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
+    "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
 }
 
 REGISTER_LINE_LIMITS = {
+    "kicad_mcp.tools.schematic_destructive_edit": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_topology": 300,

--- a/src/kicad_mcp/schematic/destructive_edit.py
+++ b/src/kicad_mcp/schematic/destructive_edit.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Hashable, Mapping
+from collections.abc import Callable, Hashable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-type ParsedRecord = Mapping[str, Any]
+type ParsedRecord = dict[str, Any]
 type SymbolMatch = tuple[str, int, int, ParsedRecord]
 type ActiveSchematicFile = Callable[[], Path]
 type ReadSchematicText = Callable[[Path], str]

--- a/src/kicad_mcp/schematic/destructive_edit.py
+++ b/src/kicad_mcp/schematic/destructive_edit.py
@@ -1,0 +1,364 @@
+"""Pure orchestration for explicit destructive schematic edits."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Hashable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+type ParsedRecord = Mapping[str, Any]
+type SymbolMatch = tuple[str, int, int, ParsedRecord]
+type ActiveSchematicFile = Callable[[], Path]
+type ReadSchematicText = Callable[[Path], str]
+type ExtractWires = Callable[[str], list[ParsedRecord]]
+type WireIdMatches = Callable[[str, str], bool]
+type WireSignature = Callable[[Any, Any, Any, Any], Hashable]
+type ExtractBlock = Callable[[str, int], tuple[str, int]]
+type ParseBlock = Callable[[str], ParsedRecord | None]
+type FormatMm = Callable[[float], str]
+type ReloadSchematic = Callable[[], str]
+type FindPlacedSymbolBlocks = Callable[[str, str], list[SymbolMatch]]
+type SymbolConnectionPoints = Callable[[ParsedRecord], set[tuple[float, float]]]
+type CoordinateKey = Callable[[Any, Any], tuple[float, float]]
+type SnapPoint = Callable[[float, float, bool], tuple[float, float]]
+type SnapNotice = Callable[[tuple[float, ...], tuple[float, ...]], str]
+type NormalizeLabelJustify = Callable[[str | None], str | None]
+type SetLabelJustify = Callable[[str, str], str]
+
+
+class TransactionalWrite(Protocol):
+    """Transaction boundary used by schematic edit orchestration."""
+
+    def __call__(
+        self,
+        mutator: Callable[[str], str],
+        *,
+        allow_node_loss: bool = False,
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class SchematicDestructiveEditService:
+    """Perform deterministic destructive edits through injected dependencies."""
+
+    active_schematic_file: ActiveSchematicFile
+    read_schematic_text: ReadSchematicText
+    extract_wires: ExtractWires
+    wire_id_matches: WireIdMatches
+    wire_signature: WireSignature
+    extract_block: ExtractBlock
+    parse_wire_block: ParseBlock
+    format_mm: FormatMm
+    transactional_write: TransactionalWrite
+    reload_schematic: ReloadSchematic
+    find_placed_symbol_blocks: FindPlacedSymbolBlocks
+    symbol_connection_points: SymbolConnectionPoints
+    parse_symbol_block: ParseBlock
+    coordinate_key: CoordinateKey
+    parse_label_block: ParseBlock
+    snap_point: SnapPoint
+    snap_notice: SnapNotice
+    normalize_label_justify: NormalizeLabelJustify
+    set_label_justify: SetLabelJustify
+
+    def delete_wire(self, wire_id: str) -> str:
+        """Delete one wire selected by UUID or unique UUID prefix."""
+        schematic_file = self.active_schematic_file()
+        current = self.read_schematic_text(schematic_file)
+        matches = [
+            wire
+            for wire in self.extract_wires(current)
+            if wire.get("uuid") and self.wire_id_matches(str(wire["uuid"]), wire_id)
+        ]
+        if not matches:
+            return f"Wire '{wire_id}' was not found in the active schematic."
+        if len(matches) > 1:
+            matching_ids = ", ".join(str(wire["uuid"]) for wire in matches[:5])
+            return f"Wire identifier '{wire_id}' is ambiguous. Matching UUIDs: {matching_ids}"
+
+        target = matches[0]
+        target_signature = self.wire_signature(
+            target["x1"],
+            target["y1"],
+            target["x2"],
+            target["y2"],
+        )
+
+        def mutator(current_text: str) -> str:
+            pieces: list[str] = []
+            cursor = 0
+            last = 0
+            removed = False
+            while cursor < len(current_text):
+                if current_text[cursor:].startswith("(wire"):
+                    block, length = self.extract_block(current_text, cursor)
+                    parsed = self.parse_wire_block(block) if block else None
+                    if parsed is not None:
+                        signature = self.wire_signature(
+                            parsed["x1"],
+                            parsed["y1"],
+                            parsed["x2"],
+                            parsed["y2"],
+                        )
+                        parsed_uuid = str(parsed.get("uuid", ""))
+                        if (
+                            signature == target_signature
+                            and parsed_uuid
+                            and self.wire_id_matches(parsed_uuid, str(target["uuid"]))
+                        ):
+                            pieces.append(current_text[last:cursor])
+                            cursor += length
+                            last = cursor
+                            removed = True
+                            continue
+                cursor += 1
+            pieces.append(current_text[last:])
+            if not removed:
+                raise ValueError(f"Wire '{wire_id}' could not be removed.")
+            return "".join(pieces)
+
+        try:
+            self.transactional_write(mutator, allow_node_loss=True)
+        except ValueError as exc:
+            return str(exc)
+        return (
+            f"{self.reload_schematic()}\n"
+            f"Deleted wire '{target['uuid']}' from "
+            f"({self.format_mm(float(target['x1']))}, {self.format_mm(float(target['y1']))}) to "
+            f"({self.format_mm(float(target['x2']))}, {self.format_mm(float(target['y2']))})."
+        )
+
+    def delete_symbol(self, reference: str) -> str:
+        """Delete placed symbol blocks and directly attached wires."""
+        removed_wire_count = 0
+        removed_symbol_count = 0
+
+        def mutator(current: str) -> str:
+            nonlocal removed_symbol_count, removed_wire_count
+
+            matches = self.find_placed_symbol_blocks(current, reference)
+            if not matches:
+                raise ValueError(f"Reference '{reference}' was not found in the schematic.")
+            removed_symbol_count = len(matches)
+            connection_points = {
+                point
+                for _, _, _, parsed in matches
+                for point in self.symbol_connection_points(parsed)
+            }
+
+            pieces: list[str] = []
+            cursor = 0
+            last = 0
+            while cursor < len(current):
+                if current[cursor:].startswith("(symbol"):
+                    block, length = self.extract_block(current, cursor)
+                    parsed = self.parse_symbol_block(block) if block else None
+                    if parsed is not None and parsed["reference"] == reference:
+                        pieces.append(current[last:cursor])
+                        cursor += length
+                        last = cursor
+                        continue
+                if current[cursor:].startswith("(wire"):
+                    block, length = self.extract_block(current, cursor)
+                    parsed_wire = self.parse_wire_block(block) if block else None
+                    if parsed_wire is not None:
+                        start = self.coordinate_key(parsed_wire["x1"], parsed_wire["y1"])
+                        end = self.coordinate_key(parsed_wire["x2"], parsed_wire["y2"])
+                        if start in connection_points or end in connection_points:
+                            removed_wire_count += 1
+                            pieces.append(current[last:cursor])
+                            cursor += length
+                            last = cursor
+                            continue
+                cursor += 1
+            pieces.append(current[last:])
+            return "".join(pieces)
+
+        try:
+            self.transactional_write(mutator, allow_node_loss=True)
+        except ValueError as exc:
+            return str(exc)
+
+        return (
+            f"{self.reload_schematic()}\n"
+            f"Deleted {removed_symbol_count} symbol block(s) for '{reference}' "
+            f"and {removed_wire_count} directly connected wire(s)."
+        )
+
+    def delete_label(self, name: str, x_mm: float, y_mm: float) -> str:
+        """Delete matching label blocks at raw or grid-snapped coordinates."""
+        tolerance = 0.05
+        removed = 0
+        snapped_x, snapped_y = self.snap_point(x_mm, y_mm, True)
+
+        def matches_target(parsed: ParsedRecord) -> bool:
+            for target_x, target_y in ((x_mm, y_mm), (snapped_x, snapped_y)):
+                if (
+                    abs(float(parsed["x"]) - target_x) <= tolerance
+                    and abs(float(parsed["y"]) - target_y) <= tolerance
+                ):
+                    return True
+            return False
+
+        def mutator(current: str) -> str:
+            nonlocal removed
+            pieces: list[str] = []
+            cursor = 0
+            last = 0
+            while cursor < len(current):
+                if current[cursor:].startswith(("(label", "(global_label", "(hierarchical_label")):
+                    block, length = self.extract_block(current, cursor)
+                    parsed = self.parse_label_block(block) if block else None
+                    if parsed is not None and parsed["name"] == name and matches_target(parsed):
+                        pieces.append(current[last:cursor])
+                        cursor += length
+                        last = cursor
+                        removed += 1
+                        continue
+                cursor += 1
+            pieces.append(current[last:])
+            if removed == 0:
+                raise ValueError(
+                    f"No label '{name}' found near "
+                    f"({self.format_mm(x_mm)}, {self.format_mm(y_mm)})."
+                )
+            return "".join(pieces)
+
+        try:
+            self.transactional_write(mutator, allow_node_loss=True)
+        except ValueError as exc:
+            return str(exc)
+        return (
+            f"{self.reload_schematic()}\n"
+            f"Deleted {removed} label(s) '{name}' at "
+            f"({self.format_mm(x_mm)}, {self.format_mm(y_mm)})."
+        )
+
+    def move_label(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        new_x_mm: float,
+        new_y_mm: float,
+        new_rotation: int | None,
+        snap_to_grid: bool,
+    ) -> str:
+        """Move the first matching label and optionally update its rotation."""
+        target_x, target_y = self.snap_point(new_x_mm, new_y_mm, snap_to_grid)
+        snap_note = self.snap_notice((new_x_mm, new_y_mm), (target_x, target_y))
+        tolerance = 0.05
+        moved = 0
+
+        def mutator(current: str) -> str:
+            nonlocal moved
+            pieces: list[str] = []
+            cursor = 0
+            last = 0
+            while cursor < len(current):
+                if moved == 0 and current[cursor:].startswith(
+                    ("(label", "(global_label", "(hierarchical_label")
+                ):
+                    block, length = self.extract_block(current, cursor)
+                    parsed = self.parse_label_block(block) if block else None
+                    if (
+                        parsed is not None
+                        and parsed["name"] == name
+                        and abs(float(parsed["x"]) - x_mm) <= tolerance
+                        and abs(float(parsed["y"]) - y_mm) <= tolerance
+                    ):
+                        rotation = (
+                            int(parsed["rotation"]) if new_rotation is None else int(new_rotation)
+                        )
+                        updated_block = re.sub(
+                            r"\(at\s+[-\d.]+\s+[-\d.]+\s+[-\d.]+\)",
+                            f"(at {self.format_mm(target_x)} "
+                            f"{self.format_mm(target_y)} {rotation})",
+                            block,
+                            count=1,
+                        )
+                        pieces.append(current[last:cursor])
+                        pieces.append(updated_block)
+                        cursor += length
+                        last = cursor
+                        moved += 1
+                        continue
+                cursor += 1
+            pieces.append(current[last:])
+            if moved == 0:
+                raise ValueError(
+                    f"No label '{name}' found near "
+                    f"({self.format_mm(x_mm)}, {self.format_mm(y_mm)})."
+                )
+            return "".join(pieces)
+
+        try:
+            self.transactional_write(mutator)
+        except ValueError as exc:
+            return str(exc)
+        lines = [
+            self.reload_schematic(),
+            f"Moved label '{name}' to ({target_x:.2f}, {target_y:.2f}) mm.",
+        ]
+        if snap_note:
+            lines.append(snap_note)
+        return "\n".join(lines)
+
+    def modify_label(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        justify: str,
+    ) -> str:
+        """Change justification on the first matching label."""
+        resolved_justify = self.normalize_label_justify(justify) or ""
+        tolerance = 0.05
+        modified = 0
+
+        def mutator(current: str) -> str:
+            nonlocal modified
+            pieces: list[str] = []
+            cursor = 0
+            last = 0
+            while cursor < len(current):
+                if modified == 0 and current[cursor:].startswith(
+                    ("(label", "(global_label", "(hierarchical_label")
+                ):
+                    block, length = self.extract_block(current, cursor)
+                    parsed = self.parse_label_block(block) if block else None
+                    if (
+                        parsed is not None
+                        and parsed["name"] == name
+                        and abs(float(parsed["x"]) - x_mm) <= tolerance
+                        and abs(float(parsed["y"]) - y_mm) <= tolerance
+                    ):
+                        updated_block = self.set_label_justify(block, resolved_justify)
+                        pieces.append(current[last:cursor])
+                        pieces.append(updated_block)
+                        cursor += length
+                        last = cursor
+                        modified += 1
+                        continue
+                cursor += 1
+            pieces.append(current[last:])
+            if modified == 0:
+                raise ValueError(
+                    f"No label '{name}' found near "
+                    f"({self.format_mm(x_mm)}, {self.format_mm(y_mm)})."
+                )
+            return "".join(pieces)
+
+        try:
+            self.transactional_write(mutator)
+        except ValueError as exc:
+            return str(exc)
+
+        justify_desc = resolved_justify or "none (centered)"
+        return (
+            f"{self.reload_schematic()}\n"
+            f"Set justify='{justify_desc}' on label '{name}' at "
+            f"({self.format_mm(x_mm)}, {self.format_mm(y_mm)})."
+        )

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -36,11 +36,8 @@ from ..models.schematic import (
     AnnotateInput,
     AutoPlaceSymbolsInput,
     CreateSheetInput,
-    DeleteSymbolInput,
-    DeleteWireInput,
     GlobalLabelInput,
     HierarchicalLabelInput,
-    ModifyLabelInput,
     PowerSymbolInput,
     RouteWireBetweenPinsInput,
     UpdatePropertiesInput,
@@ -48,6 +45,7 @@ from ..models.schematic import (
 from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
+from ..schematic.destructive_edit import SchematicDestructiveEditService
 from ..schematic.inspection import SchematicInspectionService
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
 from ..schematic.topology import SchematicTopologyService
@@ -63,7 +61,12 @@ from ..utils.sexpr import (
     _sexpr_string,
     _unescape_sexpr_string,
 )
-from . import schematic_inspection, schematic_symbol_mutation, schematic_topology
+from . import (
+    schematic_destructive_edit,
+    schematic_inspection,
+    schematic_symbol_mutation,
+    schematic_topology,
+)
 from .metadata import headless_compatible
 from .schematic_constants import (
     _SCHEMATIC_STATE_DIRNAME,
@@ -5483,6 +5486,34 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    destructive_edit_service = SchematicDestructiveEditService(
+        active_schematic_file=_get_schematic_file,
+        read_schematic_text=lambda path: path.read_text(encoding="utf-8", errors="ignore"),
+        extract_wires=_extract_wires,
+        wire_id_matches=_wire_id_matches,
+        wire_signature=_wire_signature,
+        extract_block=_extract_block,
+        parse_wire_block=_parse_wire_block,
+        format_mm=_fmt_mm,
+        transactional_write=transactional_write,
+        reload_schematic=_reload_schematic,
+        find_placed_symbol_blocks=_find_placed_symbol_blocks,
+        symbol_connection_points=_symbol_connection_points,
+        parse_symbol_block=_parse_symbol_block,
+        coordinate_key=_coord_pair_key,
+        parse_label_block=_parse_label_block,
+        snap_point=_snap_point,
+        snap_notice=_snap_notice,
+        normalize_label_justify=_normalize_label_justify,
+        set_label_justify=_set_label_justify,
+    )
+    schematic_destructive_edit.register(
+        mcp,
+        schematic_destructive_edit.SchematicDestructiveEditDependencies(
+            service=destructive_edit_service,
+        ),
+    )
+
     @mcp.tool()
     @headless_compatible
     def sch_add_symbol(
@@ -6150,320 +6181,6 @@ def register(mcp: FastMCP) -> None:
         result = _reload_schematic()
         detail = f"Added jumper '{reference}' ({value}) at ({target_x:.2f}, {target_y:.2f}) mm."
         return f"{detail}\n{result}\n{snap_note}" if snap_note else f"{detail}\n{result}"
-
-    @mcp.tool()
-    def sch_delete_wire(wire_id: str) -> str:
-        """Remove a specific wire segment using its UUID or unique UUID prefix."""
-        payload = DeleteWireInput(wire_id=wire_id)
-        sch_file = _get_schematic_file()
-        current = sch_file.read_text(encoding="utf-8", errors="ignore")
-        wire_records = _extract_wires(current)
-        matches = [
-            wire
-            for wire in wire_records
-            if wire.get("uuid") and _wire_id_matches(str(wire["uuid"]), payload.wire_id)
-        ]
-        if not matches:
-            return f"Wire '{payload.wire_id}' was not found in the active schematic."
-        if len(matches) > 1:
-            matching_ids = ", ".join(str(wire["uuid"]) for wire in matches[:5])
-            return (
-                f"Wire identifier '{payload.wire_id}' is ambiguous. Matching UUIDs: {matching_ids}"
-            )
-
-        target = matches[0]
-        target_signature = _wire_signature(
-            target["x1"],
-            target["y1"],
-            target["x2"],
-            target["y2"],
-        )
-
-        def mutator(current_text: str) -> str:
-            pieces: list[str] = []
-            cursor = 0
-            last = 0
-            removed = False
-            while cursor < len(current_text):
-                if current_text[cursor:].startswith("(wire"):
-                    block, length = _extract_block(current_text, cursor)
-                    parsed = _parse_wire_block(block) if block else None
-                    if parsed is not None:
-                        signature = _wire_signature(
-                            parsed["x1"],
-                            parsed["y1"],
-                            parsed["x2"],
-                            parsed["y2"],
-                        )
-                        parsed_uuid = str(parsed.get("uuid", ""))
-                        if (
-                            signature == target_signature
-                            and parsed_uuid
-                            and _wire_id_matches(parsed_uuid, str(target["uuid"]))
-                        ):
-                            pieces.append(current_text[last:cursor])
-                            cursor += length
-                            last = cursor
-                            removed = True
-                            continue
-                cursor += 1
-            pieces.append(current_text[last:])
-            if not removed:
-                raise ValueError(f"Wire '{payload.wire_id}' could not be removed.")
-            return "".join(pieces)
-
-        try:
-            transactional_write(mutator, allow_node_loss=True)
-        except ValueError as exc:
-            return str(exc)
-        return (
-            f"{_reload_schematic()}\n"
-            f"Deleted wire '{target['uuid']}' from "
-            f"({_fmt_mm(target['x1'])}, {_fmt_mm(target['y1'])}) to "
-            f"({_fmt_mm(target['x2'])}, {_fmt_mm(target['y2'])})."
-        )
-
-    @mcp.tool()
-    def sch_delete_symbol(reference: str) -> str:
-        """Remove a placed symbol and any directly attached wire segments."""
-        payload = DeleteSymbolInput(reference=reference)
-        removed_wire_count = 0
-        removed_symbol_count = 0
-
-        def mutator(current: str) -> str:
-            nonlocal removed_symbol_count, removed_wire_count
-
-            matches = _find_placed_symbol_blocks(current, payload.reference)
-            if not matches:
-                raise ValueError(f"Reference '{payload.reference}' was not found in the schematic.")
-            removed_symbol_count = len(matches)
-            connection_points = {
-                point for _, _, _, parsed in matches for point in _symbol_connection_points(parsed)
-            }
-
-            pieces: list[str] = []
-            cursor = 0
-            last = 0
-            while cursor < len(current):
-                if current[cursor:].startswith("(symbol"):
-                    block, length = _extract_block(current, cursor)
-                    parsed = _parse_symbol_block(block) if block else None
-                    if parsed is not None and parsed["reference"] == payload.reference:
-                        pieces.append(current[last:cursor])
-                        cursor += length
-                        last = cursor
-                        continue
-                if current[cursor:].startswith("(wire"):
-                    block, length = _extract_block(current, cursor)
-                    parsed_wire = _parse_wire_block(block) if block else None
-                    if parsed_wire is not None:
-                        start = _coord_pair_key(parsed_wire["x1"], parsed_wire["y1"])
-                        end = _coord_pair_key(parsed_wire["x2"], parsed_wire["y2"])
-                        if start in connection_points or end in connection_points:
-                            removed_wire_count += 1
-                            pieces.append(current[last:cursor])
-                            cursor += length
-                            last = cursor
-                            continue
-                cursor += 1
-            pieces.append(current[last:])
-            return "".join(pieces)
-
-        try:
-            transactional_write(mutator, allow_node_loss=True)
-        except ValueError as exc:
-            return str(exc)
-
-        return (
-            f"{_reload_schematic()}\n"
-            f"Deleted {removed_symbol_count} symbol block(s) for '{payload.reference}' "
-            f"and {removed_wire_count} directly connected wire(s)."
-        )
-
-    @mcp.tool()
-    def sch_delete_label(name: str, x_mm: float, y_mm: float) -> str:
-        """Delete label(s) (local/global/hierarchical) matching ``name`` at the
-        given coordinate. Use sch_get_labels() to find exact names/positions."""
-        tol = 0.05
-        removed = 0
-        # sch_add_label snaps to the schematic grid by default, so a label placed at
-        # (50, 50) actually lands at (50.8, 50.8). Match against both the raw query
-        # point and its grid-snapped position so the obvious add/delete round trip
-        # works, while still deleting labels that were placed off-grid.
-        snapped_x, snapped_y = _snap_point(x_mm, y_mm, True)
-
-        def _matches_target(parsed: dict[str, Any]) -> bool:
-            for target_x, target_y in ((x_mm, y_mm), (snapped_x, snapped_y)):
-                if abs(parsed["x"] - target_x) <= tol and abs(parsed["y"] - target_y) <= tol:
-                    return True
-            return False
-
-        def mutator(current: str) -> str:
-            nonlocal removed
-            pieces: list[str] = []
-            cursor = 0
-            last = 0
-            while cursor < len(current):
-                if current[cursor:].startswith(("(label", "(global_label", "(hierarchical_label")):
-                    block, length = _extract_block(current, cursor)
-                    parsed = _parse_label_block(block) if block else None
-                    if parsed is not None and parsed["name"] == name and _matches_target(parsed):
-                        pieces.append(current[last:cursor])
-                        cursor += length
-                        last = cursor
-                        removed += 1
-                        continue
-                cursor += 1
-            pieces.append(current[last:])
-            if removed == 0:
-                raise ValueError(
-                    f"No label '{name}' found near ({_fmt_mm(x_mm)}, {_fmt_mm(y_mm)})."
-                )
-            return "".join(pieces)
-
-        try:
-            transactional_write(mutator, allow_node_loss=True)
-        except ValueError as exc:
-            return str(exc)
-        return (
-            f"{_reload_schematic()}\n"
-            f"Deleted {removed} label(s) '{name}' at ({_fmt_mm(x_mm)}, {_fmt_mm(y_mm)})."
-        )
-
-    @mcp.tool()
-    def sch_move_label(
-        name: str,
-        x_mm: float,
-        y_mm: float,
-        new_x_mm: float,
-        new_y_mm: float,
-        new_rotation: int | None = None,
-        snap_to_grid: bool = False,
-    ) -> str:
-        """Move the label matching ``name`` at (x_mm, y_mm) to a new coordinate,
-        optionally re-rotating it. snap_to_grid defaults to False so the anchor
-        can land exactly on a pin/wire endpoint."""
-        target_x, target_y = _snap_point(new_x_mm, new_y_mm, snap_to_grid)
-        snap_note = _snap_notice((new_x_mm, new_y_mm), (target_x, target_y))
-        tol = 0.05
-        moved = 0
-
-        def mutator(current: str) -> str:
-            nonlocal moved
-            pieces: list[str] = []
-            cursor = 0
-            last = 0
-            while cursor < len(current):
-                if moved == 0 and current[cursor:].startswith(
-                    ("(label", "(global_label", "(hierarchical_label")
-                ):
-                    block, length = _extract_block(current, cursor)
-                    parsed = _parse_label_block(block) if block else None
-                    if (
-                        parsed is not None
-                        and parsed["name"] == name
-                        and abs(parsed["x"] - x_mm) <= tol
-                        and abs(parsed["y"] - y_mm) <= tol
-                    ):
-                        rot = parsed["rotation"] if new_rotation is None else int(new_rotation)
-                        updated_block = re.sub(
-                            r"\(at\s+[-\d.]+\s+[-\d.]+\s+[-\d.]+\)",
-                            f"(at {_fmt_mm(target_x)} {_fmt_mm(target_y)} {rot})",
-                            block,
-                            count=1,
-                        )
-                        pieces.append(current[last:cursor])
-                        pieces.append(updated_block)
-                        cursor += length
-                        last = cursor
-                        moved += 1
-                        continue
-                cursor += 1
-            pieces.append(current[last:])
-            if moved == 0:
-                raise ValueError(
-                    f"No label '{name}' found near ({_fmt_mm(x_mm)}, {_fmt_mm(y_mm)})."
-                )
-            return "".join(pieces)
-
-        try:
-            transactional_write(mutator)
-        except ValueError as exc:
-            return str(exc)
-        lines = [
-            _reload_schematic(),
-            f"Moved label '{name}' to ({target_x:.2f}, {target_y:.2f}) mm.",
-        ]
-        if snap_note:
-            lines.append(snap_note)
-        return "\n".join(lines)
-
-    @mcp.tool()
-    def sch_modify_label(
-        name: str,
-        x_mm: float,
-        y_mm: float,
-        justify: str,
-    ) -> str:
-        """Set the text justification of an existing label (local/global/
-        hierarchical) matching ``name`` at (x_mm, y_mm). Use sch_get_labels()
-        to find exact names/positions.
-
-        Global and hierarchical labels carry a directional icon at their
-        anchor; KiCad centers unjustified text on that anchor, which overlaps
-        the icon. Pass "left", "right", "top", "bottom", or a combination like
-        "left top" to move the text clear of the icon, or "none" to restore
-        KiCad's centered default.
-        """
-        payload = ModifyLabelInput(name=name, x_mm=x_mm, y_mm=y_mm, justify=justify)
-        resolved_justify = _normalize_label_justify(payload.justify) or ""
-        tol = 0.05
-        modified = 0
-
-        def mutator(current: str) -> str:
-            nonlocal modified
-            pieces: list[str] = []
-            cursor = 0
-            last = 0
-            while cursor < len(current):
-                if modified == 0 and current[cursor:].startswith(
-                    ("(label", "(global_label", "(hierarchical_label")
-                ):
-                    block, length = _extract_block(current, cursor)
-                    parsed = _parse_label_block(block) if block else None
-                    if (
-                        parsed is not None
-                        and parsed["name"] == payload.name
-                        and abs(parsed["x"] - payload.x_mm) <= tol
-                        and abs(parsed["y"] - payload.y_mm) <= tol
-                    ):
-                        updated_block = _set_label_justify(block, resolved_justify)
-                        pieces.append(current[last:cursor])
-                        pieces.append(updated_block)
-                        cursor += length
-                        last = cursor
-                        modified += 1
-                        continue
-                cursor += 1
-            pieces.append(current[last:])
-            if modified == 0:
-                raise ValueError(
-                    f"No label '{payload.name}' found near "
-                    f"({_fmt_mm(payload.x_mm)}, {_fmt_mm(payload.y_mm)})."
-                )
-            return "".join(pieces)
-
-        try:
-            transactional_write(mutator)
-        except ValueError as exc:
-            return str(exc)
-
-        justify_desc = resolved_justify or "none (centered)"
-        return (
-            f"{_reload_schematic()}\n"
-            f"Set justify='{justify_desc}' on label '{payload.name}' at "
-            f"({_fmt_mm(payload.x_mm)}, {_fmt_mm(payload.y_mm)})."
-        )
 
     @mcp.tool()
     def sch_analyze_net_compilation(

--- a/src/kicad_mcp/tools/schematic_destructive_edit.py
+++ b/src/kicad_mcp/tools/schematic_destructive_edit.py
@@ -1,0 +1,88 @@
+"""Thin FastMCP adapters for destructive schematic wire, symbol, and label edits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..models.schematic import DeleteSymbolInput, DeleteWireInput, ModifyLabelInput
+from ..schematic.destructive_edit import SchematicDestructiveEditService
+
+
+@dataclass(frozen=True)
+class SchematicDestructiveEditDependencies:
+    """Destructive edit service injected by the schematic composition root."""
+
+    service: SchematicDestructiveEditService
+
+
+def register(mcp: FastMCP, dependencies: SchematicDestructiveEditDependencies) -> None:
+    """Register destructive schematic edit tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    def sch_delete_wire(wire_id: str) -> str:
+        """Remove a specific wire segment using its UUID or unique UUID prefix."""
+        payload = DeleteWireInput(wire_id=wire_id)
+        return service.delete_wire(payload.wire_id)
+
+    @mcp.tool()
+    def sch_delete_symbol(reference: str) -> str:
+        """Remove a placed symbol and any directly attached wire segments."""
+        payload = DeleteSymbolInput(reference=reference)
+        return service.delete_symbol(payload.reference)
+
+    @mcp.tool()
+    def sch_delete_label(name: str, x_mm: float, y_mm: float) -> str:
+        """Delete label(s) (local/global/hierarchical) matching ``name`` at the
+        given coordinate. Use sch_get_labels() to find exact names/positions."""
+        return service.delete_label(name, x_mm, y_mm)
+
+    @mcp.tool()
+    def sch_move_label(
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        new_x_mm: float,
+        new_y_mm: float,
+        new_rotation: int | None = None,
+        snap_to_grid: bool = False,
+    ) -> str:
+        """Move the label matching ``name`` at (x_mm, y_mm) to a new coordinate,
+        optionally re-rotating it. snap_to_grid defaults to False so the anchor
+        can land exactly on a pin/wire endpoint."""
+        return service.move_label(
+            name,
+            x_mm,
+            y_mm,
+            new_x_mm,
+            new_y_mm,
+            new_rotation,
+            snap_to_grid,
+        )
+
+    @mcp.tool()
+    def sch_modify_label(
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        justify: str,
+    ) -> str:
+        """Set the text justification of an existing label (local/global/
+        hierarchical) matching ``name`` at (x_mm, y_mm). Use sch_get_labels()
+        to find exact names/positions.
+
+        Global and hierarchical labels carry a directional icon at their
+        anchor; KiCad centers unjustified text on that anchor, which overlaps
+        the icon. Pass "left", "right", "top", "bottom", or a combination like
+        "left top" to move the text clear of the icon, or "none" to restore
+        KiCad's centered default.
+        """
+        payload = ModifyLabelInput(name=name, x_mm=x_mm, y_mm=y_mm, justify=justify)
+        return service.modify_label(
+            payload.name,
+            payload.x_mm,
+            payload.y_mm,
+            payload.justify,
+        )

--- a/tests/unit/test_schematic_destructive_edit_architecture.py
+++ b/tests/unit/test_schematic_destructive_edit_architecture.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_destructive_edit_modules() -> None:
+    assert "kicad_mcp.schematic.destructive_edit" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.destructive_edit" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_destructive_edit" in boundaries.DOMAIN_MODULES
+
+
+def test_destructive_edit_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_destructive_edit.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+
+
+def test_destructive_edit_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_destructive_edit.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_destructive_edit"] == 300

--- a/tests/unit/test_schematic_destructive_edit_registration.py
+++ b/tests/unit/test_schematic_destructive_edit_registration.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
+
+from kicad_mcp.tools.schematic_destructive_edit import (
+    SchematicDestructiveEditDependencies,
+    register,
+)
+
+
+class FakeDestructiveEditService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def delete_wire(self, wire_id: str) -> str:
+        self.calls.append(("delete_wire", (wire_id,)))
+        return "wire-deleted"
+
+    def delete_symbol(self, reference: str) -> str:
+        self.calls.append(("delete_symbol", (reference,)))
+        return "symbol-deleted"
+
+    def delete_label(self, name: str, x_mm: float, y_mm: float) -> str:
+        self.calls.append(("delete_label", (name, x_mm, y_mm)))
+        return "label-deleted"
+
+    def move_label(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        new_x_mm: float,
+        new_y_mm: float,
+        new_rotation: int | None,
+        snap_to_grid: bool,
+    ) -> str:
+        self.calls.append(
+            (
+                "move_label",
+                (name, x_mm, y_mm, new_x_mm, new_y_mm, new_rotation, snap_to_grid),
+            )
+        )
+        return "label-moved"
+
+    def modify_label(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        justify: str,
+    ) -> str:
+        self.calls.append(("modify_label", (name, x_mm, y_mm, justify)))
+        return "label-modified"
+
+
+def _registered() -> tuple[FastMCP, FakeDestructiveEditService]:
+    server = FastMCP("schematic-destructive-edit-test")
+    service = FakeDestructiveEditService()
+    register(server, SchematicDestructiveEditDependencies(service=service))
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_delete_wire",
+        "sch_delete_symbol",
+        "sch_delete_label",
+        "sch_move_label",
+        "sch_modify_label",
+    }
+    assert tools["sch_delete_wire"].description == (
+        "Remove a specific wire segment using its UUID or unique UUID prefix."
+    )
+    assert tools["sch_delete_symbol"].description == (
+        "Remove a placed symbol and any directly attached wire segments."
+    )
+    assert tools["sch_delete_label"].description == (
+        "Delete label(s) (local/global/hierarchical) matching ``name`` at the\n"
+        "given coordinate. Use sch_get_labels() to find exact names/positions."
+    )
+    assert tools["sch_move_label"].description == (
+        "Move the label matching ``name`` at (x_mm, y_mm) to a new coordinate,\n"
+        "optionally re-rotating it. snap_to_grid defaults to False so the anchor\n"
+        "can land exactly on a pin/wire endpoint."
+    )
+    assert tools["sch_modify_label"].description == (
+        "Set the text justification of an existing label (local/global/\n"
+        "hierarchical) matching ``name`` at (x_mm, y_mm). Use sch_get_labels()\n"
+        "to find exact names/positions.\n\n"
+        "Global and hierarchical labels carry a directional icon at their\n"
+        "anchor; KiCad centers unjustified text on that anchor, which overlaps\n"
+        'the icon. Pass "left", "right", "top", "bottom", or a combination like\n'
+        '"left top" to move the text clear of the icon, or "none" to restore\n'
+        "KiCad's centered default.\n"
+    )
+    assert tools["sch_delete_wire"].parameters["required"] == ["wire_id"]
+    assert tools["sch_delete_symbol"].parameters["required"] == ["reference"]
+    assert tools["sch_delete_label"].parameters["required"] == ["name", "x_mm", "y_mm"]
+    assert tools["sch_move_label"].parameters["required"] == [
+        "name",
+        "x_mm",
+        "y_mm",
+        "new_x_mm",
+        "new_y_mm",
+    ]
+    assert tools["sch_move_label"].parameters["properties"]["new_rotation"]["default"] is None
+    assert tools["sch_move_label"].parameters["properties"]["snap_to_grid"]["default"] is False
+    assert tools["sch_modify_label"].parameters["required"] == [
+        "name",
+        "x_mm",
+        "y_mm",
+        "justify",
+    ]
+
+
+def test_registration_delegates_exact_arguments() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_delete_wire"].fn("abc") == "wire-deleted"
+    assert tools["sch_delete_symbol"].fn("R1") == "symbol-deleted"
+    assert tools["sch_delete_label"].fn("VCC", 1.0, 2.0) == "label-deleted"
+    assert tools["sch_move_label"].fn("VCC", 1.0, 2.0, 3.0, 4.0, 90, True) == ("label-moved")
+    assert tools["sch_modify_label"].fn("VCC", 3.0, 4.0, "left top") == ("label-modified")
+    assert service.calls == [
+        ("delete_wire", ("abc",)),
+        ("delete_symbol", ("R1",)),
+        ("delete_label", ("VCC", 1.0, 2.0)),
+        ("move_label", ("VCC", 1.0, 2.0, 3.0, 4.0, 90, True)),
+        ("modify_label", ("VCC", 3.0, 4.0, "left top")),
+    ]
+
+
+def test_registration_preserves_pydantic_validation() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    with pytest.raises(ValidationError):
+        tools["sch_delete_wire"].fn("")
+    with pytest.raises(ValidationError):
+        tools["sch_delete_symbol"].fn("")
+    with pytest.raises(ValidationError):
+        tools["sch_modify_label"].fn("VCC", 1.0, 2.0, "diagonal")

--- a/tests/unit/test_schematic_destructive_edit_service.py
+++ b/tests/unit/test_schematic_destructive_edit_service.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from kicad_mcp.schematic.destructive_edit import SchematicDestructiveEditService
+
+
+class _TransactionRecorder:
+    def __init__(self, current: str) -> None:
+        self.current = current
+        self.calls: list[bool] = []
+        self.updated: str | None = None
+
+    def __call__(
+        self,
+        mutator: Callable[[str], str],
+        *,
+        allow_node_loss: bool = False,
+    ) -> str:
+        self.calls.append(allow_node_loss)
+        self.updated = mutator(self.current)
+        return self.updated
+
+
+def _simple_extract_block(content: str, start: int) -> tuple[str, int]:
+    end = content.index(")", start) + 1
+    return content[start:end], end - start
+
+
+def _fmt_mm(value: float) -> str:
+    return f"{value:g}"
+
+
+def _service(
+    *,
+    current: str,
+    transaction: _TransactionRecorder | None = None,
+    wire_records: list[dict[str, Any]] | None = None,
+    wire_blocks: Mapping[str, dict[str, Any]] | None = None,
+    symbol_matches: Mapping[str, list[tuple[str, int, int, dict[str, Any]]]] | None = None,
+    symbol_blocks: Mapping[str, dict[str, Any]] | None = None,
+    label_blocks: Mapping[str, dict[str, Any]] | None = None,
+    snap_result: tuple[float, float] | None = None,
+    snap_message: str = "",
+    justify_calls: list[tuple[str, str]] | None = None,
+) -> tuple[SchematicDestructiveEditService, _TransactionRecorder]:
+    tx = transaction or _TransactionRecorder(current)
+    justify_records = justify_calls if justify_calls is not None else []
+
+    def read_text(_path: Path) -> str:
+        return current
+
+    def parse_wire(block: str) -> Mapping[str, Any] | None:
+        return (wire_blocks or {}).get(block)
+
+    def find_symbols(
+        _content: str,
+        reference: str,
+    ) -> list[tuple[str, int, int, Mapping[str, Any]]]:
+        return list((symbol_matches or {}).get(reference, []))
+
+    def parse_symbol(block: str) -> Mapping[str, Any] | None:
+        return (symbol_blocks or {}).get(block)
+
+    def parse_label(block: str) -> Mapping[str, Any] | None:
+        return (label_blocks or {}).get(block)
+
+    def normalize_justify(value: str | None) -> str | None:
+        if value is None or value.strip().casefold() in {"", "none"}:
+            return None
+        return " ".join(value.strip().casefold().split())
+
+    def set_justify(block: str, justify: str) -> str:
+        justify_records.append((block, justify))
+        return f"{block}[justify={justify}]"
+
+    return (
+        SchematicDestructiveEditService(
+            active_schematic_file=lambda: Path("demo.kicad_sch"),
+            read_schematic_text=read_text,
+            extract_wires=lambda _content: list(wire_records or []),
+            wire_id_matches=lambda actual, requested: (
+                actual.casefold() == requested.casefold()
+                or actual.casefold().startswith(requested.casefold())
+                or requested.casefold().startswith(actual.casefold())
+            ),
+            wire_signature=lambda x1, y1, x2, y2: (
+                float(x1),
+                float(y1),
+                float(x2),
+                float(y2),
+            ),
+            extract_block=_simple_extract_block,
+            parse_wire_block=parse_wire,
+            format_mm=_fmt_mm,
+            transactional_write=tx,
+            reload_schematic=lambda: "Reloaded schematic.",
+            find_placed_symbol_blocks=find_symbols,
+            symbol_connection_points=lambda parsed: set(parsed.get("points", set())),
+            parse_symbol_block=parse_symbol,
+            coordinate_key=lambda x, y: (round(float(x), 4), round(float(y), 4)),
+            parse_label_block=parse_label,
+            snap_point=lambda x, y, enabled: snap_result if enabled and snap_result else (x, y),
+            snap_notice=lambda _original, _snapped: snap_message,
+            normalize_label_justify=normalize_justify,
+            set_label_justify=set_justify,
+        ),
+        tx,
+    )
+
+
+def test_delete_wire_preserves_prefix_matching_and_destructive_transaction() -> None:
+    current = "aa(wire-a)bb"
+    record = {"uuid": "abc123", "x1": 1.0, "y1": 2.0, "x2": 3.0, "y2": 4.0}
+    service, transaction = _service(
+        current=current,
+        wire_records=[record],
+        wire_blocks={"(wire-a)": record},
+    )
+
+    assert service.delete_wire("abc") == (
+        "Reloaded schematic.\nDeleted wire 'abc123' from (1, 2) to (3, 4)."
+    )
+    assert transaction.calls == [True]
+    assert transaction.updated == "aabb"
+
+
+def test_delete_wire_preserves_missing_and_ambiguous_results() -> None:
+    missing, missing_tx = _service(current="plain")
+    assert missing.delete_wire("missing") == (
+        "Wire 'missing' was not found in the active schematic."
+    )
+    assert missing_tx.calls == []
+
+    ambiguous, ambiguous_tx = _service(
+        current="plain",
+        wire_records=[
+            {"uuid": "abcd-1", "x1": 0, "y1": 0, "x2": 1, "y2": 1},
+            {"uuid": "abcd-2", "x1": 1, "y1": 1, "x2": 2, "y2": 2},
+        ],
+    )
+    assert ambiguous.delete_wire("abcd") == (
+        "Wire identifier 'abcd' is ambiguous. Matching UUIDs: abcd-1, abcd-2"
+    )
+    assert ambiguous_tx.calls == []
+
+
+def test_delete_symbol_removes_matching_symbols_and_attached_wires() -> None:
+    current = "aa(symbol-r1)bb(wire-attached)cc(wire-other)dd"
+    symbol = {"reference": "R1", "points": {(1.0, 2.0)}}
+    attached = {"x1": 1.0, "y1": 2.0, "x2": 5.0, "y2": 6.0}
+    other = {"x1": 7.0, "y1": 8.0, "x2": 9.0, "y2": 10.0}
+    service, transaction = _service(
+        current=current,
+        symbol_matches={"R1": [("(symbol-r1)", 2, 13, symbol)]},
+        symbol_blocks={"(symbol-r1)": symbol},
+        wire_blocks={"(wire-attached)": attached, "(wire-other)": other},
+    )
+
+    assert service.delete_symbol("R1") == (
+        "Reloaded schematic.\nDeleted 1 symbol block(s) for 'R1' and 1 directly connected wire(s)."
+    )
+    assert transaction.calls == [True]
+    assert transaction.updated == "aabbcc(wire-other)dd"
+
+
+def test_delete_symbol_preserves_missing_reference_result() -> None:
+    service, transaction = _service(current="plain")
+
+    assert service.delete_symbol("R404") == ("Reference 'R404' was not found in the schematic.")
+    assert transaction.calls == [True]
+    assert transaction.updated is None
+
+
+def test_delete_label_matches_raw_or_grid_snapped_coordinates() -> None:
+    current = "aa(label-vcc)bb"
+    service, transaction = _service(
+        current=current,
+        label_blocks={"(label-vcc)": {"name": "VCC", "x": 50.8, "y": 50.8}},
+        snap_result=(50.8, 50.8),
+    )
+
+    assert service.delete_label("VCC", 50.0, 50.0) == (
+        "Reloaded schematic.\nDeleted 1 label(s) 'VCC' at (50, 50)."
+    )
+    assert transaction.calls == [True]
+    assert transaction.updated == "aabb"
+
+
+def test_delete_label_preserves_missing_result() -> None:
+    service, transaction = _service(current="aa(label-gnd)bb")
+
+    assert service.delete_label("GND", 1.0, 2.0) == ("No label 'GND' found near (1, 2).")
+    assert transaction.calls == [True]
+    assert transaction.updated is None
+
+
+def test_move_label_preserves_rotation_snap_notice_and_normal_transaction() -> None:
+    current = "aa(label-vcc (at 1 2 90))bb"
+    block = "(label-vcc (at 1 2 90)"
+    service, transaction = _service(
+        current=current,
+        label_blocks={block: {"name": "VCC", "x": 1.0, "y": 2.0, "rotation": 90}},
+        snap_result=(10.16, 20.32),
+        snap_message="Grid snap: (10.0, 20.0) -> (10.16, 20.32)",
+    )
+
+    assert service.move_label("VCC", 1.0, 2.0, 10.0, 20.0, None, True) == (
+        "Reloaded schematic.\n"
+        "Moved label 'VCC' to (10.16, 20.32) mm.\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)"
+    )
+    assert transaction.calls == [False]
+    assert "(at 10.16 20.32 90)" in str(transaction.updated)
+
+
+def test_move_label_preserves_missing_result_without_reload() -> None:
+    service, transaction = _service(current="plain")
+
+    assert service.move_label("NOPE", 1.0, 2.0, 3.0, 4.0, 0, False) == (
+        "No label 'NOPE' found near (1, 2)."
+    )
+    assert transaction.calls == [False]
+    assert transaction.updated is None
+
+
+def test_modify_label_preserves_normalization_and_result() -> None:
+    current = "aa(label-vcc)bb"
+    justify_calls: list[tuple[str, str]] = []
+    service, transaction = _service(
+        current=current,
+        label_blocks={"(label-vcc)": {"name": "VCC", "x": 1.0, "y": 2.0}},
+        justify_calls=justify_calls,
+    )
+
+    assert service.modify_label("VCC", 1.0, 2.0, "LEFT   TOP") == (
+        "Reloaded schematic.\nSet justify='left top' on label 'VCC' at (1, 2)."
+    )
+    assert transaction.calls == [False]
+    assert justify_calls == [("(label-vcc)", "left top")]
+
+
+def test_modify_label_preserves_centered_and_missing_results() -> None:
+    centered, _transaction = _service(
+        current="aa(label-vcc)bb",
+        label_blocks={"(label-vcc)": {"name": "VCC", "x": 1.0, "y": 2.0}},
+    )
+    assert centered.modify_label("VCC", 1.0, 2.0, "none") == (
+        "Reloaded schematic.\nSet justify='none (centered)' on label 'VCC' at (1, 2)."
+    )
+
+    missing, missing_tx = _service(current="plain")
+    assert missing.modify_label("NOPE", 1.0, 2.0, "left") == ("No label 'NOPE' found near (1, 2).")
+    assert missing_tx.calls == [False]

--- a/tests/unit/test_schematic_destructive_edit_service.py
+++ b/tests/unit/test_schematic_destructive_edit_service.py
@@ -52,19 +52,19 @@ def _service(
     def read_text(_path: Path) -> str:
         return current
 
-    def parse_wire(block: str) -> Mapping[str, Any] | None:
+    def parse_wire(block: str) -> dict[str, Any] | None:
         return (wire_blocks or {}).get(block)
 
     def find_symbols(
         _content: str,
         reference: str,
-    ) -> list[tuple[str, int, int, Mapping[str, Any]]]:
+    ) -> list[tuple[str, int, int, dict[str, Any]]]:
         return list((symbol_matches or {}).get(reference, []))
 
-    def parse_symbol(block: str) -> Mapping[str, Any] | None:
+    def parse_symbol(block: str) -> dict[str, Any] | None:
         return (symbol_blocks or {}).get(block)
 
-    def parse_label(block: str) -> Mapping[str, Any] | None:
+    def parse_label(block: str) -> dict[str, Any] | None:
         return (label_blocks or {}).get(block)
 
     def normalize_justify(value: str | None) -> str | None:

--- a/tests/unit/test_schematic_destructive_edit_service.py
+++ b/tests/unit/test_schematic_destructive_edit_service.py
@@ -147,6 +147,21 @@ def test_delete_wire_preserves_missing_and_ambiguous_results() -> None:
     assert ambiguous_tx.calls == []
 
 
+def test_delete_wire_preserves_transaction_time_missing_result() -> None:
+    record = {"uuid": "abc123", "x1": 1.0, "y1": 2.0, "x2": 3.0, "y2": 4.0}
+    transaction = _TransactionRecorder("plain")
+    service, transaction = _service(
+        current="aa(wire-a)bb",
+        transaction=transaction,
+        wire_records=[record],
+        wire_blocks={"(wire-a)": record},
+    )
+
+    assert service.delete_wire("abc") == "Wire 'abc' could not be removed."
+    assert transaction.calls == [True]
+    assert transaction.updated is None
+
+
 def test_delete_symbol_removes_matching_symbols_and_attached_wires() -> None:
     current = "aa(symbol-r1)bb(wire-attached)cc(wire-other)dd"
     symbol = {"reference": "R1", "points": {(1.0, 2.0)}}
@@ -187,6 +202,24 @@ def test_delete_label_matches_raw_or_grid_snapped_coordinates() -> None:
     )
     assert transaction.calls == [True]
     assert transaction.updated == "aabb"
+
+
+def test_delete_label_skips_nonmatching_label_before_target() -> None:
+    current = "aa(label-other)bb(label-vcc)cc"
+    service, transaction = _service(
+        current=current,
+        label_blocks={
+            "(label-other)": {"name": "VCC", "x": 1.0, "y": 2.0},
+            "(label-vcc)": {"name": "VCC", "x": 50.8, "y": 50.8},
+        },
+        snap_result=(50.8, 50.8),
+    )
+
+    assert service.delete_label("VCC", 50.0, 50.0) == (
+        "Reloaded schematic.\nDeleted 1 label(s) 'VCC' at (50, 50)."
+    )
+    assert transaction.calls == [True]
+    assert transaction.updated == "aa(label-other)bbcc"
 
 
 def test_delete_label_preserves_missing_result() -> None:


### PR DESCRIPTION
## Summary

- extract explicit wire, symbol, and label edit orchestration into a typed, FastMCP-free `SchematicDestructiveEditService`
- add a 69-line registration adapter for `sch_delete_wire`, `sch_delete_symbol`, `sch_delete_label`, `sch_move_label`, and `sch_modify_label`
- reduce the main schematic registration function from 3,093 to 2,807 lines
- add architecture policy for service purity, adapter isolation, and the 300-line registration limit
- document the bounded design, implementation plan, verification evidence, and remaining #434 work

## Compatibility and safety

- public tool names, descriptions, input schemas, annotations, profiles, validation, matching tolerances, and outputs are unchanged
- exact full-server metadata comparison against `main` is identical for all five tools
- the committed tool-surface snapshot remains unchanged
- `allow_node_loss=True` remains limited to wire, symbol, and label deletion; label movement and justification retain the default structural-loss guard
- transaction/checkpoint behavior, reload ordering, backend selection, and exception behavior remain unchanged
- no runtime dependency is added
- this is the fourth bounded tranche of #434 and does not close the parent task

## Verification

- focused service, registration, and schematic integration suite: 150 passed
- focused line coverage for the extracted service and adapter: 100%
- full unit suite passed with five expected skips
- committed MCP `tools/list` latency benchmark passed
- metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated documentation, workflow policy/security, strict MkDocs, and tool-surface snapshot checks passed
- main schematic `register()` span: 3,093 → 2,807 lines
- adapter `register()` span: 69 lines

## Review notes

The extraction intentionally preserves the existing explicit destructive boundaries rather than broadening them. Deletion call sites still opt into structural loss, while non-deletion label edits remain protected by the default round-trip guard.

Refs #434