### PR TITLE
refactor(schematic): extract back-annotation domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md
@@ -1,6 +1,6 @@
 # Schematic Back-Annotation Service Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Extract project hop-over settings and pin/gate swap intent behavior from FastMCP registration into a directly testable schematic domain service.
 
@@ -30,11 +30,11 @@
 - Produces: `SchematicBackAnnotationService.swap_pins(component_ref: str, pin_a: str, pin_b: str) -> str`
 - Produces: `SchematicBackAnnotationService.swap_gates(component_ref: str, gate_a: int, gate_b: int) -> str`
 
-- [ ] **Step 1: Write failing service tests**
+- [x] **Step 1: Write failing service tests**
 
 Cover missing/invalid project JSON, hop-over writes, numeric pin filtering/sorting, unit discovery, invalid candidates, and persisted pin/gate intent payloads.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
 Run:
 
@@ -44,11 +44,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_service.
 
 Expected: collection fails because `kicad_mcp.schematic.back_annotation` does not exist.
 
-- [ ] **Step 3: Implement the service**
+- [x] **Step 3: Implement the service**
 
 Use injected callables and preserve the current strings and state payloads exactly. Keep a private payload builder so swap methods share candidate discovery without importing FastMCP.
 
-- [ ] **Step 4: Verify GREEN and types**
+- [x] **Step 4: Verify GREEN and types**
 
 Run:
 
@@ -60,7 +60,7 @@ uv run --all-extras pyright src/kicad_mcp/schematic/back_annotation.py
 
 Expected: all pass with no type findings.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/schematic/back_annotation.py tests/unit/test_schematic_back_annotation_service.py
@@ -79,11 +79,11 @@ git commit -m "refactor(schematic): extract back-annotation service"
 - Produces: `SchematicBackAnnotationDependencies(service: SchematicBackAnnotationService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicBackAnnotationDependencies) -> None`
 
-- [ ] **Step 1: Write failing adapter tests**
+- [x] **Step 1: Write failing adapter tests**
 
 Assert exact tool names, descriptions, defaults, required fields, annotations, headless metadata, validation, and delegation arguments.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
 Run:
 
@@ -93,11 +93,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_registra
 
 Expected: collection fails because the adapter module does not exist.
 
-- [ ] **Step 3: Implement adapter and composition root**
+- [x] **Step 3: Implement adapter and composition root**
 
 Register the four existing signatures and inject current helpers from `schematic.py`. Delete the four nested tool implementations from the main `register()` function.
 
-- [ ] **Step 4: Verify adapter and focused integration behavior**
+- [x] **Step 4: Verify adapter and focused integration behavior**
 
 Run:
 
@@ -112,7 +112,7 @@ uv run --all-extras pytest -q \
 
 Expected: all pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/kicad_mcp/tools/schematic.py src/kicad_mcp/tools/schematic_back_annotation.py tests/unit/test_schematic_back_annotation_registration.py
@@ -125,11 +125,11 @@ git commit -m "refactor(schematic): delegate back-annotation registration"
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_back_annotation_architecture.py`
 
-- [ ] **Step 1: Write failing architecture tests**
+- [x] **Step 1: Write failing architecture tests**
 
 Require the new service in `PURE_HELPERS`, forbid the adapter from importing `tools.schematic`, and require a 300-line adapter registration limit.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
 Run:
 
@@ -139,11 +139,11 @@ uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_architec
 
 Expected: failures for missing policy entries.
 
-- [ ] **Step 3: Extend the architecture checker**
+- [x] **Step 3: Extend the architecture checker**
 
 Add the service and adapter paths, forbidden adapter import, pure-helper classification, and line limit.
 
-- [ ] **Step 4: Verify architecture and public surface**
+- [x] **Step 4: Verify architecture and public surface**
 
 Run:
 
@@ -155,7 +155,7 @@ uv run --all-extras pytest -q tests/integration/test_tool_surface_snapshot.py
 
 Compare full-server metadata for the four tools against `main`; expected result is exact equality.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add scripts/check_architecture_boundaries.py tests/unit/test_schematic_back_annotation_architecture.py
@@ -167,7 +167,7 @@ git commit -m "test(architecture): guard back-annotation boundaries"
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md`
 
-- [ ] **Step 1: Run focused coverage**
+- [x] **Step 1: Run focused coverage**
 
 ```bash
 uv run --all-extras pytest -q \
@@ -180,7 +180,7 @@ uv run --all-extras pytest -q \
 
 Expected: at least 83% and no uncovered new behavior branches left without justification.
 
-- [ ] **Step 2: Run repository quality gates**
+- [x] **Step 2: Run repository quality gates**
 
 ```bash
 corepack pnpm run check:meta
@@ -198,16 +198,29 @@ uv run --all-extras python scripts/run_pytest.py unit
 
 Expected: all pass; only existing documented warnings/skips may remain.
 
-- [ ] **Step 3: Record measured evidence**
+- [x] **Step 3: Record measured evidence**
 
 Update this plan with service/adapter coverage, focused/full test results, public-surface equality, register spans, and security/package outcomes.
 
-- [ ] **Step 4: Commit evidence**
+- [x] **Step 4: Commit evidence**
 
 ```bash
 git add docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md
 git commit -m "docs(architecture): record back-annotation evidence"
 ```
