### PR TITLE
refactor(schematic): extract basic authoring domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-basic-authoring-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-basic-authoring-service.md
@@ -29,11 +29,11 @@
 - Produces methods: `add_symbol`, `add_wire`, `add_label`, and `add_power_symbol`.
 - Consumes injected target, parser, library, snapping, formatting, block-builder, transaction, UUID, and reload callables.
 
-- [ ] **Step 1: Write failing direct service tests**
+- [x] **Step 1: Write failing direct service tests**
 
 Cover symbol success, missing symbol with suggestions, invalid units, library insertion, warnings and result ordering, wire targeting/snapping, label alias/error behavior, and delegated power-symbol success/failure.
 
-- [ ] **Step 2: Run and verify RED**
+- [x] **Step 2: Run and verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_service.py
@@ -41,15 +41,15 @@ uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_service.
 
 Expected: collection failure because `kicad_mcp.schematic.basic_authoring` does not exist.
 
-- [ ] **Step 3: Implement the injected service**
+- [x] **Step 3: Implement the injected service**
 
 Implement only the current observable orchestration. Keep Pydantic models out of the service and accept already validated primitive values.
 
-- [ ] **Step 4: Run and verify GREEN**
+- [x] **Step 4: Run and verify GREEN**
 
 Run the command from Step 2. Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/schematic/basic_authoring.py \
@@ -69,11 +69,11 @@ git commit -m "refactor(schematic): extract basic authoring service"
 - Produces: `SchematicBasicAuthoringDependencies(service)`.
 - Produces: `register(mcp, dependencies) -> None`.
 
-- [ ] **Step 1: Write failing registration tests**
+- [x] **Step 1: Write failing registration tests**
 
 Assert exact public names, descriptions, schemas, headless metadata, Pydantic validation, alias behavior, and argument delegation.
 
-- [ ] **Step 2: Run and verify RED**
+- [x] **Step 2: Run and verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_registration.py
@@ -81,11 +81,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_registra
 
 Expected: collection failure because the adapter does not exist.
 
-- [ ] **Step 3: Implement and wire the adapter**
+- [x] **Step 3: Implement and wire the adapter**
 
 Construct the service in the composition root, register the adapter once, and remove the five nested legacy functions.
 
-- [ ] **Step 4: Run focused behavior tests**
+- [x] **Step 4: Run focused behavior tests**
 
 ```bash
 uv run --all-extras pytest -q \
@@ -97,7 +97,7 @@ uv run --all-extras pytest -q \
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/tools/schematic.py \
@@ -112,15 +112,15 @@ git commit -m "refactor(schematic): delegate basic authoring registration"
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_basic_authoring_architecture.py`
 
-- [ ] **Step 1: Write failing architecture tests**
+- [x] **Step 1: Write failing architecture tests**
 
 Assert service/adapter tracking, service purity, adapter isolation, and the 300-line limit.
 
-- [ ] **Step 2: Extend the architecture checker**
+- [x] **Step 2: Extend the architecture checker**
 
 Register both modules, keep only the service in `PURE_HELPERS`, add the adapter import guard, and enforce the line limit.
 
