### PR TITLE
refactor(schematic): delegate connectivity primitive authoring

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-connectivity-primitives.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-connectivity-primitives.md
@@ -1,0 +1,120 @@
+# Schematic Connectivity Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move bus, bus-entry, and no-connect authoring from the schematic MCP monolith into the existing FastMCP-free basic-authoring service and thin adapter without changing the public surface.
+
+**Architecture:** Extend `SchematicBasicAuthoringService` with three deterministic orchestration methods using the existing target, snap, transaction, reload, and append dependencies plus injected bus-entry and no-connect block builders. Extend the existing FastMCP adapter for validation and registration, then remove the legacy nested functions from the composition root.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, pytest, Ruff, mypy, Pyright, existing architecture and tool-surface gates.
+
+## Global Constraints
+
+- Preserve exact tool names, descriptions, schemas, annotations, profiles, validation, defaults, result strings, and result ordering.
+- Preserve child-sheet targeting and default structural-loss protection.
+- Keep `schematic_basic_authoring.register()` at or below 300 lines.
+- Keep the service FastMCP-free and free of server, connection, GUI, IPC, SWIG, and registry imports.
+- Do not add dependencies or close #434.
+
+---
+
+### Task 1: Extend the basic-authoring service
+
+**Files:**
+- Modify: `tests/unit/test_schematic_basic_authoring_service.py`
+- Modify: `src/kicad_mcp/schematic/basic_authoring.py`
+
+**Interfaces:**
+- Produces: `add_bus(x1_mm, y1_mm, x2_mm, y2_mm, snap_to_grid, sheet, sheet_file) -> str`.
+- Produces: `add_bus_wire_entry(x_mm, y_mm, direction, snap_to_grid, sheet, sheet_file) -> str`.
+- Produces: `add_no_connect(x_mm, y_mm, snap_to_grid, sheet, sheet_file) -> str`.
+- Consumes injected `wire_block`, `bus_entry_block`, `no_connect_block`, target, snap, append, transaction, and reload callables.
+
+- [ ] **Step 1: Write failing direct service tests**
+
+Add tests that call each new method and assert the exact appended block, target path, snapped coordinates, default transaction guard, reload-first response, target detail, and snap notice.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_service.py
+```
+
+Expected: failures because the three methods and new injected block builders do not exist.
+
+- [ ] **Step 3: Implement the minimal service methods**
+
+Extend the wire-block callable to accept an optional kind, inject bus-entry and no-connect builders, and implement the three methods using the same flow as existing wire/label authoring.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/schematic/basic_authoring.py tests/unit/test_schematic_basic_authoring_service.py
+git commit -m "refactor(schematic): extend basic authoring primitives"
+```
+
+### Task 2: Extend the thin registration adapter
+
+**Files:**
+- Modify: `tests/unit/test_schematic_basic_authoring_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic_basic_authoring.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes the three new service methods.
+- Preserves public tools `sch_add_bus`, `sch_add_bus_wire_entry`, and `sch_add_no_connect`.
+
+- [ ] **Step 1: Write failing registration tests**
+
+Assert the three tool names, exact descriptions, schemas/defaults, validation, and delegation arguments.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_registration.py
+```
+
+Expected: failures because the adapter does not register the three tools.
+
+- [ ] **Step 3: Register and compose the tools**
+
+Inject `bus_entry_block` and `no_connect_block` into the service, register the tools in the existing adapter, and remove the three legacy nested functions and now-unused model imports.
+
+- [ ] **Step 4: Run focused behavior tests**
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_basic_authoring_service.py \
+  tests/unit/test_schematic_basic_authoring_registration.py \
+  tests/integration/test_schematic_tools.py \
+  tests/integration/test_schematic_extended.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/tools/schematic.py src/kicad_mcp/tools/schematic_basic_authoring.py \
+  tests/unit/test_schematic_basic_authoring_registration.py
+git commit -m "refactor(schematic): delegate connectivity primitive registration"
+```
+
+### Task 3: Verify boundaries and publish
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-connectivity-primitives.md`
+- Existing checks: `tests/unit/test_schematic_basic_authoring_architecture.py`
+
+- [ ] Verify the adapter `register()` span remains at or below 300 lines and the existing architecture checker passes.
+- [ ] Compare full-server metadata for all three tools against `main`; require exact equality.
+- [ ] Run focused line coverage and require all modified service/adapter lines to be covered.
+- [ ] Run metadata, formatting, Ruff, mypy, scoped strict Pyright, full unit, workflow-security, strict MkDocs, snapshot, and latency benchmark gates.
+- [ ] Record exact test, coverage, metadata, and line-count evidence in this plan.
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect every bot/agent comment, review, and GraphQL review thread; resolve actionable findings.
+- [ ] Squash merge only when all required checks are successful and the merge state is clean.