+
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_set_hop_over`, `sch_list_swappable_pins`, `sch_swap_pins`, and `sch_swap_gates` matches `main`; names, descriptions, input schemas, defaults, and annotations are identical.
+- The committed tool-surface snapshot and generated tool documentation pass without regeneration.
+- The main schematic `register()` span decreased from 2,498 to 2,403 lines; the back-annotation adapter `register()` spans 27 lines.
+- Focused service, registration, architecture, KiCad 10 parity, and schematic integration verification passed: 156 tests.
+- The extracted service and adapter have 100% focused line coverage.
+- The full unit suite passed with five expected skips and the existing Windows-daemon async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, workflow policy/security, strict MkDocs, tool-surface snapshot, and the committed MCP latency benchmark all pass.
+- Bandit reported no medium/high findings, pip-audit reported no known vulnerabilities, and source/wheel builds plus package metadata validation passed.
+- No runtime dependency, public tool contract, experimental profile exposure, state filename, state payload, candidate ordering, project JSON behavior, or result string changed.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md
@@ -1,0 +1,218 @@
+# Schematic Back-Annotation Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract project hop-over settings and pin/gate swap intent behavior from FastMCP registration into a directly testable schematic domain service.
+
+**Architecture:** Add one pure orchestration service and one thin FastMCP adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root by injecting its existing project, symbol-library, and state-storage helpers.
+
+**Tech Stack:** Python 3.13, FastMCP, pytest, Ruff, mypy, Pyright, existing architecture and metadata generators.
+
+## Global Constraints
+
+- Preserve all four public tool names, signatures, descriptions, schemas, annotations, profiles, defaults, and result strings.
+- Preserve current project JSON and `.kicad-mcp` state-file behavior.
+- Do not add runtime dependencies.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `tools.schematic`.
+
+---
+
+### Task 1: Add the FastMCP-free domain service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/back_annotation.py`
+- Create: `tests/unit/test_schematic_back_annotation_service.py`
+
+**Interfaces:**
+- Produces: `SchematicBackAnnotationService.set_hop_over(enabled: bool) -> str`
+- Produces: `SchematicBackAnnotationService.list_swappable_pins(component_ref: str) -> str`
+- Produces: `SchematicBackAnnotationService.swap_pins(component_ref: str, pin_a: str, pin_b: str) -> str`
+- Produces: `SchematicBackAnnotationService.swap_gates(component_ref: str, gate_a: int, gate_b: int) -> str`
+
+- [ ] **Step 1: Write failing service tests**
+
+Cover missing/invalid project JSON, hop-over writes, numeric pin filtering/sorting, unit discovery, invalid candidates, and persisted pin/gate intent payloads.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_service.py
+```
+
+Expected: collection fails because `kicad_mcp.schematic.back_annotation` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+Use injected callables and preserve the current strings and state payloads exactly. Keep a private payload builder so swap methods share candidate discovery without importing FastMCP.
+
+- [ ] **Step 4: Verify GREEN and types**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_service.py
+uv run --all-extras ruff check src/kicad_mcp/schematic/back_annotation.py tests/unit/test_schematic_back_annotation_service.py
+uv run --all-extras pyright src/kicad_mcp/schematic/back_annotation.py
+```
+
+Expected: all pass with no type findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/schematic/back_annotation.py tests/unit/test_schematic_back_annotation_service.py
+git commit -m "refactor(schematic): extract back-annotation service"
+```
+
+### Task 2: Add the thin FastMCP adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_back_annotation.py`
+- Create: `tests/unit/test_schematic_back_annotation_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicBackAnnotationService`
+- Produces: `SchematicBackAnnotationDependencies(service: SchematicBackAnnotationService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicBackAnnotationDependencies) -> None`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Assert exact tool names, descriptions, defaults, required fields, annotations, headless metadata, validation, and delegation arguments.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_registration.py
+```
+
+Expected: collection fails because the adapter module does not exist.
+
+- [ ] **Step 3: Implement adapter and composition root**
+
+Register the four existing signatures and inject current helpers from `schematic.py`. Delete the four nested tool implementations from the main `register()` function.
+
+- [ ] **Step 4: Verify adapter and focused integration behavior**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_back_annotation_service.py \
+  tests/unit/test_schematic_back_annotation_registration.py \
+  tests/unit/test_kicad10_parity_tools.py \
+  tests/integration/test_schematic_tools.py \
+  tests/integration/test_schematic_extended.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kicad_mcp/tools/schematic.py src/kicad_mcp/tools/schematic_back_annotation.py tests/unit/test_schematic_back_annotation_registration.py
+git commit -m "refactor(schematic): delegate back-annotation registration"
+```
+
+### Task 3: Enforce architecture and contract preservation
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_back_annotation_architecture.py`
+
+- [ ] **Step 1: Write failing architecture tests**
+
+Require the new service in `PURE_HELPERS`, forbid the adapter from importing `tools.schematic`, and require a 300-line adapter registration limit.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_architecture.py
+```
+
+Expected: failures for missing policy entries.
+
+- [ ] **Step 3: Extend the architecture checker**
+
+Add the service and adapter paths, forbidden adapter import, pure-helper classification, and line limit.
+
+- [ ] **Step 4: Verify architecture and public surface**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q tests/unit/test_schematic_back_annotation_architecture.py
+uv run --all-extras python scripts/check_architecture_boundaries.py
+uv run --all-extras pytest -q tests/integration/test_tool_surface_snapshot.py
+```
+
+Compare full-server metadata for the four tools against `main`; expected result is exact equality.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check_architecture_boundaries.py tests/unit/test_schematic_back_annotation_architecture.py
+git commit -m "test(architecture): guard back-annotation boundaries"
+```
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md`
+
+- [ ] **Step 1: Run focused coverage**
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_back_annotation_service.py \
+  tests/unit/test_schematic_back_annotation_registration.py \
+  --cov=kicad_mcp.schematic.back_annotation \
+  --cov=kicad_mcp.tools.schematic_back_annotation \
+  --cov-report=term-missing
+```
+
+Expected: at least 83% and no uncovered new behavior branches left without justification.
+
+- [ ] **Step 2: Run repository quality gates**
+
+```bash
+corepack pnpm run check:meta
+corepack pnpm run format:check
+corepack pnpm run lint
+corepack pnpm run typecheck
+uv run --all-extras pyright src/kicad_mcp/schematic/back_annotation.py
+corepack pnpm run check:workflows
+DISABLE_MKDOCS_2_WARNING=true uv run --all-extras mkdocs build --strict
+uv run --all-extras pytest -q -m benchmark tests/unit/test_benchmark_latency.py
+corepack pnpm run check:security
+corepack pnpm run package:check
+uv run --all-extras python scripts/run_pytest.py unit
+```
+
+Expected: all pass; only existing documented warnings/skips may remain.
+
+- [ ] **Step 3: Record measured evidence**
+
+Update this plan with service/adapter coverage, focused/full test results, public-surface equality, register spans, and security/package outcomes.
+
+- [ ] **Step 4: Commit evidence**
+
+```bash
+git add docs/superpowers/plans/2026-07-23-schematic-back-annotation-service.md
+git commit -m "docs(architecture): record back-annotation evidence"
+```
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] **Step 1: Push and open a professional English PR referencing #434**
+- [ ] **Step 2: Inspect all bot/agent comments, reviews, and GraphQL review threads**
+- [ ] **Step 3: Address every actionable finding and rerun affected checks**
+- [ ] **Step 4: Merge only after all required checks pass and the merge state is clean**
+- [ ] **Step 5: Update `main` and remove the worktree and local/remote topic branch**