-- [ ] **Step 3: Verify public-surface stability**
+- [x] **Step 3: Verify public-surface stability**
 
 ```bash
 uv run --all-extras python scripts/check_architecture_boundaries.py
@@ -130,7 +130,7 @@ corepack pnpm run docs:tools:check
 
 Expected: all pass without snapshot regeneration.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add scripts/check_architecture_boundaries.py \
@@ -140,8 +140,20 @@ git commit -m "test(architecture): guard basic authoring boundaries"
 
 ### Task 4: Verify, publish, and review
 
-- [ ] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, focused coverage, and representative performance gates.
-- [ ] Record exact public-surface and registration line-count evidence.
+- [x] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, focused coverage, and representative performance gates.
+- [x] Record exact public-surface and registration line-count evidence.
 - [ ] Push and open a professional English PR referencing #434.
 - [ ] Inspect every bot/agent comment, review, and review thread; resolve actionable findings.
 - [ ] Merge only after all required checks pass.
+
+
+## Verification Evidence
+
+- Exact full-server metadata for all five extracted tools matches `main`: names, descriptions, input schemas, and annotations are identical.
+- `tests/integration/test_tool_surface_snapshot.py` passes without snapshot regeneration.
+- The main schematic `register()` span decreased from 2,807 to 2,591 lines; the basic-authoring adapter `register()` spans 199 lines.
+- Focused service, registration, and schematic integration coverage passed: 149 tests.
+- The extracted service and adapter have 100% focused line coverage.
+- The full unit suite passed with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, and the committed MCP latency benchmark all pass.
+- No runtime dependency, public tool contract, child-sheet targeting, grid default, transaction target, reload order, warning order, or backend-selection behavior changed.

--- a/docs/superpowers/plans/2026-07-23-schematic-basic-authoring-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-basic-authoring-service.md
@@ -1,0 +1,147 @@
+# Schematic Basic Authoring Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract five basic schematic authoring tools into a FastMCP-free service and a sub-300-line registration adapter without changing the public MCP surface.
+
+**Architecture:** `kicad_mcp.schematic.basic_authoring` owns deterministic symbol, wire, label, and power-symbol orchestration behind injected callables. `kicad_mcp.tools.schematic_basic_authoring` retains FastMCP decorators and Pydantic validation. `tools.schematic.register()` remains the composition root.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, pytest, Ruff, mypy, Pyright, existing architecture and tool-surface gates.
+
+## Global Constraints
+
+- Preserve exact names, descriptions, schemas, annotations, profiles, defaults, validation, messages, and result-line ordering.
+- Preserve child-sheet targeting, grid defaults, library insertion, root UUID selection, project naming, warnings, transaction targets, and reload ordering.
+- Keep the domain service free of FastMCP, server/connection state, GUI dependencies, KiCad IPC, and `tools.schematic` imports.
+- Keep `tools.schematic_basic_authoring.register()` at or below 300 lines.
+- Do not add runtime dependencies or close #434.
+
+---
+
+### Task 1: Extract the basic authoring service
+
+**Files:**
+- Create: `tests/unit/test_schematic_basic_authoring_service.py`
+- Create: `src/kicad_mcp/schematic/basic_authoring.py`
+
+**Interfaces:**
+- Produces: `SchematicBasicAuthoringService`.
+- Produces methods: `add_symbol`, `add_wire`, `add_label`, and `add_power_symbol`.
+- Consumes injected target, parser, library, snapping, formatting, block-builder, transaction, UUID, and reload callables.
+
+- [ ] **Step 1: Write failing direct service tests**
+
+Cover symbol success, missing symbol with suggestions, invalid units, library insertion, warnings and result ordering, wire targeting/snapping, label alias/error behavior, and delegated power-symbol success/failure.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_service.py
+```
+
+Expected: collection failure because `kicad_mcp.schematic.basic_authoring` does not exist.
+
+- [ ] **Step 3: Implement the injected service**
+
+Implement only the current observable orchestration. Keep Pydantic models out of the service and accept already validated primitive values.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/schematic/basic_authoring.py \
+  tests/unit/test_schematic_basic_authoring_service.py
+git commit -m "refactor(schematic): extract basic authoring service"
+```
+
+### Task 2: Add the thin registration adapter
+
+**Files:**
+- Create: `tests/unit/test_schematic_basic_authoring_registration.py`
+- Create: `src/kicad_mcp/tools/schematic_basic_authoring.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicBasicAuthoringService`.
+- Produces: `SchematicBasicAuthoringDependencies(service)`.
+- Produces: `register(mcp, dependencies) -> None`.
+
+- [ ] **Step 1: Write failing registration tests**
+
+Assert exact public names, descriptions, schemas, headless metadata, Pydantic validation, alias behavior, and argument delegation.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_registration.py
+```
+
+Expected: collection failure because the adapter does not exist.
+
+- [ ] **Step 3: Implement and wire the adapter**
+
+Construct the service in the composition root, register the adapter once, and remove the five nested legacy functions.
+
+- [ ] **Step 4: Run focused behavior tests**
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_basic_authoring_service.py \
+  tests/unit/test_schematic_basic_authoring_registration.py \
+  tests/integration/test_schematic_tools.py \
+  tests/integration/test_schematic_extended.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/tools/schematic.py \
+  src/kicad_mcp/tools/schematic_basic_authoring.py \
+  tests/unit/test_schematic_basic_authoring_registration.py
+git commit -m "refactor(schematic): delegate basic authoring registration"
+```
+
+### Task 3: Enforce architecture and surface stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_basic_authoring_architecture.py`
+
+- [ ] **Step 1: Write failing architecture tests**
+
+Assert service/adapter tracking, service purity, adapter isolation, and the 300-line limit.
+
+- [ ] **Step 2: Extend the architecture checker**
+
+Register both modules, keep only the service in `PURE_HELPERS`, add the adapter import guard, and enforce the line limit.
+
+- [ ] **Step 3: Verify public-surface stability**
+
+```bash
+uv run --all-extras python scripts/check_architecture_boundaries.py
+uv run --all-extras pytest -q tests/integration/test_tool_surface_snapshot.py
+corepack pnpm run docs:tools:check
+```
+
+Expected: all pass without snapshot regeneration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check_architecture_boundaries.py \
+  tests/unit/test_schematic_basic_authoring_architecture.py
+git commit -m "test(architecture): guard basic authoring boundaries"
+```
+
+### Task 4: Verify, publish, and review
+
+- [ ] Run metadata, format, lint, mypy, scoped strict Pyright, full unit, workflow security, strict docs, snapshot, focused coverage, and representative performance gates.
+- [ ] Record exact public-surface and registration line-count evidence.
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect every bot/agent comment, review, and review thread; resolve actionable findings.
+- [ ] Merge only after all required checks pass.

--- a/docs/superpowers/specs/2026-07-23-schematic-basic-authoring-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-basic-authoring-service-design.md
@@ -1,0 +1,102 @@
+# Schematic Basic Authoring Service Extraction Design
+
+**Status:** Accepted
+**Date:** 2026-07-23
+**Tracking issue:** #434
+
+## Context
+
+After the inspection, topology, symbol-mutation, and destructive-edit tranches, `src/kicad_mcp/tools/schematic.py` still owns basic symbol, wire, label, and power-symbol creation inside its FastMCP registration function. These tools share grid snapping, child-sheet targeting, transactional writes, reload ordering, and exact result composition, but their domain behavior remains coupled to FastMCP.
+
+## Decision
+
+Create two focused modules:
+
+- `kicad_mcp.schematic.basic_authoring`: a FastMCP-free service for deterministic symbol, wire, label, and power-symbol creation.
+- `kicad_mcp.tools.schematic_basic_authoring`: a thin registration adapter that preserves public decorators and Pydantic validation.
+
+The existing schematic registration function remains the composition root. It injects the current parser, target resolver, symbol-library lookups, formatting helpers, transaction boundary, and reload callback.
+
+## Tool Boundary
+
+This tranche extracts exactly five public tools:
+
+- `sch_add_symbol`
+- `sch_add_component`
+- `sch_add_wire`
+- `sch_add_label`
+- `sch_add_power_symbol`
+
+`sch_add_component` remains a public compatibility alias for symbol creation. `sch_add_power_symbol` continues to create a generated `#PWR` reference and delegates through the same symbol-authoring path.
+
+`sch_add_pin_labels`, bus tools, no-connect markers, and higher-level circuit construction remain in later bounded tranches.
+
+## Service Interface
+
+`SchematicBasicAuthoringService` exposes:
+
+```python
+add_symbol(..., sheet: str | None, sheet_file: str | None) -> str
+add_wire(..., sheet: str | None, sheet_file: str | None) -> str
+add_label(..., sheet: str | None, sheet_file: str | None) -> str
+add_power_symbol(..., sheet: str | None, sheet_file: str | None) -> str
+```
+
+The service receives already validated primitive arguments. The adapter retains Pydantic validation with `AddSymbolInput`, `AddWireInput`, and `AddLabelInput`.
+
+Injected dependencies cover:
+
+- target resolution and target-detail formatting;
+- schematic parsing and project-name lookup;
+- symbol-library loading, suggestions, and unit discovery;
+- grid snapping and snap notices;
+- overlap and footprint warnings;
+- symbol, wire, and label block construction;
+- insertion before sheet instances;
+- UUID generation;
+- transactional writes and schematic reload.
+
+The service imports no FastMCP, server, connection, GUI, KiCad IPC, or schematic registry module.
+
+## Compatibility Rules
+
+- Preserve all public names, descriptions, schemas, annotations, profiles, defaults, and validation behavior.
+- Preserve symbol-not-found suggestions and unsupported-unit messages.
+- Preserve library-definition insertion, root UUID selection, project-name selection, overlap warning, footprint warning, and child-sheet targeting.
+- Preserve the `name`/`text` label alias and its exact missing-value exception.
+- Preserve grid defaults, transaction target paths, reload ordering, and result-line ordering.
+- Preserve power-symbol generated references and final placement message.
+- Do not add runtime dependencies or change the tool-surface snapshot.
+
+## Error Handling
+
+- Missing symbols return the existing human-readable result without writing or reloading.
+- Unsupported units return the existing available-unit result without writing or reloading.
+- Missing label `name` and `text` raises the existing `ValueError` before target resolution.
+- Transaction, parser, and helper exceptions propagate exactly as before.
+- Power-symbol lookup failures return the delegated symbol failure unchanged.
+
+## Architecture Enforcement
+
+The architecture checker will:
+
+- track both new modules;
+- keep only the service in `PURE_HELPERS`;
+- reject imports from the adapter back into `tools.schematic`;
+- enforce a 300-line limit on the adapter `register()` function;
+- continue cycle detection across extracted modules.
+
+## Verification
+
+Required evidence:
+
+1. direct service tests without FastMCP;
+2. registration tests for exact names, schemas, descriptions, metadata, validation, and delegation;
+3. exact full-server metadata comparison against `main`;
+4. unchanged tool-surface snapshot and generated tool reference;
+5. focused schematic integration tests;
+6. full unit, type, coverage, workflow-security, strict documentation, and performance gates.
+
+## Rollout
+
+This is the fifth bounded tranche of #434 and does not close the issue. Later tranches will extract pin-label and bus/marker authoring, circuit compilation/building, placement/readability, rendering/preview, sheet metadata/layout, and template orchestration.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -23,6 +23,10 @@ DOMAIN_MODULES = {
     / "contract_verifier.py",
     "kicad_mcp.models.sch_transaction": SRC_ROOT / "kicad_mcp" / "models" / "sch_transaction.py",
     "kicad_mcp.models.visual_qa": SRC_ROOT / "kicad_mcp" / "models" / "visual_qa.py",