--- a/docs/superpowers/plans/2026-07-23-schematic-connectivity-primitives.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-connectivity-primitives.md
@@ -1,6 +1,6 @@
 # Schematic Connectivity Primitives Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Move bus, bus-entry, and no-connect authoring from the schematic MCP monolith into the existing FastMCP-free basic-authoring service and thin adapter without changing the public surface.
 
@@ -30,11 +30,11 @@
 - Produces: `add_no_connect(x_mm, y_mm, snap_to_grid, sheet, sheet_file) -> str`.
 - Consumes injected `wire_block`, `bus_entry_block`, `no_connect_block`, target, snap, append, transaction, and reload callables.
 
-- [ ] **Step 1: Write failing direct service tests**
+- [x] **Step 1: Write failing direct service tests**
 
 Add tests that call each new method and assert the exact appended block, target path, snapped coordinates, default transaction guard, reload-first response, target detail, and snap notice.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_service.py
@@ -42,15 +42,15 @@ uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_service.
 
 Expected: failures because the three methods and new injected block builders do not exist.
 
-- [ ] **Step 3: Implement the minimal service methods**
+- [x] **Step 3: Implement the minimal service methods**
 
 Extend the wire-block callable to accept an optional kind, inject bus-entry and no-connect builders, and implement the three methods using the same flow as existing wire/label authoring.
 
-- [ ] **Step 4: Run tests to verify GREEN**
+- [x] **Step 4: Run tests to verify GREEN**
 
 Run the command from Step 2. Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/schematic/basic_authoring.py tests/unit/test_schematic_basic_authoring_service.py
@@ -68,11 +68,11 @@ git commit -m "refactor(schematic): extend basic authoring primitives"
 - Consumes the three new service methods.
 - Preserves public tools `sch_add_bus`, `sch_add_bus_wire_entry`, and `sch_add_no_connect`.
 
-- [ ] **Step 1: Write failing registration tests**
+- [x] **Step 1: Write failing registration tests**
 
 Assert the three tool names, exact descriptions, schemas/defaults, validation, and delegation arguments.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 ```bash
 uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_registration.py
@@ -80,11 +80,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_basic_authoring_registra
 
 Expected: failures because the adapter does not register the three tools.
 
-- [ ] **Step 3: Register and compose the tools**
+- [x] **Step 3: Register and compose the tools**
 
 Inject `bus_entry_block` and `no_connect_block` into the service, register the tools in the existing adapter, and remove the three legacy nested functions and now-unused model imports.
 
-- [ ] **Step 4: Run focused behavior tests**
+- [x] **Step 4: Run focused behavior tests**
 
 ```bash
 uv run --all-extras pytest -q \
@@ -96,7 +96,7 @@ uv run --all-extras pytest -q \
 
 Expected: all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/tools/schematic.py src/kicad_mcp/tools/schematic_basic_authoring.py \