--- a/docs/superpowers/specs/2026-07-23-schematic-back-annotation-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-back-annotation-service-design.md
@@ -1,0 +1,72 @@
+# Schematic Back-Annotation Service Design
+
+## Context
+
+`src/kicad_mcp/tools/schematic.py` still owns four related tools that manage schematic project settings and deferred swap intents:
+
+- `sch_set_hop_over`
+- `sch_list_swappable_pins`
+- `sch_swap_pins`
+- `sch_swap_gates`
+
+These tools combine FastMCP registration with project JSON mutation, symbol-library inspection, candidate validation, and `.kicad-mcp` state persistence. They form a coherent boundary distinct from schematic geometry authoring.
+
+## Decision
+
+Create a FastMCP-free `SchematicBackAnnotationService` in `src/kicad_mcp/schematic/back_annotation.py` and a thin registration adapter in `src/kicad_mcp/tools/schematic_back_annotation.py`.
+
+The service receives explicit callables for:
+
+- active project-file lookup;
+- placed-symbol lookup and library-ID parsing;
+- pin-alias and unit discovery;
+- symbol-library file access;
+- `.kicad-mcp` state loading and saving.
+
+The adapter preserves the current tool names, signatures, descriptions, annotations, and headless metadata. `schematic.py` remains the composition root and injects existing helpers into the service.
+
+## Behavior Preservation
+
+The extraction must preserve:
+
+- the exact missing-project and invalid-project JSON errors;
+- `hop_over_display` mutation and formatted JSON output;
+- numeric-only pin candidates sorted numerically;
+- available gate discovery from symbol-library blocks;
+- the exact informational note in the swappable-candidates payload;
+- invalid pin/gate messages without writing state;
+- append-only `pin_swaps.json` and `gate_swaps.json` intent records;
+- existing state filenames, payload shapes, and result strings;
+- all four tools' `headless_compatible` metadata.
+
+No public tool surface or operating-mode profile changes are permitted.
+
+## Error Handling
+
+The service keeps current fail-fast behavior. Missing symbol references and malformed library IDs continue to propagate through existing injected helpers. Project JSON decode failures are translated to the current `ValueError` messages. Invalid swap candidates return the existing non-exception result strings and do not persist state.
+
+## Architecture Constraints
+
+- The domain module must not import FastMCP, server composition, KiCad connection modules, or `tools.schematic`.
+- The adapter may import FastMCP, the service type, and metadata decorators only.
+- The adapter `register()` function must remain at or below 300 lines.
+- `schematic.py` must contain composition only for these four tools after extraction.
+
+## Verification
+
+Evidence must include:
+
+- direct service tests without FastMCP;
+- adapter tests for names, schemas, descriptions, metadata, defaults, validation, and delegation;
+- exact full-server surface comparison against `main`;
+- unchanged committed tool-surface snapshot;
+- focused schematic integration tests;
+- architecture boundary checks;
+- formatting, Ruff, mypy, scoped Pyright, full unit, coverage, workflow-security, strict documentation, package, security, and representative latency checks.
+
+## Non-Goals
+
+- Applying pin or gate swaps directly to KiCad files;
+- changing experimental profile exposure;
+- changing state-file formats;
+- extracting jumper authoring, pin-label routing, circuit compilation, or rendering tools in this tranche.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -23,6 +23,10 @@ DOMAIN_MODULES = {
     / "contract_verifier.py",
     "kicad_mcp.models.sch_transaction": SRC_ROOT / "kicad_mcp" / "models" / "sch_transaction.py",
     "kicad_mcp.models.visual_qa": SRC_ROOT / "kicad_mcp" / "models" / "visual_qa.py",
+    "kicad_mcp.schematic.back_annotation": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "back_annotation.py",
     "kicad_mcp.schematic.basic_authoring": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -37,6 +41,10 @@ DOMAIN_MODULES = {
     / "schematic"
     / "symbol_mutation.py",
     "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
+    "kicad_mcp.tools.schematic_back_annotation": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_back_annotation.py",
     "kicad_mcp.tools.schematic_basic_authoring": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -73,6 +81,7 @@ PURE_HELPERS = {
     "kicad_mcp.models.contract_verifier",
     "kicad_mcp.models.sch_transaction",
     "kicad_mcp.models.visual_qa",
+    "kicad_mcp.schematic.back_annotation",
     "kicad_mcp.schematic.basic_authoring",
     "kicad_mcp.schematic.destructive_edit",
     "kicad_mcp.schematic.inspection",
@@ -93,6 +102,7 @@ FORBIDDEN_PURE_IMPORT_PREFIXES = (
 )
 
 ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
+    "kicad_mcp.tools.schematic_back_annotation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_basic_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
@@ -101,6 +111,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
 }
 
 REGISTER_LINE_LIMITS = {
+    "kicad_mcp.tools.schematic_back_annotation": 300,
     "kicad_mcp.tools.schematic_basic_authoring": 300,
     "kicad_mcp.tools.schematic_destructive_edit": 300,
     "kicad_mcp.tools.schematic_inspection": 300,

--- a/src/kicad_mcp/schematic/back_annotation.py
+++ b/src/kicad_mcp/schematic/back_annotation.py
@@ -1,0 +1,137 @@
+"""FastMCP-free orchestration for schematic settings and swap intents."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+type ProjectFile = Callable[[], Path | None]
+type SymbolByReference = Callable[[str], Mapping[str, Any]]
+type SplitLibId = Callable[[str], tuple[str, str]]
+type PinAliasPositions = Callable[
+    [str, str, float, float, int, int],
+    Mapping[str, tuple[float, float]],
+]
+type SymbolLibraryFile = Callable[[str], Path | None]
+type CollectSymbolBlocks = Callable[[str, str], list[str]]
+type AvailableUnitsFromBlocks = Callable[[list[str]], set[int]]
+type LoadState = Callable[[str, dict[str, Any]], dict[str, Any]]
+type SaveState = Callable[[str, dict[str, Any]], Path]
+
+
+@dataclass(frozen=True)
+class SchematicBackAnnotationService:
+    """Manage schematic project settings and deferred swap intents."""
+
+    project_file: ProjectFile
+    symbol_by_reference: SymbolByReference
+    split_lib_id: SplitLibId
+    pin_alias_positions: PinAliasPositions
+    symbol_library_file: SymbolLibraryFile
+    collect_symbol_blocks: CollectSymbolBlocks
+    available_units_from_blocks: AvailableUnitsFromBlocks
+    load_state: LoadState
+    save_state: SaveState
+
+    def set_hop_over(self, enabled: bool = True) -> str:
+        """Toggle KiCad 10 hop-over display in the active project settings."""
+        project_file = self.project_file()
+        if project_file is None or not project_file.exists():
+            raise ValueError(
+                "No project file is configured. Call kicad_set_project() before changing "
+                "schematic display settings."
+            )
+        try:
+            raw_project_payload = json.loads(project_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Project file '{project_file}' does not contain valid JSON.") from exc
+        if not isinstance(raw_project_payload, dict):
+            raise ValueError("The active project file must contain a JSON object.")
+        project_payload = cast(dict[str, object], raw_project_payload)
+
+        schematic_settings = cast(
+            dict[str, object],
+            project_payload.setdefault("schematic", {}),
+        )
+        schematic_settings["hop_over_display"] = bool(enabled)
+        project_file.write_text(json.dumps(project_payload, indent=2), encoding="utf-8")
+        state = "enabled" if enabled else "disabled"
+        return f"Hop-over display set to {state} in {project_file}."
+
+    def _swappable_payload(self, component_ref: str) -> dict[str, object]:
+        symbol = self.symbol_by_reference(component_ref)
+        library, symbol_name = self.split_lib_id(str(symbol.get("lib_id", "")))
+        aliases = self.pin_alias_positions(
+            library,
+            symbol_name,
+            float(symbol.get("x", 0.0)),
+            float(symbol.get("y", 0.0)),
+            int(symbol.get("rotation", 0)),
+            int(symbol.get("unit", 1)),
+        )
+        pins = sorted(
+            {alias for alias in aliases if alias and alias.isdigit()},
+            key=int,
+        )
+
+        units: list[int] = []
+        symbol_file = self.symbol_library_file(library)
+        if symbol_file is not None:
+            content = symbol_file.read_text(encoding="utf-8", errors="ignore")
+            blocks = self.collect_symbol_blocks(content, symbol_name)
+            units = sorted(self.available_units_from_blocks(blocks))
+
+        return {
+            "reference": component_ref,
+            "pins": pins,
+            "gates": units,
+            "note": "Recorded swaps are stored as back-annotation intents in .kicad-mcp.",
+        }
+
+    def list_swappable_pins(self, component_ref: str) -> str:
+        """List candidate pins and units that can participate in a swap workflow."""
+        return json.dumps(self._swappable_payload(component_ref), indent=2)
+
+    def swap_pins(self, component_ref: str, pin_a: str, pin_b: str) -> str:
+        """Record a pin-swap back-annotation intent for a component."""
+        payload = self._swappable_payload(component_ref)
+        pins = cast(list[str], payload.get("pins", []))
+        if pin_a not in pins or pin_b not in pins:
+            return (
+                f"Pins '{pin_a}' and/or '{pin_b}' are not swappable candidates "
+                f"for '{component_ref}'."
+            )
+
+        state = self.load_state("pin_swaps.json", {"swaps": []})
+        swaps = cast(list[dict[str, str]], state.setdefault("swaps", []))
+        swaps.append(
+            {
+                "reference": component_ref,
+                "pin_a": pin_a,
+                "pin_b": pin_b,
+            }
+        )
+        path = self.save_state("pin_swaps.json", state)
+        return f"Recorded pin swap {component_ref}:{pin_a}<->{pin_b} in {path}."
+
+    def swap_gates(self, component_ref: str, gate_a: int, gate_b: int) -> str:
+        """Record a gate-swap back-annotation intent for a multi-unit component."""
+        payload = self._swappable_payload(component_ref)
+        gates = cast(list[int], payload.get("gates", []))
+        if gate_a not in gates or gate_b not in gates:
+            return f"Gates '{gate_a}' and/or '{gate_b}' are not available on '{component_ref}'."
+
+        state = self.load_state("gate_swaps.json", {"swaps": []})
+        swaps = cast(list[dict[str, object]], state.setdefault("swaps", []))
+        swaps.append(
+            {
+                "reference": component_ref,
+                "gate_a": gate_a,
+                "gate_b": gate_b,
+            }
+        )
+        path = self.save_state("gate_swaps.json", state)
+        return f"Recorded gate swap {component_ref}:{gate_a}<->{gate_b} in {path}."

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -42,6 +42,7 @@ from ..models.schematic import (
 from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
+from ..schematic.back_annotation import SchematicBackAnnotationService
 from ..schematic.basic_authoring import SchematicBasicAuthoringService
 from ..schematic.destructive_edit import SchematicDestructiveEditService
 from ..schematic.inspection import SchematicInspectionService
@@ -60,6 +61,7 @@ from ..utils.sexpr import (
     _unescape_sexpr_string,
 )
 from . import (
+    schematic_back_annotation,
     schematic_basic_authoring,
     schematic_destructive_edit,
     schematic_inspection,
@@ -5544,6 +5546,24 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    back_annotation_service = SchematicBackAnnotationService(
+        project_file=lambda: get_config().project_file,
+        symbol_by_reference=_symbol_by_reference,
+        split_lib_id=_split_lib_id,
+        pin_alias_positions=get_pin_alias_positions,
+        symbol_library_file=_symbol_library_file,
+        collect_symbol_blocks=_collect_symbol_blocks,
+        available_units_from_blocks=_available_units_from_blocks,
+        load_state=_load_schematic_state,
+        save_state=_save_schematic_state,
+    )
+    schematic_back_annotation.register(
+        mcp,
+        schematic_back_annotation.SchematicBackAnnotationDependencies(
+            service=back_annotation_service,
+        ),
+    )
+
     @mcp.tool()
     def sch_add_pin_labels(
         connections: list[dict[str, Any]],
@@ -5725,119 +5745,6 @@ def register(mcp: FastMCP) -> None:
             f"{_reload_schematic()}\n{_format_target_detail(target)}\n"
             f"Added {len(wire_blocks)} pin terminal(s) with stubs:\n" + "\n".join(results)
         )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_set_hop_over(enabled: bool = True) -> str:
-        """Toggle KiCad 10 hop-over display in the active project settings."""
-        cfg = get_config()
-        if cfg.project_file is None or not cfg.project_file.exists():
-            raise ValueError(
-                "No project file is configured. Call kicad_set_project() before changing "
-                "schematic display settings."
-            )
-        try:
-            project_payload = json.loads(cfg.project_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"Project file '{cfg.project_file}' does not contain valid JSON."
-            ) from exc
-        if not isinstance(project_payload, dict):
-            raise ValueError("The active project file must contain a JSON object.")
-
-        schematic_settings = cast(
-            dict[str, object],
-            project_payload.setdefault("schematic", {}),
-        )
-        schematic_settings["hop_over_display"] = bool(enabled)
-        cfg.project_file.write_text(json.dumps(project_payload, indent=2), encoding="utf-8")
-        return (
-            f"Hop-over display set to {'enabled' if enabled else 'disabled'} in {cfg.project_file}."
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_list_swappable_pins(component_ref: str) -> str:
-        """List candidate pins and units that can participate in a swap workflow."""
-        symbol = _symbol_by_reference(component_ref)
-        library, symbol_name = _split_lib_id(str(symbol.get("lib_id", "")))
-        pins = sorted(
-            {
-                alias
-                for alias in get_pin_alias_positions(
-                    library,
-                    symbol_name,
-                    float(symbol.get("x", 0.0)),
-                    float(symbol.get("y", 0.0)),
-                    int(symbol.get("rotation", 0)),
-                    int(symbol.get("unit", 1)),
-                )
-                if alias and alias.isdigit()
-            },
-            key=int,
-        )
-
-        units = []
-        sym_file = _symbol_library_file(library)
-        if sym_file is not None:
-            content = sym_file.read_text(encoding="utf-8", errors="ignore")
-            symbol_blocks = _collect_symbol_blocks(content, symbol_name)
-            units = sorted(_available_units_from_blocks(symbol_blocks))
-
-        return json.dumps(
-            {
-                "reference": component_ref,
-                "pins": pins,
-                "gates": units,
-                "note": "Recorded swaps are stored as back-annotation intents in .kicad-mcp.",
-            },
-            indent=2,
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_swap_pins(component_ref: str, pin_a: str, pin_b: str) -> str:
-        """Record a pin-swap back-annotation intent for a component."""
-        swappable = json.loads(sch_list_swappable_pins(component_ref))
-        pins = cast(list[str], swappable.get("pins", []))
-        if pin_a not in pins or pin_b not in pins:
-            return (
-                f"Pins '{pin_a}' and/or '{pin_b}' are not swappable candidates "
-                f"for '{component_ref}'."
-            )
-
-        state = _load_schematic_state("pin_swaps.json", {"swaps": []})
-        swaps = cast(list[dict[str, str]], state.setdefault("swaps", []))
-        swaps.append(
-            {
-                "reference": component_ref,
-                "pin_a": pin_a,
-                "pin_b": pin_b,
-            }
-        )
-        path = _save_schematic_state("pin_swaps.json", state)
-        return f"Recorded pin swap {component_ref}:{pin_a}<->{pin_b} in {path}."
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_swap_gates(component_ref: str, gate_a: int, gate_b: int) -> str:
-        """Record a gate-swap back-annotation intent for a multi-unit component."""
-        swappable = json.loads(sch_list_swappable_pins(component_ref))
-        gates = cast(list[int], swappable.get("gates", []))
-        if gate_a not in gates or gate_b not in gates:
-            return f"Gates '{gate_a}' and/or '{gate_b}' are not available on '{component_ref}'."
-
-        state = _load_schematic_state("gate_swaps.json", {"swaps": []})
-        swaps = cast(list[dict[str, object]], state.setdefault("swaps", []))
-        swaps.append(
-            {
-                "reference": component_ref,
-                "gate_a": gate_a,
-                "gate_b": gate_b,
-            }
-        )
-        path = _save_schematic_state("gate_swaps.json", state)
-        return f"Recorded gate swap {component_ref}:{gate_a}<->{gate_b} in {path}."
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/schematic_back_annotation.py
+++ b/src/kicad_mcp/tools/schematic_back_annotation.py
@@ -1,5 +1,7 @@
 """Thin FastMCP adapters for schematic settings and swap intents."""
 
+# pyright: reportUnusedFunction=false
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/kicad_mcp/tools/schematic_back_annotation.py
+++ b/src/kicad_mcp/tools/schematic_back_annotation.py
@@ -1,0 +1,46 @@
+"""Thin FastMCP adapters for schematic settings and swap intents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.back_annotation import SchematicBackAnnotationService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicBackAnnotationDependencies:
+    """Back-annotation service injected by the schematic composition root."""
+
+    service: SchematicBackAnnotationService
+
+
+def register(mcp: FastMCP, dependencies: SchematicBackAnnotationDependencies) -> None:
+    """Register schematic settings and deferred swap-intent tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_set_hop_over(enabled: bool = True) -> str:
+        """Toggle KiCad 10 hop-over display in the active project settings."""
+        return service.set_hop_over(enabled)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_list_swappable_pins(component_ref: str) -> str:
+        """List candidate pins and units that can participate in a swap workflow."""
+        return service.list_swappable_pins(component_ref)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_swap_pins(component_ref: str, pin_a: str, pin_b: str) -> str:
+        """Record a pin-swap back-annotation intent for a component."""
+        return service.swap_pins(component_ref, pin_a, pin_b)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_swap_gates(component_ref: str, gate_a: int, gate_b: int) -> str:
+        """Record a gate-swap back-annotation intent for a multi-unit component."""
+        return service.swap_gates(component_ref, gate_a, gate_b)

--- a/tests/unit/test_schematic_back_annotation_architecture.py
+++ b/tests/unit/test_schematic_back_annotation_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_back_annotation_modules() -> None:
+    assert "kicad_mcp.schematic.back_annotation" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.back_annotation" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_back_annotation" in boundaries.DOMAIN_MODULES
+
+
+def test_back_annotation_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_back_annotation.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_back_annotation"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_back_annotation_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_back_annotation.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_back_annotation"] == 300

--- a/tests/unit/test_schematic_back_annotation_registration.py
+++ b/tests/unit/test_schematic_back_annotation_registration.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_back_annotation import (
+    SchematicBackAnnotationDependencies,
+    register,
+)
+
+
+class FakeBackAnnotationService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def set_hop_over(self, enabled: bool = True) -> str:
+        self.calls.append(("set_hop_over", (enabled,)))
+        return "hop"
+
+    def list_swappable_pins(self, component_ref: str) -> str:
+        self.calls.append(("list_swappable_pins", (component_ref,)))
+        return "list"
+
+    def swap_pins(self, component_ref: str, pin_a: str, pin_b: str) -> str:
+        self.calls.append(("swap_pins", (component_ref, pin_a, pin_b)))
+        return "pins"
+
+    def swap_gates(self, component_ref: str, gate_a: int, gate_b: int) -> str:
+        self.calls.append(("swap_gates", (component_ref, gate_a, gate_b)))
+        return "gates"
+
+
+def _registered() -> tuple[FastMCP, FakeBackAnnotationService]:
+    server = FastMCP("schematic-back-annotation-test")
+    service = FakeBackAnnotationService()
+    register(server, SchematicBackAnnotationDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schema_defaults() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_set_hop_over",
+        "sch_list_swappable_pins",
+        "sch_swap_pins",
+        "sch_swap_gates",
+    }
+    assert tools["sch_set_hop_over"].description == (
+        "Toggle KiCad 10 hop-over display in the active project settings."
+    )
+    assert tools["sch_list_swappable_pins"].description == (
+        "List candidate pins and units that can participate in a swap workflow."
+    )
+    assert tools["sch_swap_pins"].description == (
+        "Record a pin-swap back-annotation intent for a component."
+    )
+    assert tools["sch_swap_gates"].description == (
+        "Record a gate-swap back-annotation intent for a multi-unit component."
+    )
+    assert tools["sch_set_hop_over"].parameters["properties"]["enabled"]["default"] is True
+    assert tools["sch_set_hop_over"].parameters.get("required") is None
+    assert tools["sch_list_swappable_pins"].parameters["required"] == ["component_ref"]
+    assert tools["sch_swap_pins"].parameters["required"] == [
+        "component_ref",
+        "pin_a",
+        "pin_b",
+    ]
+    assert tools["sch_swap_gates"].parameters["required"] == [
+        "component_ref",
+        "gate_a",
+        "gate_b",
+    ]
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    for name in tools:
+        metadata = get_tool_metadata(name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+        assert metadata.requires_kicad_running is False
+
+
+def test_registration_delegates_all_arguments_and_defaults() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_set_hop_over"].fn() == "hop"
+    assert tools["sch_list_swappable_pins"].fn(component_ref="R1") == "list"
+    assert tools["sch_swap_pins"].fn(component_ref="R1", pin_a="1", pin_b="2") == "pins"
+    assert tools["sch_swap_gates"].fn(component_ref="U1", gate_a=1, gate_b=2) == "gates"
+
+    assert service.calls == [
+        ("set_hop_over", (True,)),
+        ("list_swappable_pins", ("R1",)),
+        ("swap_pins", ("R1", "1", "2")),
+        ("swap_gates", ("U1", 1, 2)),
+    ]

--- a/tests/unit/test_schematic_back_annotation_service.py
+++ b/tests/unit/test_schematic_back_annotation_service.py
@@ -147,9 +147,8 @@ def test_swap_pins_appends_intent_and_preserves_same_pin_behavior() -> None:
         state=state,
     )
 
-    assert service.swap_pins("R1", "1", "1") == (
-        "Recorded pin swap R1:1<->1 in .kicad-mcp/pin_swaps.json."
-    )
+    saved_path = Path(".kicad-mcp") / "pin_swaps.json"
+    assert service.swap_pins("R1", "1", "1") == (f"Recorded pin swap R1:1<->1 in {saved_path}.")
     assert state.saved == [
         (
             "pin_swaps.json",
@@ -179,9 +178,8 @@ def test_swap_gates_appends_intent(tmp_path: Path) -> None:
     state.loaded["gate_swaps.json"] = {"swaps": []}
     service, state = _service(symbol_library_file=library, units={1, 2}, state=state)
 
-    assert service.swap_gates("U1", 1, 2) == (
-        "Recorded gate swap U1:1<->2 in .kicad-mcp/gate_swaps.json."
-    )
+    saved_path = Path(".kicad-mcp") / "gate_swaps.json"
+    assert service.swap_gates("U1", 1, 2) == (f"Recorded gate swap U1:1<->2 in {saved_path}.")
     assert state.saved == [
         (
             "gate_swaps.json",

--- a/tests/unit/test_schematic_back_annotation_service.py
+++ b/tests/unit/test_schematic_back_annotation_service.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kicad_mcp.schematic.back_annotation import SchematicBackAnnotationService
+
+
+class _StateRecorder:
+    def __init__(self) -> None:
+        self.loaded: dict[str, dict[str, Any]] = {}
+        self.saved: list[tuple[str, dict[str, Any]]] = []
+
+    def load(self, filename: str, default: dict[str, Any]) -> dict[str, Any]:
+        payload = self.loaded.get(filename, default)
+        return json.loads(json.dumps(payload))
+
+    def save(self, filename: str, payload: dict[str, Any]) -> Path:
+        self.saved.append((filename, json.loads(json.dumps(payload))))
+        return Path(".kicad-mcp") / filename
+
+
+def _service(
+    *,
+    project_file: Path | None = None,
+    symbol: dict[str, Any] | None = None,
+    aliases: dict[str, tuple[float, float]] | None = None,
+    symbol_library_file: Path | None = None,
+    units: set[int] | None = None,
+    state: _StateRecorder | None = None,
+) -> tuple[SchematicBackAnnotationService, _StateRecorder]:
+    recorder = state or _StateRecorder()
+    service = SchematicBackAnnotationService(
+        project_file=lambda: project_file,
+        symbol_by_reference=lambda reference: (
+            symbol
+            or {
+                "reference": reference,
+                "lib_id": "Device:R",
+                "x": 10.0,
+                "y": 20.0,
+                "rotation": 90,
+                "unit": 1,
+            }
+        ),
+        split_lib_id=lambda lib_id: tuple(lib_id.split(":", 1)),  # type: ignore[return-value]
+        pin_alias_positions=lambda *_args: (
+            aliases
+            or {
+                "10": (1.0, 1.0),
+                "2": (2.0, 2.0),
+                "A": (3.0, 3.0),
+                "": (4.0, 4.0),
+            }
+        ),
+        symbol_library_file=lambda _library: symbol_library_file,
+        collect_symbol_blocks=lambda _content, _symbol_name: ["unit-1", "unit-2"],
+        available_units_from_blocks=lambda _blocks: set(units or {2, 1}),
+        load_state=recorder.load,
+        save_state=recorder.save,
+    )
+    return service, recorder
+
+
+def test_set_hop_over_requires_configured_existing_project(tmp_path: Path) -> None:
+    missing, _state = _service(project_file=None)
+    with pytest.raises(
+        ValueError,
+        match="No project file is configured. Call kicad_set_project",
+    ):
+        missing.set_hop_over(True)
+
+    absent_path, _state = _service(project_file=tmp_path / "missing.kicad_pro")
+    with pytest.raises(ValueError, match="No project file is configured"):
+        absent_path.set_hop_over(False)
+
+
+def test_set_hop_over_preserves_json_errors_and_object_requirement(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.kicad_pro"
+    invalid.write_text("{not-json", encoding="utf-8")
+    service, _state = _service(project_file=invalid)
+    with pytest.raises(ValueError, match="does not contain valid JSON"):
+        service.set_hop_over(True)
+
+    non_object = tmp_path / "list.kicad_pro"
+    non_object.write_text("[]", encoding="utf-8")
+    service, _state = _service(project_file=non_object)
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        service.set_hop_over(True)
+
+
+def test_set_hop_over_updates_project_payload_and_result(tmp_path: Path) -> None:
+    project = tmp_path / "demo.kicad_pro"
+    project.write_text(json.dumps({"board": {}, "schematic": {"legacy": True}}), encoding="utf-8")
+    service, _state = _service(project_file=project)
+
+    assert service.set_hop_over(False) == f"Hop-over display set to disabled in {project}."
+    payload = json.loads(project.read_text(encoding="utf-8"))
+    assert payload == {
+        "board": {},
+        "schematic": {"legacy": True, "hop_over_display": False},
+    }
+    assert project.read_text(encoding="utf-8").startswith("{\n  ")
+
+
+def test_list_swappable_pins_filters_numeric_aliases_and_sorts_units(tmp_path: Path) -> None:
+    library = tmp_path / "Device.kicad_sym"
+    library.write_text("symbol library", encoding="utf-8")
+    service, _state = _service(symbol_library_file=library, units={3, 1, 2})
+
+    result = json.loads(service.list_swappable_pins("R1"))
+
+    assert result == {
+        "reference": "R1",
+        "pins": ["2", "10"],
+        "gates": [1, 2, 3],
+        "note": "Recorded swaps are stored as back-annotation intents in .kicad-mcp.",
+    }
+
+
+def test_list_swappable_pins_omits_gate_discovery_without_library_file() -> None:
+    service, _state = _service(symbol_library_file=None)
+
+    result = json.loads(service.list_swappable_pins("R1"))
+
+    assert result["pins"] == ["2", "10"]
+    assert result["gates"] == []
+
+
+def test_swap_pins_rejects_invalid_candidates_without_state_write() -> None:
+    service, state = _service(aliases={"1": (0.0, 0.0), "2": (1.0, 1.0)})
+
+    assert service.swap_pins("R1", "1", "3") == (
+        "Pins '1' and/or '3' are not swappable candidates for 'R1'."
+    )
+    assert state.saved == []
+
+
+def test_swap_pins_appends_intent_and_preserves_same_pin_behavior() -> None:
+    state = _StateRecorder()
+    state.loaded["pin_swaps.json"] = {"swaps": [{"reference": "U1", "pin_a": "1", "pin_b": "2"}]}
+    service, state = _service(
+        aliases={"1": (0.0, 0.0), "2": (1.0, 1.0)},
+        state=state,
+    )
+
+    assert service.swap_pins("R1", "1", "1") == (
+        "Recorded pin swap R1:1<->1 in .kicad-mcp/pin_swaps.json."
+    )
+    assert state.saved == [
+        (
+            "pin_swaps.json",
+            {
+                "swaps": [
+                    {"reference": "U1", "pin_a": "1", "pin_b": "2"},
+                    {"reference": "R1", "pin_a": "1", "pin_b": "1"},
+                ]
+            },
+        )
+    ]
+
+
+def test_swap_gates_rejects_invalid_candidates_without_state_write(tmp_path: Path) -> None:
+    library = tmp_path / "Device.kicad_sym"
+    library.write_text("symbol library", encoding="utf-8")
+    service, state = _service(symbol_library_file=library, units={1})
+
+    assert service.swap_gates("R1", 1, 2) == ("Gates '1' and/or '2' are not available on 'R1'.")
+    assert state.saved == []
+
+
+def test_swap_gates_appends_intent(tmp_path: Path) -> None:
+    library = tmp_path / "Device.kicad_sym"
+    library.write_text("symbol library", encoding="utf-8")
+    state = _StateRecorder()
+    state.loaded["gate_swaps.json"] = {"swaps": []}
+    service, state = _service(symbol_library_file=library, units={1, 2}, state=state)
+
+    assert service.swap_gates("U1", 1, 2) == (
+        "Recorded gate swap U1:1<->2 in .kicad-mcp/gate_swaps.json."
+    )
+    assert state.saved == [
+        (
+            "gate_swaps.json",
+            {"swaps": [{"reference": "U1", "gate_a": 1, "gate_b": 2}]},
+        )
+    ]


### PR DESCRIPTION
## Summary

- extract hop-over project settings and deferred pin/gate swap orchestration into a typed, FastMCP-free `SchematicBackAnnotationService`
- add a 27-line registration adapter for `sch_set_hop_over`, `sch_list_swappable_pins`, `sch_swap_pins`, and `sch_swap_gates`
- reduce the main schematic registration function from 2,498 to 2,403 lines
- add architecture policy for service purity, adapter isolation, and the 300-line registration limit
- document the bounded design, implementation plan, and verification evidence

## Compatibility and safety

- public tool names, descriptions, input schemas, annotations, defaults, profiles, validation, and result strings are unchanged
- exact full-server metadata comparison against `main` is identical for all four tools
- project JSON errors and hop-over persistence behavior remain unchanged
- pin candidates remain numeric-only and numerically sorted; gate discovery remains symbol-library-backed
- `pin_swaps.json` and `gate_swaps.json` filenames, payloads, append-only behavior, and invalid-candidate no-write behavior are unchanged
- the committed tool-surface snapshot and generated documentation remain unchanged
- no runtime dependency is added
- this is another bounded tranche of #434 and does not close the parent task

## Verification

- focused service, registration, architecture, KiCad 10 parity, and schematic integration suite: 156 passed
- focused line coverage for the extracted service and adapter: 100%
- full unit suite passed with five expected skips
- metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated docs, workflow policy/security, strict MkDocs, tool-surface snapshot, and latency benchmark checks passed
- Bandit reported no medium/high findings; dependency audit reported no known vulnerabilities
- source distribution, wheel build, and package metadata checks passed

## Review notes

The service records back-annotation intent only; it does not apply pin or gate swaps directly to KiCad files. Jumper authoring, pin-label routing, circuit compilation, and rendering remain separate future tranches.

Refs #434