+    "kicad_mcp.schematic.basic_authoring": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "basic_authoring.py",
     "kicad_mcp.schematic.destructive_edit": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -33,6 +37,10 @@ DOMAIN_MODULES = {
     / "schematic"
     / "symbol_mutation.py",
     "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
+    "kicad_mcp.tools.schematic_basic_authoring": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_basic_authoring.py",
     "kicad_mcp.tools.schematic_destructive_edit": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -65,6 +73,7 @@ PURE_HELPERS = {
     "kicad_mcp.models.contract_verifier",
     "kicad_mcp.models.sch_transaction",
     "kicad_mcp.models.visual_qa",
+    "kicad_mcp.schematic.basic_authoring",
     "kicad_mcp.schematic.destructive_edit",
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.symbol_mutation",
@@ -84,6 +93,7 @@ FORBIDDEN_PURE_IMPORT_PREFIXES = (
 )
 
 ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
+    "kicad_mcp.tools.schematic_basic_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
@@ -91,6 +101,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
 }
 
 REGISTER_LINE_LIMITS = {
+    "kicad_mcp.tools.schematic_basic_authoring": 300,
     "kicad_mcp.tools.schematic_destructive_edit": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,

--- a/src/kicad_mcp/schematic/basic_authoring.py
+++ b/src/kicad_mcp/schematic/basic_authoring.py
@@ -1,0 +1,302 @@
+"""Pure orchestration for basic schematic symbol, wire, and label authoring."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class SchematicTarget(Protocol):
+    """Minimal resolved-target surface used by basic authoring."""
+
+    @property
+    def path(self) -> Path: ...
+
+    @property
+    def is_root(self) -> bool: ...
+
+
+class ResolveTarget(Protocol):
+    """Resolve an optional child-sheet selector."""
+
+    def __call__(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> SchematicTarget: ...
+
+
+class TransactionalWrite(Protocol):
+    """Write one deterministic schematic mutation to an explicit target."""
+
+    def __call__(self, mutator: Callable[[str], str], path: Path) -> str: ...
+
+
+class PlaceSymbolBlock(Protocol):
+    """Create a placed-symbol S-expression block."""
+
+    def __call__(
+        self,
+        *,
+        lib_id: str,
+        x: float,
+        y: float,
+        reference: str,
+        value: str,
+        footprint: str = "",
+        rotation: int = 0,
+        unit: int = 1,
+        project_name: str,
+        root_uuid: str,
+    ) -> str: ...
+
+
+class LabelBlock(Protocol):
+    """Create a local-label S-expression block."""
+
+    def __call__(
+        self,
+        name: str,
+        x: float,
+        y: float,
+        rotation: int = 0,
+        *,
+        justify: str | None = None,
+    ) -> str: ...
+
+
+type FormatTargetDetail = Callable[[SchematicTarget], str]
+type ParseSchematic = Callable[[Path], Mapping[str, Any]]
+type ProjectName = Callable[[], str]
+type LoadLibSymbol = Callable[[str, str], str | None]
+type SuggestSymbolNames = Callable[[str, str], list[str]]
+type SymbolAvailableUnits = Callable[[str, str], set[int]]
+type FormatAvailableUnits = Callable[[set[int]], str]
+type SnapPoint = Callable[[float, float, bool], tuple[float, float]]
+type SnapLine = Callable[
+    [float, float, float, float, bool],
+    tuple[float, float, float, float],
+]
+type SnapNotice = Callable[[tuple[float, ...], tuple[float, ...]], str]
+type PointNearExisting = Callable[[float, float, list[dict[str, Any]]], str]
+type ValidateFootprint = Callable[[str], str | None]
+type WireBlock = Callable[[float, float, float, float], str]
+type AppendBeforeSheetInstances = Callable[[str, str], str]
+type ReloadSchematic = Callable[[], str]
+type NewUuid = Callable[[], str]
+type FormatMm = Callable[[float], str]
+
+
+@dataclass(frozen=True)
+class SchematicBasicAuthoringService:
+    """Compose basic authoring operations from injected deterministic helpers."""
+
+    resolve_target: ResolveTarget
+    format_target_detail: FormatTargetDetail
+    parse_schematic: ParseSchematic
+    project_name: ProjectName
+    load_lib_symbol: LoadLibSymbol
+    suggest_symbol_names: SuggestSymbolNames
+    symbol_available_units: SymbolAvailableUnits
+    format_available_units: FormatAvailableUnits
+    snap_point: SnapPoint
+    snap_line: SnapLine
+    snap_notice: SnapNotice
+    point_near_existing: PointNearExisting
+    validate_footprint: ValidateFootprint
+    place_symbol_block: PlaceSymbolBlock
+    wire_block: WireBlock
+    label_block: LabelBlock
+    append_before_sheet_instances: AppendBeforeSheetInstances
+    transactional_write: TransactionalWrite
+    reload_schematic: ReloadSchematic
+    new_uuid: NewUuid
+    format_mm: FormatMm
+
+    def add_symbol(
+        self,
+        library: str,
+        symbol_name: str,
+        x_mm: float,
+        y_mm: float,
+        reference: str,
+        value: str,
+        footprint: str,
+        rotation: int,
+        snap_to_grid: bool,
+        unit: int,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add one placed symbol while preserving current warnings and ordering."""
+        symbol_x, symbol_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (symbol_x, symbol_y))
+        lib_definition = self.load_lib_symbol(library, symbol_name)
+        if lib_definition is None:
+            suggestions = self.suggest_symbol_names(library, symbol_name)
+            hint = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+            return f"Symbol '{library}:{symbol_name}' was not found.{hint}"
+
+        available_units = self.symbol_available_units(library, symbol_name)
+        if available_units and unit not in available_units:
+            return (
+                f"Symbol '{library}:{symbol_name}' does not support unit {unit}. "
+                f"Available units: {self.format_available_units(available_units)}."
+            )
+
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        schematic_data = self.parse_schematic(target.path)
+        root_uuid = str(schematic_data["uuid"] or self.new_uuid())
+        lib_id = f"{library}:{symbol_name}"
+        existing = [
+            *schematic_data["symbols"],
+            *schematic_data["power_symbols"],
+        ]
+        overlap_warning = self.point_near_existing(symbol_x, symbol_y, existing)
+
+        def mutator(current: str) -> str:
+            updated = current
+            if f'(symbol "{lib_id}"' not in updated:
+                if "(lib_symbols)" in updated:
+                    updated = updated.replace(
+                        "(lib_symbols)",
+                        f"(lib_symbols\n\t{lib_definition}\n\t)",
+                        1,
+                    )
+                else:
+                    updated = updated.replace(
+                        "\t(lib_symbols\n",
+                        f"\t(lib_symbols\n\t{lib_definition}\n",
+                        1,
+                    )
+            block = self.place_symbol_block(
+                lib_id=lib_id,
+                x=symbol_x,
+                y=symbol_y,
+                reference=reference,
+                value=value,
+                footprint=footprint,
+                rotation=rotation,
+                unit=unit,
+                project_name=self.project_name(),
+                root_uuid=root_uuid,
+            )
+            return self.append_before_sheet_instances(updated, block)
+
+        self.transactional_write(mutator, target.path)
+        result = self.reload_schematic()
+        footprint_warning = self.validate_footprint(footprint or "")
+        return "\n".join(
+            part
+            for part in (
+                result,
+                self.format_target_detail(target),
+                snap_note,
+                overlap_warning,
+                footprint_warning,
+            )
+            if part
+        )
+
+    def add_wire(
+        self,
+        x1_mm: float,
+        y1_mm: float,
+        x2_mm: float,
+        y2_mm: float,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add one wire to a resolved schematic target."""
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        wire_coordinates = self.snap_line(
+            x1_mm,
+            y1_mm,
+            x2_mm,
+            y2_mm,
+            snap_to_grid,
+        )
+        snap_note = self.snap_notice(
+            (x1_mm, y1_mm, x2_mm, y2_mm),
+            wire_coordinates,
+        )
+        self.transactional_write(
+            lambda current: self.append_before_sheet_instances(
+                current,
+                self.wire_block(*wire_coordinates),
+            ),
+            target.path,
+        )
+        result = self.reload_schematic()
+        return "\n".join(
+            part for part in (result, self.format_target_detail(target), snap_note) if part
+        )
+
+    def add_label(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add one local label to a resolved schematic target."""
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        label_x, label_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (label_x, label_y))
+        self.transactional_write(
+            lambda current: self.append_before_sheet_instances(
+                current,
+                self.label_block(
+                    name,
+                    label_x,
+                    label_y,
+                    rotation,
+                    justify=justify,
+                ),
+            ),
+            target.path,
+        )
+        result = self.reload_schematic()
+        return "\n".join(
+            part for part in (result, self.format_target_detail(target), snap_note) if part
+        )
+
+    def add_power_symbol(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        rotation: int,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add a generated-reference power symbol through the symbol path."""
+        placed_x, placed_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        result = self.add_symbol(
+            library="power",
+            symbol_name=name,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            reference=f"#PWR{self.new_uuid()[:4]}",
+            value=name,
+            footprint="",
+            rotation=rotation,
+            snap_to_grid=snap_to_grid,
+            unit=1,
+            sheet=sheet,
+            sheet_file=sheet_file,
+        )
+        if "was not found" in result:
+            return result
+        return (
+            f"{result}\nPower symbol {name} placed at "
+            f"({self.format_mm(placed_x)}, {self.format_mm(placed_y)})"
+        )

--- a/src/kicad_mcp/schematic/basic_authoring.py
+++ b/src/kicad_mcp/schematic/basic_authoring.py
@@ -28,12 +28,6 @@ class ResolveTarget(Protocol):
     ) -> SchematicTarget: ...
 
 
-class TransactionalWrite(Protocol):
-    """Write one deterministic schematic mutation to an explicit target."""
-
-    def __call__(self, mutator: Callable[[str], str], path: Path) -> str: ...
-
-
 class PlaceSymbolBlock(Protocol):
     """Create a placed-symbol S-expression block."""
 
@@ -67,7 +61,6 @@ class LabelBlock(Protocol):
     ) -> str: ...
 
 
-type FormatTargetDetail = Callable[[SchematicTarget], str]
 type ParseSchematic = Callable[[Path], Mapping[str, Any]]
 type ProjectName = Callable[[], str]
 type LoadLibSymbol = Callable[[str, str], str | None]
@@ -80,10 +73,11 @@ type SnapLine = Callable[
     tuple[float, float, float, float],
 ]
 type SnapNotice = Callable[[tuple[float, ...], tuple[float, ...]], str]
-type PointNearExisting = Callable[[float, float, list[dict[str, Any]]], str]
+type PointNearExisting = Callable[[float, float, list[dict[str, Any]]], str | None]
 type ValidateFootprint = Callable[[str], str | None]
 type WireBlock = Callable[[float, float, float, float], str]
 type AppendBeforeSheetInstances = Callable[[str, str], str]
+type TransactionalWrite = Callable[[Callable[[str], str], Path], str]
 type ReloadSchematic = Callable[[], str]
 type NewUuid = Callable[[], str]
 type FormatMm = Callable[[float], str]
@@ -94,7 +88,6 @@ class SchematicBasicAuthoringService:
     """Compose basic authoring operations from injected deterministic helpers."""
 
     resolve_target: ResolveTarget
-    format_target_detail: FormatTargetDetail
     parse_schematic: ParseSchematic
     project_name: ProjectName
     load_lib_symbol: LoadLibSymbol
@@ -114,6 +107,11 @@ class SchematicBasicAuthoringService:
     reload_schematic: ReloadSchematic
     new_uuid: NewUuid
     format_mm: FormatMm
+
+    @staticmethod
+    def _format_target_detail(target: SchematicTarget) -> str:
+        kind = "root" if target.is_root else "child"
+        return f"Target schematic ({kind}): {target.path}"
 
     def add_symbol(
         self,
@@ -192,7 +190,7 @@ class SchematicBasicAuthoringService:
             part
             for part in (
                 result,
-                self.format_target_detail(target),
+                self._format_target_detail(target),
                 snap_note,
                 overlap_warning,
                 footprint_warning,
@@ -232,7 +230,7 @@ class SchematicBasicAuthoringService:
         )
         result = self.reload_schematic()
         return "\n".join(
-            part for part in (result, self.format_target_detail(target), snap_note) if part
+            part for part in (result, self._format_target_detail(target), snap_note) if part
         )
 
     def add_label(
@@ -265,7 +263,7 @@ class SchematicBasicAuthoringService:
         )
         result = self.reload_schematic()
         return "\n".join(
-            part for part in (result, self.format_target_detail(target), snap_note) if part
+            part for part in (result, self._format_target_detail(target), snap_note) if part
         )
 
     def add_power_symbol(

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -45,6 +45,7 @@ from ..models.schematic import (
 from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
+from ..schematic.basic_authoring import SchematicBasicAuthoringService
 from ..schematic.destructive_edit import SchematicDestructiveEditService
 from ..schematic.inspection import SchematicInspectionService
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
@@ -62,6 +63,7 @@ from ..utils.sexpr import (
     _unescape_sexpr_string,
 )
 from . import (
+    schematic_basic_authoring,
     schematic_destructive_edit,
     schematic_inspection,
     schematic_symbol_mutation,
@@ -5514,219 +5516,34 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
-    @mcp.tool()
-    @headless_compatible
-    def sch_add_symbol(
-        library: str,
-        symbol_name: str,
-        x_mm: float,
-        y_mm: float,
-        reference: str,
-        value: str,
-        footprint: str = "",
-        rotation: int = 0,
-        snap_to_grid: bool = True,
-        unit: int = 1,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a schematic symbol at an absolute coordinate.
-
-        Coordinates snap to the 1.27 mm / 50 mil schematic grid by default; set
-        snap_to_grid=False only when an exact off-grid coordinate is intentional.
-        """
-        payload = AddSymbolInput(
-            library=library,
-            symbol_name=symbol_name,
-            x_mm=x_mm,
-            y_mm=y_mm,
-            reference=reference,
-            value=value,
-            footprint=footprint,
-            rotation=rotation,
-            snap_to_grid=snap_to_grid,
-            unit=unit,
-        )
-        symbol_x, symbol_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (symbol_x, symbol_y))
-        lib_def = load_lib_symbol(payload.library, payload.symbol_name)
-        if lib_def is None:
-            suggestions = suggest_symbol_names(payload.library, payload.symbol_name)
-            hint = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
-            return f"Symbol '{payload.library}:{payload.symbol_name}' was not found.{hint}"
-        available_units = get_symbol_available_units(payload.library, payload.symbol_name)
-        if available_units and payload.unit not in available_units:
-            return (
-                f"Symbol '{payload.library}:{payload.symbol_name}' does not support unit "
-                f"{payload.unit}. Available units: {_format_available_units(available_units)}."
-            )
-
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        sch_file = target.path
-        sch_data = parse_schematic_file(sch_file)
-        root_uuid = sch_data["uuid"] or new_uuid()
-        cfg = get_config()
-        project_name = cfg.project_file.stem if cfg.project_file is not None else "KiCadMCP"
-        lib_id = f"{payload.library}:{payload.symbol_name}"
-
-        # Collision warning: does the insertion point overlap existing symbols?
-        all_existing = sch_data["symbols"] + sch_data["power_symbols"]
-        overlap_warning = _point_near_existing(symbol_x, symbol_y, all_existing)
-
-        def mutator(current: str) -> str:
-            updated = current
-            if f'(symbol "{lib_id}"' not in updated:
-                if "(lib_symbols)" in updated:
-                    updated = updated.replace("(lib_symbols)", f"(lib_symbols\n\t{lib_def}\n\t)", 1)
-                else:
-                    updated = updated.replace(
-                        "\t(lib_symbols\n", f"\t(lib_symbols\n\t{lib_def}\n", 1
-                    )
-            block = place_symbol_block(
-                lib_id=lib_id,
-                x=symbol_x,
-                y=symbol_y,
-                reference=payload.reference,
-                value=payload.value,
-                footprint=payload.footprint,
-                rotation=payload.rotation,
-                unit=payload.unit,
-                project_name=project_name,
-                root_uuid=root_uuid,
-            )
-            return _append_before_sheet_instances(updated, block)
-
-        transactional_write(mutator, sch_file)
-        result = _reload_schematic()
-        fp_warning = _validate_footprint(payload.footprint or "")
-        parts = [
-            p
-            for p in [result, _format_target_detail(target), snap_note, overlap_warning, fp_warning]
-            if p
-        ]
-        return "\n".join(parts)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_add_component(
-        library: str,
-        symbol_name: str,
-        x_mm: float,
-        y_mm: float,
-        reference: str,
-        value: str,
-        footprint: str = "",
-        rotation: int = 0,
-        snap_to_grid: bool = True,
-        unit: int = 1,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a schematic component through the hybrid IPC reload path."""
-        return str(
-            sch_add_symbol(
-                library=library,
-                symbol_name=symbol_name,
-                x_mm=x_mm,
-                y_mm=y_mm,
-                reference=reference,
-                value=value,
-                footprint=footprint,
-                rotation=rotation,
-                snap_to_grid=snap_to_grid,
-                unit=unit,
-                sheet=sheet,
-                sheet_file=sheet_file,
-            )
-        )
-
-    @mcp.tool()
-    def sch_add_wire(
-        x1_mm: float,
-        y1_mm: float,
-        x2_mm: float,
-        y2_mm: float,
-        snap_to_grid: bool = True,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a schematic wire, snapping endpoints to the 1.27 mm / 50 mil grid by default."""
-        payload = AddWireInput(
-            x1_mm=x1_mm,
-            y1_mm=y1_mm,
-            x2_mm=x2_mm,
-            y2_mm=y2_mm,
-            snap_to_grid=snap_to_grid,
-        )
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        wire_coords = _snap_line(
-            payload.x1_mm,
-            payload.y1_mm,
-            payload.x2_mm,
-            payload.y2_mm,
-            payload.snap_to_grid,
-        )
-        snap_note = _snap_notice(
-            (payload.x1_mm, payload.y1_mm, payload.x2_mm, payload.y2_mm),
-            wire_coords,
-        )
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                wire_block(*wire_coords),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
-
-    @mcp.tool()
-    def sch_add_label(
-        name: str | None = None,
-        x_mm: float = 0.0,
-        y_mm: float = 0.0,
-        rotation: int = 0,
-        snap_to_grid: bool = True,
-        text: str | None = None,
-        justify: str | None = None,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a schematic label, snapping its anchor to the 1.27 mm / 50 mil grid by default.
-
-        ``justify`` overrides KiCad's centered default (e.g. "left", "right",
-        "top", "bottom", "left top"); local labels have no directional icon so
-        centered text is usually correct and this is rarely needed.
-        """
-        label_text = name or text
-        if not label_text:
-            raise ValueError("Either name or text parameter is required.")
-        payload = AddLabelInput(
-            name=label_text,
-            x_mm=x_mm,
-            y_mm=y_mm,
-            rotation=rotation,
-            snap_to_grid=snap_to_grid,
-            justify=justify,
-        )
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        label_x, label_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (label_x, label_y))
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                label_block(
-                    payload.name,
-                    label_x,
-                    label_y,
-                    payload.rotation,
-                    justify=payload.justify,
-                ),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
+    basic_authoring_service = SchematicBasicAuthoringService(
+        resolve_target=_resolve_schematic_target,
+        parse_schematic=parse_schematic_file,
+        project_name=_project_name,
+        load_lib_symbol=load_lib_symbol,
+        suggest_symbol_names=suggest_symbol_names,
+        symbol_available_units=get_symbol_available_units,
+        format_available_units=_format_available_units,
+        snap_point=_snap_point,
+        snap_line=_snap_line,
+        snap_notice=_snap_notice,
+        point_near_existing=_point_near_existing,
+        validate_footprint=_validate_footprint,
+        place_symbol_block=place_symbol_block,
+        wire_block=wire_block,
+        label_block=label_block,
+        append_before_sheet_instances=_append_before_sheet_instances,
+        transactional_write=transactional_write,
+        reload_schematic=_reload_schematic,
+        new_uuid=new_uuid,
+        format_mm=_fmt_mm,
+    )
+    schematic_basic_authoring.register(
+        mcp,
+        schematic_basic_authoring.SchematicBasicAuthoringDependencies(
+            service=basic_authoring_service,
+        ),
+    )
 
     @mcp.tool()
     def sch_add_pin_labels(
@@ -5909,37 +5726,6 @@ def register(mcp: FastMCP) -> None:
             f"{_reload_schematic()}\n{_format_target_detail(target)}\n"
             f"Added {len(wire_blocks)} pin terminal(s) with stubs:\n" + "\n".join(results)
         )
-
-    @mcp.tool()
-    def sch_add_power_symbol(
-        name: str,
-        x_mm: float,
-        y_mm: float,
-        rotation: int = 0,
-        snap_to_grid: bool = True,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a power symbol, snapping its anchor to the 1.27 mm / 50 mil grid by default."""
-        placed_x, placed_y = _snap_point(x_mm, y_mm, snap_to_grid)
-        result = str(
-            sch_add_symbol(
-                library="power",
-                symbol_name=name,
-                x_mm=x_mm,
-                y_mm=y_mm,
-                reference=f"#PWR{new_uuid()[:4]}",
-                value=name,
-                footprint="",
-                rotation=rotation,
-                snap_to_grid=snap_to_grid,
-                sheet=sheet,
-                sheet_file=sheet_file,
-            )
-        )
-        if "was not found" in result:
-            return result
-        return f"{result}\nPower symbol {name} placed at ({_fmt_mm(placed_x)}, {_fmt_mm(placed_y)})"
 
     @mcp.tool()
     def sch_add_bus(

--- a/src/kicad_mcp/tools/schematic_basic_authoring.py
+++ b/src/kicad_mcp/tools/schematic_basic_authoring.py
@@ -1,0 +1,219 @@
+"""Thin FastMCP adapters for basic schematic authoring tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..models.schematic import AddLabelInput, AddSymbolInput, AddWireInput
+from ..schematic.basic_authoring import SchematicBasicAuthoringService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicBasicAuthoringDependencies:
+    """Basic authoring service injected by the schematic composition root."""
+
+    service: SchematicBasicAuthoringService
+
+
+def register(mcp: FastMCP, dependencies: SchematicBasicAuthoringDependencies) -> None:
+    """Register basic schematic symbol, wire, and label authoring tools."""
+    service = dependencies.service
+
+    def validated_add_symbol(
+        library: str,
+        symbol_name: str,
+        x_mm: float,
+        y_mm: float,
+        reference: str,
+        value: str,
+        footprint: str,
+        rotation: int,
+        snap_to_grid: bool,
+        unit: int,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        payload = AddSymbolInput(
+            library=library,
+            symbol_name=symbol_name,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            reference=reference,
+            value=value,
+            footprint=footprint,
+            rotation=rotation,
+            snap_to_grid=snap_to_grid,
+            unit=unit,
+        )
+        return service.add_symbol(
+            payload.library,
+            payload.symbol_name,
+            payload.x_mm,
+            payload.y_mm,
+            payload.reference,
+            payload.value,
+            payload.footprint,
+            payload.rotation,
+            payload.snap_to_grid,
+            payload.unit,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_add_symbol(
+        library: str,
+        symbol_name: str,
+        x_mm: float,
+        y_mm: float,
+        reference: str,
+        value: str,
+        footprint: str = "",
+        rotation: int = 0,
+        snap_to_grid: bool = True,
+        unit: int = 1,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a schematic symbol at an absolute coordinate.
+
+        Coordinates snap to the 1.27 mm / 50 mil schematic grid by default; set
+        snap_to_grid=False only when an exact off-grid coordinate is intentional."""
+        return validated_add_symbol(
+            library,
+            symbol_name,
+            x_mm,
+            y_mm,
+            reference,
+            value,
+            footprint,
+            rotation,
+            snap_to_grid,
+            unit,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_add_component(
+        library: str,
+        symbol_name: str,
+        x_mm: float,
+        y_mm: float,
+        reference: str,
+        value: str,
+        footprint: str = "",
+        rotation: int = 0,
+        snap_to_grid: bool = True,
+        unit: int = 1,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a schematic component through the hybrid IPC reload path."""
+        return validated_add_symbol(
+            library,
+            symbol_name,
+            x_mm,
+            y_mm,
+            reference,
+            value,
+            footprint,
+            rotation,
+            snap_to_grid,
+            unit,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_wire(
+        x1_mm: float,
+        y1_mm: float,
+        x2_mm: float,
+        y2_mm: float,
+        snap_to_grid: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a schematic wire, snapping endpoints to the 1.27 mm / 50 mil grid by default."""
+        payload = AddWireInput(
+            x1_mm=x1_mm,
+            y1_mm=y1_mm,
+            x2_mm=x2_mm,
+            y2_mm=y2_mm,
+            snap_to_grid=snap_to_grid,
+        )
+        return service.add_wire(
+            payload.x1_mm,
+            payload.y1_mm,
+            payload.x2_mm,
+            payload.y2_mm,
+            payload.snap_to_grid,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_label(
+        name: str | None = None,
+        x_mm: float = 0.0,
+        y_mm: float = 0.0,
+        rotation: int = 0,
+        snap_to_grid: bool = True,
+        text: str | None = None,
+        justify: str | None = None,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a schematic label, snapping its anchor to the 1.27 mm / 50 mil grid by default.
+
+        ``justify`` overrides KiCad's centered default (e.g. "left", "right",
+        "top", "bottom", "left top"); local labels have no directional icon so
+        centered text is usually correct and this is rarely needed."""
+        label_text = name or text
+        if not label_text:
+            raise ValueError("Either name or text parameter is required.")
+        payload = AddLabelInput(
+            name=label_text,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            rotation=rotation,
+            snap_to_grid=snap_to_grid,
+            justify=justify,
+        )
+        return service.add_label(
+            payload.name,
+            payload.x_mm,
+            payload.y_mm,
+            payload.rotation,
+            payload.snap_to_grid,
+            payload.justify,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_power_symbol(
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        rotation: int = 0,
+        snap_to_grid: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a power symbol, snapping its anchor to the 1.27 mm / 50 mil grid by default."""
+        return service.add_power_symbol(
+            name,
+            x_mm,
+            y_mm,
+            rotation,
+            snap_to_grid,
+            sheet,
+            sheet_file,
+        )

--- a/tests/unit/test_schematic_basic_authoring_architecture.py
+++ b/tests/unit/test_schematic_basic_authoring_architecture.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_basic_authoring_modules() -> None:
+    assert "kicad_mcp.schematic.basic_authoring" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.basic_authoring" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_basic_authoring" in boundaries.DOMAIN_MODULES
+
+
+def test_basic_authoring_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_basic_authoring.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+
+
+def test_basic_authoring_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_basic_authoring.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_basic_authoring"] == 300

--- a/tests/unit/test_schematic_basic_authoring_registration.py
+++ b/tests/unit/test_schematic_basic_authoring_registration.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_basic_authoring import (
+    SchematicBasicAuthoringDependencies,
+    register,
+)
+
+
+class FakeBasicAuthoringService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def add_symbol(
+        self,
+        library: str,
+        symbol_name: str,
+        x_mm: float,
+        y_mm: float,
+        reference: str,
+        value: str,
+        footprint: str,
+        rotation: int,
+        snap_to_grid: bool,
+        unit: int,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (
+            library,
+            symbol_name,
+            x_mm,
+            y_mm,
+            reference,
+            value,
+            footprint,
+            rotation,
+            snap_to_grid,
+            unit,
+            sheet,
+            sheet_file,
+        )
+        self.calls.append(("add_symbol", args))
+        return "symbol"
+
+    def add_wire(
+        self,
+        x1_mm: float,
+        y1_mm: float,
+        x2_mm: float,
+        y2_mm: float,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (x1_mm, y1_mm, x2_mm, y2_mm, snap_to_grid, sheet, sheet_file)
+        self.calls.append(("add_wire", args))
+        return "wire"
+
+    def add_label(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (name, x_mm, y_mm, rotation, snap_to_grid, justify, sheet, sheet_file)
+        self.calls.append(("add_label", args))
+        return "label"
+
+    def add_power_symbol(
+        self,
+        name: str,
+        x_mm: float,
+        y_mm: float,
+        rotation: int,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (name, x_mm, y_mm, rotation, snap_to_grid, sheet, sheet_file)
+        self.calls.append(("add_power_symbol", args))
+        return "power"
+
+
+def _registered() -> tuple[FastMCP, FakeBasicAuthoringService]:
+    server = FastMCP("schematic-basic-authoring-test")
+    service = FakeBasicAuthoringService()
+    register(server, SchematicBasicAuthoringDependencies(service=service))
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schema_defaults() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_add_symbol",
+        "sch_add_component",
+        "sch_add_wire",
+        "sch_add_label",
+        "sch_add_power_symbol",
+    }
+    assert tools["sch_add_symbol"].description == (
+        "Add a schematic symbol at an absolute coordinate.\n\n"
+        "Coordinates snap to the 1.27 mm / 50 mil schematic grid by default; set\n"
+        "snap_to_grid=False only when an exact off-grid coordinate is intentional."
+    )
+    assert tools["sch_add_component"].description == (
+        "Add a schematic component through the hybrid IPC reload path."
+    )
+    assert tools["sch_add_wire"].description == (
+        "Add a schematic wire, snapping endpoints to the 1.27 mm / 50 mil grid by default."
+    )
+    assert tools["sch_add_label"].description == (
+        "Add a schematic label, snapping its anchor to the 1.27 mm / 50 mil grid by default.\n\n"
+        '``justify`` overrides KiCad\'s centered default (e.g. "left", "right",\n'
+        '"top", "bottom", "left top"); local labels have no directional icon so\n'
+        "centered text is usually correct and this is rarely needed."
+    )
+    assert tools["sch_add_power_symbol"].description == (
+        "Add a power symbol, snapping its anchor to the 1.27 mm / 50 mil grid by default."
+    )
+    assert tools["sch_add_symbol"].parameters["required"] == [
+        "library",
+        "symbol_name",
+        "x_mm",
+        "y_mm",
+        "reference",
+        "value",
+    ]
+    assert tools["sch_add_symbol"].parameters["properties"]["footprint"]["default"] == ""
+    assert tools["sch_add_symbol"].parameters["properties"]["rotation"]["default"] == 0
+    assert tools["sch_add_symbol"].parameters["properties"]["snap_to_grid"]["default"] is True
+    assert tools["sch_add_symbol"].parameters["properties"]["unit"]["default"] == 1
+    assert tools["sch_add_label"].parameters.get("required") is None
+    assert tools["sch_add_label"].parameters["properties"]["name"]["default"] is None
+    assert tools["sch_add_label"].parameters["properties"]["text"]["default"] is None
+    assert tools["sch_add_power_symbol"].parameters["required"] == ["name", "x_mm", "y_mm"]
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    _server, _service = _registered()
+
+    assert get_tool_metadata("sch_add_symbol") is not None
+    assert get_tool_metadata("sch_add_symbol").headless_compatible is True  # type: ignore[union-attr]
+    assert get_tool_metadata("sch_add_component") is not None
+    assert get_tool_metadata("sch_add_component").headless_compatible is True  # type: ignore[union-attr]
+    assert get_tool_metadata("sch_add_wire") is None
+    assert get_tool_metadata("sch_add_label") is None
+    assert get_tool_metadata("sch_add_power_symbol") is None
+
+
+def test_registration_delegates_symbol_and_component_with_defaults() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    kwargs = {
+        "library": "Device",
+        "symbol_name": "R",
+        "x_mm": 10.0,
+        "y_mm": 20.0,
+        "reference": "R1",
+        "value": "10k",
+    }
+    assert tools["sch_add_symbol"].fn(**kwargs) == "symbol"
+    assert tools["sch_add_component"].fn(**kwargs) == "symbol"
+    expected = (
+        "Device",
+        "R",
+        10.0,
+        20.0,
+        "R1",
+        "10k",
+        "",
+        0,
+        True,
+        1,
+        None,
+        None,
+    )
+    assert service.calls == [("add_symbol", expected), ("add_symbol", expected)]
+
+
+def test_registration_delegates_wire_label_alias_and_power_symbol() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert (
+        tools["sch_add_wire"].fn(
+            x1_mm=1.0,
+            y1_mm=2.0,
+            x2_mm=3.0,
+            y2_mm=4.0,
+            snap_to_grid=False,
+            sheet="Power",
+            sheet_file=None,
+        )
+        == "wire"
+    )
+    assert (
+        tools["sch_add_label"].fn(
+            name=None,
+            text="VCC",
+            x_mm=5.0,
+            y_mm=6.0,
+            rotation=90,
+            snap_to_grid=False,
+            justify="left",
+            sheet=None,
+            sheet_file="child.kicad_sch",
+        )
+        == "label"
+    )
+    assert (
+        tools["sch_add_power_symbol"].fn(
+            name="VCC",
+            x_mm=7.0,
+            y_mm=8.0,
+            rotation=180,
+            snap_to_grid=True,
+            sheet=None,
+            sheet_file=None,
+        )
+        == "power"
+    )
+    assert service.calls == [
+        ("add_wire", (1.0, 2.0, 3.0, 4.0, False, "Power", None)),
+        ("add_label", ("VCC", 5.0, 6.0, 90, False, "left", None, "child.kicad_sch")),
+        ("add_power_symbol", ("VCC", 7.0, 8.0, 180, True, None, None)),
+    ]
+
+
+def test_registration_preserves_label_missing_value_and_pydantic_validation() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    with pytest.raises(ValueError, match="Either name or text parameter is required"):
+        tools["sch_add_label"].fn()
+    with pytest.raises(ValidationError):
+        tools["sch_add_symbol"].fn(
+            library="",
+            symbol_name="R",
+            x_mm=1.0,
+            y_mm=2.0,
+            reference="R1",
+            value="10k",
+        )

--- a/tests/unit/test_schematic_basic_authoring_service.py
+++ b/tests/unit/test_schematic_basic_authoring_service.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from kicad_mcp.schematic.basic_authoring import SchematicBasicAuthoringService
+
+
+class _TransactionRecorder:
+    def __init__(self, current: str = "(lib_symbols)\n(sheet_instances)") -> None:
+        self.current = current
+        self.calls: list[tuple[Path, str]] = []
+        self.updated: str | None = None
+
+    def __call__(self, mutator: Callable[[str], str], path: Path) -> str:
+        self.updated = mutator(self.current)
+        self.calls.append((path, self.updated))
+        return str(path)
+
+
+class _ReloadRecorder:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> str:
+        self.calls += 1
+        return "Reloaded schematic."
+
+
+def _service(
+    *,
+    lib_definition: str | None = '(symbol "Device:R")',
+    suggestions: list[str] | None = None,
+    available_units: set[int] | None = None,
+    parsed: dict[str, Any] | None = None,
+    transaction: _TransactionRecorder | None = None,
+    reload: _ReloadRecorder | None = None,
+    uuid_values: list[str] | None = None,
+    captured_symbol_blocks: list[dict[str, Any]] | None = None,
+) -> tuple[
+    SchematicBasicAuthoringService,
+    _TransactionRecorder,
+    _ReloadRecorder,
+    list[dict[str, Any]],
+]:
+    tx = transaction or _TransactionRecorder()
+    reloader = reload or _ReloadRecorder()
+    uuids = iter(uuid_values or ["root-uuid", "power-ref"])
+    symbol_calls = captured_symbol_blocks if captured_symbol_blocks is not None else []
+
+    def place_symbol_block(
+        *,
+        lib_id: str,
+        x: float,
+        y: float,
+        reference: str,
+        value: str,
+        footprint: str = "",
+        rotation: int = 0,
+        unit: int = 1,
+        project_name: str,
+        root_uuid: str,
+    ) -> str:
+        kwargs: dict[str, Any] = {
+            "lib_id": lib_id,
+            "x": x,
+            "y": y,
+            "reference": reference,
+            "value": value,
+            "footprint": footprint,
+            "rotation": rotation,
+            "unit": unit,
+            "project_name": project_name,
+            "root_uuid": root_uuid,
+        }
+        symbol_calls.append(kwargs)
+        return f"(placed {lib_id} {reference})"
+
+    service = SchematicBasicAuthoringService(
+        resolve_target=lambda sheet=None, sheet_file=None: SimpleNamespace(
+            path=Path(sheet_file or sheet or "root.kicad_sch"),
+            is_root=not bool(sheet or sheet_file),
+            description=sheet or sheet_file or "root",
+        ),
+        format_target_detail=lambda target: (
+            f"Target schematic ({'root' if target.is_root else 'child'}): {target.path}"
+        ),
+        parse_schematic=lambda _path: (
+            parsed
+            or {
+                "uuid": "existing-root",
+                "symbols": [{"x": 1.0, "y": 2.0}],
+                "power_symbols": [{"x": 3.0, "y": 4.0}],
+            }
+        ),
+        project_name=lambda: "DemoProject",
+        load_lib_symbol=lambda _library, _name: lib_definition,
+        suggest_symbol_names=lambda _library, _name: list(suggestions or []),
+        symbol_available_units=lambda _library, _name: set(available_units or {1}),
+        format_available_units=lambda units: ", ".join(str(unit) for unit in sorted(units)),
+        snap_point=lambda x, y, enabled: (10.16, 20.32) if enabled else (x, y),
+        snap_line=lambda x1, y1, x2, y2, enabled: (
+            (1.27, 2.54, 3.81, 5.08) if enabled else (x1, y1, x2, y2)
+        ),
+        snap_notice=lambda original, snapped: (
+            "" if original == snapped else f"Grid snap: {original} -> {snapped}"
+        ),
+        point_near_existing=lambda _x, _y, existing: (
+            f"Overlap warning: {len(existing)} existing item(s)."
+        ),
+        validate_footprint=lambda footprint: (
+            f"Footprint warning: {footprint}" if footprint else None
+        ),
+        place_symbol_block=place_symbol_block,
+        wire_block=lambda *coords: f"(wire {' '.join(str(value) for value in coords)})",
+        label_block=lambda name, x, y, rotation, justify=None: (
+            f"(label {name} {x} {y} {rotation} {justify})"
+        ),
+        append_before_sheet_instances=lambda current, block: current.replace(
+            "(sheet_instances)", f"{block}\n(sheet_instances)", 1
+        ),
+        transactional_write=tx,
+        reload_schematic=reloader,
+        new_uuid=lambda: next(uuids),
+        format_mm=lambda value: f"{value:g}",
+    )
+    return service, tx, reloader, symbol_calls
+
+
+def test_add_symbol_preserves_target_write_warnings_and_result_order() -> None:
+    service, transaction, reload, symbol_calls = _service(available_units={1, 2})
+
+    result = service.add_symbol(
+        library="Device",
+        symbol_name="R",
+        x_mm=10.0,
+        y_mm=20.0,
+        reference="R1",
+        value="10k",
+        footprint="Resistor_SMD:R_0603",
+        rotation=90,
+        snap_to_grid=True,
+        unit=2,
+        sheet="Power",
+        sheet_file=None,
+    )
+
+    assert result == (
+        "Reloaded schematic.\n"
+        "Target schematic (child): Power\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)\n"
+        "Overlap warning: 2 existing item(s).\n"
+        "Footprint warning: Resistor_SMD:R_0603"
+    )
+    assert reload.calls == 1
+    assert transaction.calls[0][0] == Path("Power")
+    assert '(symbol "Device:R")' in str(transaction.updated)
+    assert "(placed Device:R R1)" in str(transaction.updated)
+    assert symbol_calls == [
+        {
+            "lib_id": "Device:R",
+            "x": 10.16,
+            "y": 20.32,
+            "reference": "R1",
+            "value": "10k",
+            "footprint": "Resistor_SMD:R_0603",
+            "rotation": 90,
+            "unit": 2,
+            "project_name": "DemoProject",
+            "root_uuid": "existing-root",
+        }
+    ]
+
+
+def test_add_symbol_preserves_missing_symbol_suggestions_without_write() -> None:
+    service, transaction, reload, _calls = _service(
+        lib_definition=None,
+        suggestions=["R", "R_Small"],
+    )
+
+    assert (
+        service.add_symbol(
+            "Device",
+            "RX",
+            1.0,
+            2.0,
+            "R1",
+            "10k",
+            "",
+            0,
+            True,
+            1,
+            None,
+            None,
+        )
+        == "Symbol 'Device:RX' was not found. Did you mean: R, R_Small?"
+    )
+    assert transaction.calls == []
+    assert reload.calls == 0
+
+
+def test_add_symbol_preserves_invalid_unit_result_without_write() -> None:
+    service, transaction, reload, _calls = _service(available_units={1, 3})
+
+    assert service.add_symbol(
+        "Amplifier_Operational",
+        "LM358",
+        1.0,
+        2.0,
+        "U1",
+        "LM358",
+        "",
+        0,
+        True,
+        2,
+        None,
+        None,
+    ) == ("Symbol 'Amplifier_Operational:LM358' does not support unit 2. Available units: 1, 3.")
+    assert transaction.calls == []
+    assert reload.calls == 0
+
+
+def test_add_symbol_uses_generated_root_uuid_when_parser_has_none() -> None:
+    service, _transaction, _reload, symbol_calls = _service(
+        parsed={"uuid": None, "symbols": [], "power_symbols": []},
+        uuid_values=["generated-root"],
+    )
+
+    service.add_symbol(
+        "Device",
+        "R",
+        1.0,
+        2.0,
+        "R1",
+        "10k",
+        "",
+        0,
+        False,
+        1,
+        None,
+        None,
+    )
+
+    assert symbol_calls[0]["root_uuid"] == "generated-root"
+
+
+def test_add_wire_preserves_snapping_target_and_result_order() -> None:
+    service, transaction, reload, _calls = _service()
+
+    assert service.add_wire(1.0, 2.0, 4.0, 5.0, True, None, "child.kicad_sch") == (
+        "Reloaded schematic.\n"
+        "Target schematic (child): child.kicad_sch\n"
+        "Grid snap: (1.0, 2.0, 4.0, 5.0) -> (1.27, 2.54, 3.81, 5.08)"
+    )
+    assert reload.calls == 1
+    assert transaction.calls[0][0] == Path("child.kicad_sch")
+    assert "(wire 1.27 2.54 3.81 5.08)" in str(transaction.updated)
+
+
+def test_add_label_preserves_justify_target_and_result_order() -> None:
+    service, transaction, reload, _calls = _service()
+
+    assert service.add_label("VCC", 10.0, 20.0, 90, True, "left", "Power", None) == (
+        "Reloaded schematic.\n"
+        "Target schematic (child): Power\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)"
+    )
+    assert reload.calls == 1
+    assert transaction.calls[0][0] == Path("Power")
+    assert "(label VCC 10.16 20.32 90 left)" in str(transaction.updated)
+
+
+def test_add_power_symbol_preserves_generated_reference_and_placement_message() -> None:
+    symbol_calls: list[dict[str, Any]] = []
+    service, _transaction, reload, _calls = _service(
+        uuid_values=["abcd1234"],
+        captured_symbol_blocks=symbol_calls,
+    )
+
+    result = service.add_power_symbol("VCC", 10.0, 20.0, 180, True, None, None)
+
+    assert result.endswith("\nPower symbol VCC placed at (10.16, 20.32)")
+    assert reload.calls == 1
+    assert symbol_calls[0]["reference"] == "#PWRabcd"
+    assert symbol_calls[0]["lib_id"] == "power:VCC"
+    assert symbol_calls[0]["rotation"] == 180
+
+
+def test_add_power_symbol_returns_missing_symbol_result_unchanged() -> None:
+    service, transaction, reload, _calls = _service(lib_definition=None)
+
+    result = service.add_power_symbol("NO_SUCH_POWER", 1.0, 2.0, 0, True, None, None)
+
+    assert result == "Symbol 'power:NO_SUCH_POWER' was not found."
+    assert transaction.calls == []
+    assert reload.calls == 0

--- a/tests/unit/test_schematic_basic_authoring_service.py
+++ b/tests/unit/test_schematic_basic_authoring_service.py
@@ -84,9 +84,6 @@ def _service(
             is_root=not bool(sheet or sheet_file),
             description=sheet or sheet_file or "root",
         ),
-        format_target_detail=lambda target: (
-            f"Target schematic ({'root' if target.is_root else 'child'}): {target.path}"
-        ),
         parse_schematic=lambda _path: (
             parsed
             or {

--- a/tests/unit/test_schematic_basic_authoring_service.py
+++ b/tests/unit/test_schematic_basic_authoring_service.py
@@ -171,6 +171,31 @@ def test_add_symbol_preserves_target_write_warnings_and_result_order() -> None:
     ]
 
 
+def test_add_symbol_inserts_library_definition_into_nonempty_section() -> None:
+    transaction = _TransactionRecorder(
+        current='\t(lib_symbols\n\t\t(symbol "Device:C")\n\t)\n(sheet_instances)'
+    )
+    service, transaction, _reload, _calls = _service(transaction=transaction)
+
+    service.add_symbol(
+        "Device",
+        "R",
+        1.0,
+        2.0,
+        "R1",
+        "10k",
+        "",
+        0,
+        False,
+        1,
+        None,
+        None,
+    )
+
+    assert '\t(lib_symbols\n\t(symbol "Device:R")' in str(transaction.updated)
+    assert '\t\t(symbol "Device:C")' in str(transaction.updated)
+
+
 def test_add_symbol_preserves_missing_symbol_suggestions_without_write() -> None:
     service, transaction, reload, _calls = _service(
         lib_definition=None,


### PR DESCRIPTION
## Summary

- extract basic symbol, wire, label, and power-symbol orchestration into a typed, FastMCP-free `SchematicBasicAuthoringService`
- add a 199-line registration adapter for `sch_add_symbol`, `sch_add_component`, `sch_add_wire`, `sch_add_label`, and `sch_add_power_symbol`
- reduce the main schematic registration function from 2,807 to 2,591 lines
- add architecture policy for service purity, adapter isolation, and the 300-line registration limit
- document the bounded design, implementation plan, verification evidence, and remaining #434 work

## Compatibility and safety

- public tool names, descriptions, input schemas, annotations, profiles, defaults, validation, and outputs are unchanged
- exact full-server metadata comparison against `main` is identical for all five tools
- the committed tool-surface snapshot remains unchanged
- child-sheet targeting, grid defaults, symbol-library insertion, unit validation, root UUID/project-name selection, warnings, transaction target paths, and reload ordering remain unchanged
- `sch_add_component` remains a compatibility alias through the same validated symbol-authoring path
- the `name`/`text` label alias and exact missing-value exception remain unchanged
- no runtime dependency is added
- this is the fifth bounded tranche of #434 and does not close the parent task

## Verification

- focused service, registration, and schematic integration suite: 149 passed
- focused line coverage for the extracted service and adapter: 100%
- full unit suite passed with five expected skips
- committed MCP `tools/list` latency benchmark passed
- metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated documentation, workflow policy/security, strict MkDocs, and tool-surface snapshot checks passed
- main schematic `register()` span: 2,807 → 2,591 lines
- adapter `register()` span: 199 lines

## Review notes

This extraction preserves the current file-backed authoring behavior and public contracts. Higher-level pin-label, bus/marker, circuit-building, placement, rendering, sheet-layout, and template orchestration remain in later bounded tranches.

Refs #434