@@ -110,11 +110,23 @@ git commit -m "refactor(schematic): delegate connectivity primitive registration
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-connectivity-primitives.md`
 - Existing checks: `tests/unit/test_schematic_basic_authoring_architecture.py`
 
-- [ ] Verify the adapter `register()` span remains at or below 300 lines and the existing architecture checker passes.
-- [ ] Compare full-server metadata for all three tools against `main`; require exact equality.
-- [ ] Run focused line coverage and require all modified service/adapter lines to be covered.
-- [ ] Run metadata, formatting, Ruff, mypy, scoped strict Pyright, full unit, workflow-security, strict MkDocs, snapshot, and latency benchmark gates.
-- [ ] Record exact test, coverage, metadata, and line-count evidence in this plan.
+- [x] Verify the adapter `register()` span remains at or below 300 lines and the existing architecture checker passes.
+- [x] Compare full-server metadata for all three tools against `main`; require exact equality.
+- [x] Run focused line coverage and require all modified service/adapter lines to be covered.
+- [x] Run metadata, formatting, Ruff, mypy, scoped strict Pyright, full unit, workflow-security, strict MkDocs, snapshot, and latency benchmark gates.
+- [x] Record exact test, coverage, metadata, and line-count evidence in this plan.
+## Verification Evidence
+
+- Full-server metadata is byte-for-byte equivalent to `main` for `sch_add_bus`, `sch_add_bus_wire_entry`, and `sch_add_no_connect`.
+- Focused service, registration, and schematic integration suite: 154 passed.
+- Focused line coverage: 100% for `basic_authoring.py` and `schematic_basic_authoring.py`.
+- Full unit suite passed with five expected skips; the existing Windows daemon AsyncMock warning remains unchanged.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool docs, workflow policy/security, strict MkDocs, tool-surface snapshot, and committed latency benchmark checks passed.
+- Bandit reported no medium/high issues; dependency audit reported no known vulnerabilities; source and wheel package metadata checks passed.
+- Main schematic `register()` span: 2,591 → 2,498 lines.
+- Basic-authoring adapter `register()` span: 272 lines, below the 300-line limit.
+- No public snapshot, dependency, transaction, structural-loss, or runtime-policy change was introduced.
+
 - [ ] Push and open a professional English PR referencing #434.
 - [ ] Inspect every bot/agent comment, review, and GraphQL review thread; resolve actionable findings.
 - [ ] Squash merge only when all required checks are successful and the merge state is clean.

--- a/docs/superpowers/specs/2026-07-23-schematic-connectivity-primitives-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-connectivity-primitives-design.md
@@ -1,0 +1,43 @@
+# Schematic Connectivity Primitive Authoring Design
+
+## Context
+
+`src/kicad_mcp/tools/schematic.py` still registers and implements three closely related file-backed authoring tools: `sch_add_bus`, `sch_add_bus_wire_entry`, and `sch_add_no_connect`. They repeat the same target-resolution, grid-snap, transactional append, reload, and response-ordering flow that is already owned by `SchematicBasicAuthoringService` for symbols, wires, and labels.
+
+## Decision
+
+Extend the existing `SchematicBasicAuthoringService` and `schematic_basic_authoring` FastMCP adapter rather than create another service boundary. Bus segments, bus-entry markers, and no-connect markers are basic schematic authoring primitives and share the same injected dependencies and target semantics.
+
+The service will gain:
+
+- `add_bus(...)`
+- `add_bus_wire_entry(...)`
+- `add_no_connect(...)`
+
+The FastMCP adapter will retain Pydantic validation through `AddBusInput`, `AddBusWireEntryInput`, and `AddNoConnectInput`. `tools.schematic.register()` remains the composition root and injects the existing `wire_block`, plus `bus_entry_block` and `no_connect_block`.
+
+## Compatibility and safety
+
+- Preserve exact public tool names, descriptions, schemas, annotations, profiles, default values, and output ordering.
+- Preserve child-sheet targeting through `sheet` and `sheet_file`.
+- Preserve 1.27 mm grid-snap behavior and snap notices.
+- Preserve the default transaction loss guard; none of these tools opts into structural loss.
+- Preserve reload ordering: transactional write first, then schematic reload, then target and snap details.
+- Do not add dependencies or change the public tool-surface snapshot.
+
+## Boundaries
+
+`kicad_mcp.schematic.basic_authoring` remains FastMCP-free and imports no registry, server, connection, GUI, KiCad IPC, or SWIG modules. `kicad_mcp.tools.schematic_basic_authoring` remains a thin validation and registration adapter and must keep its `register()` function at or below 300 lines.
+
+## Verification
+
+- Direct service tests cover bus, bus-entry, and no-connect writes, grid coordinates, target path propagation, block construction, response ordering, and transaction flags.
+- Registration tests cover exact names, descriptions, schemas, defaults, validation, and argument delegation.
+- Full-server metadata for the three tools must match `main` exactly.
+- Architecture, tool-surface snapshot, generated docs, focused integration, full unit, type, coverage, workflow-security, strict documentation, and latency benchmark gates must pass.
+
+## Non-goals
+
+- Pin-label routing, jumpers, swap intents, hop-over settings, circuit compilation, or new schematic features.
+- Public renaming or schema changes.
+- Transaction/checkpoint model changes.

--- a/src/kicad_mcp/schematic/basic_authoring.py
+++ b/src/kicad_mcp/schematic/basic_authoring.py
@@ -75,7 +75,23 @@ type SnapLine = Callable[
 type SnapNotice = Callable[[tuple[float, ...], tuple[float, ...]], str]
 type PointNearExisting = Callable[[float, float, list[dict[str, Any]]], str | None]
 type ValidateFootprint = Callable[[str], str | None]
-type WireBlock = Callable[[float, float, float, float], str]
+
+
+class WireBlock(Protocol):
+    """Create a wire or bus S-expression block."""
+
+    def __call__(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        kind: str = "wire",
+    ) -> str: ...
+
+
+type BusEntryBlock = Callable[[float, float, str], str]
+type NoConnectBlock = Callable[[float, float], str]
 type AppendBeforeSheetInstances = Callable[[str, str], str]
 type TransactionalWrite = Callable[[Callable[[str], str], Path], str]
 type ReloadSchematic = Callable[[], str]
@@ -101,6 +117,8 @@ class SchematicBasicAuthoringService:
     validate_footprint: ValidateFootprint
     place_symbol_block: PlaceSymbolBlock
     wire_block: WireBlock
+    bus_entry_block: BusEntryBlock
+    no_connect_block: NoConnectBlock
     label_block: LabelBlock
     append_before_sheet_instances: AppendBeforeSheetInstances
     transactional_write: TransactionalWrite
@@ -225,6 +243,90 @@ class SchematicBasicAuthoringService:
             lambda current: self.append_before_sheet_instances(
                 current,
                 self.wire_block(*wire_coordinates),
+            ),
+            target.path,
+        )
+        result = self.reload_schematic()
+        return "\n".join(
+            part for part in (result, self._format_target_detail(target), snap_note) if part
+        )
+
+    def add_bus(
+        self,
+        x1_mm: float,
+        y1_mm: float,
+        x2_mm: float,
+        y2_mm: float,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add one bus segment to a resolved schematic target."""
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        bus_coordinates = self.snap_line(
+            x1_mm,
+            y1_mm,
+            x2_mm,
+            y2_mm,
+            snap_to_grid,
+        )
+        snap_note = self.snap_notice(
+            (x1_mm, y1_mm, x2_mm, y2_mm),
+            bus_coordinates,
+        )
+        self.transactional_write(
+            lambda current: self.append_before_sheet_instances(
+                current,
+                self.wire_block(*bus_coordinates, "bus"),
+            ),
+            target.path,
+        )
+        result = self.reload_schematic()
+        return "\n".join(
+            part for part in (result, self._format_target_detail(target), snap_note) if part
+        )
+
+    def add_bus_wire_entry(
+        self,
+        x_mm: float,
+        y_mm: float,
+        direction: str,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add one bus-entry marker to a resolved schematic target."""
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        entry_x, entry_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (entry_x, entry_y))
+        self.transactional_write(
+            lambda current: self.append_before_sheet_instances(
+                current,
+                self.bus_entry_block(entry_x, entry_y, direction),
+            ),
+            target.path,
+        )
+        result = self.reload_schematic()
+        return "\n".join(
+            part for part in (result, self._format_target_detail(target), snap_note) if part
+        )
+
+    def add_no_connect(
+        self,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add one no-connect marker to a resolved schematic target."""
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        marker_x, marker_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (marker_x, marker_y))
+        self.transactional_write(
+            lambda current: self.append_before_sheet_instances(
+                current,
+                self.no_connect_block(marker_x, marker_y),
             ),
             target.path,
         )

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -27,10 +27,7 @@ from ..discovery import is_numbered_duplicate_kicad_file
 from ..errors import SchematicWriteUnsafeError
 from ..mcp_media import image_tool_result, text_tool_result
 from ..models.schematic import (
-    AddBusInput,
-    AddBusWireEntryInput,
     AddLabelInput,
-    AddNoConnectInput,
     AddSymbolInput,
     AddWireInput,
     AnnotateInput,
@@ -5531,6 +5528,8 @@ def register(mcp: FastMCP) -> None:
         validate_footprint=_validate_footprint,
         place_symbol_block=place_symbol_block,
         wire_block=wire_block,
+        bus_entry_block=bus_entry_block,
+        no_connect_block=no_connect_block,
         label_block=label_block,
         append_before_sheet_instances=_append_before_sheet_instances,
         transactional_write=transactional_write,
@@ -5726,101 +5725,6 @@ def register(mcp: FastMCP) -> None:
             f"{_reload_schematic()}\n{_format_target_detail(target)}\n"
             f"Added {len(wire_blocks)} pin terminal(s) with stubs:\n" + "\n".join(results)
         )
-
-    @mcp.tool()
-    def sch_add_bus(
-        x1_mm: float,
-        y1_mm: float,
-        x2_mm: float,
-        y2_mm: float,
-        snap_to_grid: bool = True,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a schematic bus, snapping endpoints to the 1.27 mm / 50 mil grid by default."""
-        payload = AddBusInput(
-            x1_mm=x1_mm,
-            y1_mm=y1_mm,
-            x2_mm=x2_mm,
-            y2_mm=y2_mm,
-            snap_to_grid=snap_to_grid,
-        )
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        bus_coords = _snap_line(
-            payload.x1_mm,
-            payload.y1_mm,
-            payload.x2_mm,
-            payload.y2_mm,
-            payload.snap_to_grid,
-        )
-        snap_note = _snap_notice(
-            (payload.x1_mm, payload.y1_mm, payload.x2_mm, payload.y2_mm),
-            bus_coords,
-        )
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                wire_block(*bus_coords, "bus"),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
-
-    @mcp.tool()
-    def sch_add_bus_wire_entry(
-        x_mm: float,
-        y_mm: float,
-        direction: str = "up_right",
-        snap_to_grid: bool = True,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a bus wire entry marker.
-
-        Snaps its anchor to the 1.27 mm / 50 mil grid by default.
-        """
-        payload = AddBusWireEntryInput(
-            x_mm=x_mm,
-            y_mm=y_mm,
-            direction=direction,
-            snap_to_grid=snap_to_grid,
-        )
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        entry_x, entry_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (entry_x, entry_y))
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                bus_entry_block(entry_x, entry_y, payload.direction),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
-
-    @mcp.tool()
-    def sch_add_no_connect(
-        x_mm: float,
-        y_mm: float,
-        snap_to_grid: bool = True,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a no-connect marker, snapping it to the 1.27 mm / 50 mil grid by default."""
-        payload = AddNoConnectInput(x_mm=x_mm, y_mm=y_mm, snap_to_grid=snap_to_grid)
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        marker_x, marker_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (marker_x, marker_y))
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                no_connect_block(marker_x, marker_y),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/schematic_basic_authoring.py
+++ b/src/kicad_mcp/tools/schematic_basic_authoring.py
@@ -6,7 +6,14 @@ from dataclasses import dataclass
 
 from mcp.server.fastmcp import FastMCP
 
-from ..models.schematic import AddLabelInput, AddSymbolInput, AddWireInput
+from ..models.schematic import (
+    AddBusInput,
+    AddBusWireEntryInput,
+    AddLabelInput,
+    AddNoConnectInput,
+    AddSymbolInput,
+    AddWireInput,
+)
 from ..schematic.basic_authoring import SchematicBasicAuthoringService
 from .metadata import headless_compatible
 
@@ -214,6 +221,79 @@ def register(mcp: FastMCP, dependencies: SchematicBasicAuthoringDependencies) ->
             y_mm,
             rotation,
             snap_to_grid,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_bus(
+        x1_mm: float,
+        y1_mm: float,
+        x2_mm: float,
+        y2_mm: float,
+        snap_to_grid: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a schematic bus, snapping endpoints to the 1.27 mm / 50 mil grid by default."""
+        payload = AddBusInput(
+            x1_mm=x1_mm,
+            y1_mm=y1_mm,
+            x2_mm=x2_mm,
+            y2_mm=y2_mm,
+            snap_to_grid=snap_to_grid,
+        )
+        return service.add_bus(
+            payload.x1_mm,
+            payload.y1_mm,
+            payload.x2_mm,
+            payload.y2_mm,
+            payload.snap_to_grid,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_bus_wire_entry(
+        x_mm: float,
+        y_mm: float,
+        direction: str = "up_right",
+        snap_to_grid: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a bus wire entry marker.
+
+        Snaps its anchor to the 1.27 mm / 50 mil grid by default."""
+        payload = AddBusWireEntryInput(
+            x_mm=x_mm,
+            y_mm=y_mm,
+            direction=direction,
+            snap_to_grid=snap_to_grid,
+        )
+        return service.add_bus_wire_entry(
+            payload.x_mm,
+            payload.y_mm,
+            payload.direction,
+            payload.snap_to_grid,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_no_connect(
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a no-connect marker, snapping it to the 1.27 mm / 50 mil grid by default."""
+        payload = AddNoConnectInput(x_mm=x_mm, y_mm=y_mm, snap_to_grid=snap_to_grid)
+        return service.add_no_connect(
+            payload.x_mm,
+            payload.y_mm,
+            payload.snap_to_grid,
             sheet,
             sheet_file,
         )

--- a/tests/unit/test_schematic_basic_authoring_registration.py
+++ b/tests/unit/test_schematic_basic_authoring_registration.py
@@ -92,6 +92,45 @@ class FakeBasicAuthoringService:
         self.calls.append(("add_power_symbol", args))
         return "power"
 
+    def add_bus(
+        self,
+        x1_mm: float,
+        y1_mm: float,
+        x2_mm: float,
+        y2_mm: float,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (x1_mm, y1_mm, x2_mm, y2_mm, snap_to_grid, sheet, sheet_file)
+        self.calls.append(("add_bus", args))
+        return "bus"
+
+    def add_bus_wire_entry(
+        self,
+        x_mm: float,
+        y_mm: float,
+        direction: str,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (x_mm, y_mm, direction, snap_to_grid, sheet, sheet_file)
+        self.calls.append(("add_bus_wire_entry", args))
+        return "bus-entry"
+
+    def add_no_connect(
+        self,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        args = (x_mm, y_mm, snap_to_grid, sheet, sheet_file)
+        self.calls.append(("add_no_connect", args))
+        return "no-connect"
+
 
 def _registered() -> tuple[FastMCP, FakeBasicAuthoringService]:
     server = FastMCP("schematic-basic-authoring-test")
@@ -110,6 +149,9 @@ def test_registration_preserves_names_descriptions_and_schema_defaults() -> None
         "sch_add_wire",
         "sch_add_label",
         "sch_add_power_symbol",
+        "sch_add_bus",
+        "sch_add_bus_wire_entry",
+        "sch_add_no_connect",
     }
     assert tools["sch_add_symbol"].description == (
         "Add a schematic symbol at an absolute coordinate.\n\n"
@@ -131,6 +173,15 @@ def test_registration_preserves_names_descriptions_and_schema_defaults() -> None
     assert tools["sch_add_power_symbol"].description == (
         "Add a power symbol, snapping its anchor to the 1.27 mm / 50 mil grid by default."
     )
+    assert tools["sch_add_bus"].description == (
+        "Add a schematic bus, snapping endpoints to the 1.27 mm / 50 mil grid by default."
+    )
+    assert tools["sch_add_bus_wire_entry"].description == (
+        "Add a bus wire entry marker.\n\nSnaps its anchor to the 1.27 mm / 50 mil grid by default."
+    )
+    assert tools["sch_add_no_connect"].description == (
+        "Add a no-connect marker, snapping it to the 1.27 mm / 50 mil grid by default."
+    )
     assert tools["sch_add_symbol"].parameters["required"] == [
         "library",
         "symbol_name",
@@ -147,6 +198,18 @@ def test_registration_preserves_names_descriptions_and_schema_defaults() -> None
     assert tools["sch_add_label"].parameters["properties"]["name"]["default"] is None
     assert tools["sch_add_label"].parameters["properties"]["text"]["default"] is None
     assert tools["sch_add_power_symbol"].parameters["required"] == ["name", "x_mm", "y_mm"]
+    assert tools["sch_add_bus"].parameters["required"] == [
+        "x1_mm",
+        "y1_mm",
+        "x2_mm",
+        "y2_mm",
+    ]
+    assert tools["sch_add_bus"].parameters["properties"]["snap_to_grid"]["default"] is True
+    assert tools["sch_add_bus_wire_entry"].parameters["required"] == ["x_mm", "y_mm"]
+    assert tools["sch_add_bus_wire_entry"].parameters["properties"]["direction"]["default"] == (
+        "up_right"
+    )
+    assert tools["sch_add_no_connect"].parameters["required"] == ["x_mm", "y_mm"]
 
 
 def test_registration_preserves_headless_metadata() -> None:
@@ -159,6 +222,9 @@ def test_registration_preserves_headless_metadata() -> None:
     assert get_tool_metadata("sch_add_wire") is None
     assert get_tool_metadata("sch_add_label") is None
     assert get_tool_metadata("sch_add_power_symbol") is None
+    assert get_tool_metadata("sch_add_bus") is None
+    assert get_tool_metadata("sch_add_bus_wire_entry") is None
+    assert get_tool_metadata("sch_add_no_connect") is None
 
 
 def test_registration_delegates_symbol_and_component_with_defaults() -> None:
@@ -255,4 +321,51 @@ def test_registration_preserves_label_missing_value_and_pydantic_validation() ->
             y_mm=2.0,
             reference="R1",
             value="10k",
+        )
+
+
+def test_registration_delegates_connectivity_primitives_and_defaults() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert (
+        tools["sch_add_bus"].fn(
+            x1_mm=1.0,
+            y1_mm=2.0,
+            x2_mm=3.0,
+            y2_mm=4.0,
+            sheet="Signals",
+        )
+        == "bus"
+    )
+    assert (
+        tools["sch_add_bus_wire_entry"].fn(
+            x_mm=5.0,
+            y_mm=6.0,
+            direction="down_left",
+            snap_to_grid=False,
+            sheet_file="child.kicad_sch",
+        )
+        == "bus-entry"
+    )
+    assert tools["sch_add_no_connect"].fn(x_mm=7.0, y_mm=8.0) == "no-connect"
+    assert service.calls == [
+        ("add_bus", (1.0, 2.0, 3.0, 4.0, True, "Signals", None)),
+        (
+            "add_bus_wire_entry",
+            (5.0, 6.0, "down_left", False, None, "child.kicad_sch"),
+        ),
+        ("add_no_connect", (7.0, 8.0, True, None, None)),
+    ]
+
+
+def test_registration_preserves_bus_entry_direction_validation() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    with pytest.raises(ValidationError):
+        tools["sch_add_bus_wire_entry"].fn(
+            x_mm=1.0,
+            y_mm=2.0,
+            direction="sideways",
         )

--- a/tests/unit/test_schematic_basic_authoring_service.py
+++ b/tests/unit/test_schematic_basic_authoring_service.py
@@ -112,6 +112,8 @@ def _service(
         ),
         place_symbol_block=place_symbol_block,
         wire_block=lambda *coords: f"(wire {' '.join(str(value) for value in coords)})",
+        bus_entry_block=lambda x, y, direction: f"(bus-entry {x} {y} {direction})",
+        no_connect_block=lambda x, y: f"(no-connect {x} {y})",
         label_block=lambda name, x, y, rotation, justify=None: (
             f"(label {name} {x} {y} {rotation} {justify})"
         ),
@@ -318,3 +320,49 @@ def test_add_power_symbol_returns_missing_symbol_result_unchanged() -> None:
     assert result == "Symbol 'power:NO_SUCH_POWER' was not found."
     assert transaction.calls == []
     assert reload.calls == 0
+
+
+def test_add_bus_preserves_snapping_target_and_bus_block() -> None:
+    service, transaction, reload, _calls = _service()
+
+    assert service.add_bus(1.0, 2.0, 4.0, 5.0, True, "Signals", None) == (
+        "Reloaded schematic.\n"
+        "Target schematic (child): Signals\n"
+        "Grid snap: (1.0, 2.0, 4.0, 5.0) -> (1.27, 2.54, 3.81, 5.08)"
+    )
+    assert reload.calls == 1
+    assert transaction.calls[0][0] == Path("Signals")
+    assert "(wire 1.27 2.54 3.81 5.08 bus)" in str(transaction.updated)
+
+
+def test_add_bus_wire_entry_preserves_direction_snap_and_target() -> None:
+    service, transaction, reload, _calls = _service()
+
+    assert service.add_bus_wire_entry(
+        10.0,
+        20.0,
+        "down_left",
+        True,
+        None,
+        "child.kicad_sch",
+    ) == (
+        "Reloaded schematic.\n"
+        "Target schematic (child): child.kicad_sch\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)"
+    )
+    assert reload.calls == 1
+    assert transaction.calls[0][0] == Path("child.kicad_sch")
+    assert "(bus-entry 10.16 20.32 down_left)" in str(transaction.updated)
+
+
+def test_add_no_connect_preserves_snap_target_and_default_guard() -> None:
+    service, transaction, reload, _calls = _service()
+
+    assert service.add_no_connect(10.0, 20.0, True, None, None) == (
+        "Reloaded schematic.\n"
+        "Target schematic (root): root.kicad_sch\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)"
+    )
+    assert reload.calls == 1
+    assert transaction.calls[0][0] == Path("root.kicad_sch")
+    assert "(no-connect 10.16 20.32)" in str(transaction.updated)


### PR DESCRIPTION
## Summary

- extend the FastMCP-free `SchematicBasicAuthoringService` with bus, bus-entry, and no-connect authoring
- move `sch_add_bus`, `sch_add_bus_wire_entry`, and `sch_add_no_connect` into the existing thin basic-authoring adapter
- reduce the main schematic registration function from 2,591 to 2,498 lines
- keep the expanded adapter registration function at 272 lines, below the 300-line architecture limit
- document the bounded design, implementation plan, and verification evidence

## Compatibility and safety

- public tool names, descriptions, schemas, annotations, profiles, defaults, validation, and result ordering are unchanged
- exact full-server metadata comparison against `main` is identical for all three tools
- child-sheet targeting, grid snapping, transaction/checkpoint behavior, reload ordering, and the default structural-loss guard are unchanged
- the committed tool-surface snapshot and generated tool documentation remain unchanged
- no runtime dependency is added
- this is another bounded tranche of #434 and does not close the parent task

## Verification

- focused service, registration, and schematic integration suite: 154 passed
- focused line coverage for the service and adapter: 100%
- full unit suite passed with five expected skips
- metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated docs, workflow policy/security, strict MkDocs, tool-surface snapshot, and latency benchmark checks passed
- Bandit reported no medium/high findings; dependency audit reported no known vulnerabilities
- source distribution, wheel build, and package metadata checks passed

## Review notes

The change extends the existing basic-authoring boundary instead of introducing another service. Jumper, pin-label routing, swap intents, display settings, and circuit compilation remain separate future tranches.

Refs #434