### PR TITLE
refactor(schematic): extract hierarchy authoring domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-hierarchy-authoring-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-hierarchy-authoring-service.md
@@ -29,11 +29,11 @@
 - Produces: `SchematicHierarchyAuthoringService.add_hierarchical_label(text, x_mm, y_mm, shape, rotation, snap_to_grid, justify, sheet, sheet_file) -> str`
 - Produces: `SchematicHierarchyAuthoringService.add_global_label(text, x_mm, y_mm, shape, rotation, snap_to_grid, justify, sheet, sheet_file) -> str`
 
-- [ ] Write direct failing tests for missing dependency, duplicate/existing/new child files, failures, snapping, targeting, label block arguments, transaction target, reload order, and exact results.
-- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_hierarchy_authoring_service.py`; expect collection failure because the module is absent.
-- [ ] Implement the minimal injected service while preserving current strings and warning fields.
-- [ ] Run service tests, Ruff, mypy/Pyright for the new module; expect all pass.
-- [ ] Commit with `refactor(schematic): extract hierarchy authoring service`.
+- [x] Write direct failing tests for missing dependency, duplicate/existing/new child files, failures, snapping, targeting, label block arguments, transaction target, reload order, and exact results.
+- [x] Run `uv run --all-extras pytest -q tests/unit/test_schematic_hierarchy_authoring_service.py`; expect collection failure because the module is absent.
+- [x] Implement the minimal injected service while preserving current strings and warning fields.
+- [x] Run service tests, Ruff, mypy/Pyright for the new module; expect all pass.
+- [x] Commit with `refactor(schematic): extract hierarchy authoring service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -47,11 +47,11 @@
 - Produces: `SchematicHierarchyAuthoringDependencies(service: SchematicHierarchyAuthoringService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicHierarchyAuthoringDependencies) -> None`
 
-- [ ] Write failing adapter tests for exact names, descriptions, defaults, required fields, aliases, validation, metadata, and delegation.
-- [ ] Run the adapter test; expect collection failure because the adapter is absent.
-- [ ] Implement registration and composition wiring; remove the three nested legacy tool functions.
-- [ ] Run service/adapter and focused schematic integration tests; expect all pass.
-- [ ] Commit with `refactor(schematic): delegate hierarchy authoring registration`.
+- [x] Write failing adapter tests for exact names, descriptions, defaults, required fields, aliases, validation, metadata, and delegation.
+- [x] Run the adapter test; expect collection failure because the adapter is absent.
+- [x] Implement registration and composition wiring; remove the three nested legacy tool functions.
+- [x] Run service/adapter and focused schematic integration tests; expect all pass.
+- [x] Commit with `refactor(schematic): delegate hierarchy authoring registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -59,20 +59,34 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_hierarchy_authoring_architecture.py`
 
-- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
-- [ ] Add both modules to the architecture policy and run the checker.
-- [ ] Compare exact full-server metadata for the three tools against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard hierarchy authoring boundaries`.
+- [x] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [x] Add both modules to the architecture policy and run the checker.
+- [x] Compare exact full-server metadata for the three tools against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard hierarchy authoring boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-hierarchy-authoring-service.md`
 
-- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
-- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, and full unit gates.
-- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
-- [ ] Commit with `docs(architecture): record hierarchy authoring evidence`.
+- [x] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [x] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, and full unit gates.
+- [x] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [x] Commit with `docs(architecture): record hierarchy authoring evidence`.
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_create_sheet`, `sch_add_hierarchical_label`, and `sch_add_global_label` matches `main`: names, descriptions, input schemas, defaults, aliases, and annotations are identical.
+- The committed tool-surface snapshot passes without regeneration.
+- The main schematic `register()` span decreased from 2,403 to 2,259 lines; the hierarchy-authoring adapter `register()` spans 119 lines.
+- Focused service, registration, architecture, and schematic integration coverage passed: 156 tests.
+- The extracted service and adapter have 100% focused line coverage.
+- The full unit suite passed across 1,670 collected tests with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, latency benchmark, Bandit, dependency audit, and package build gates pass.
+- OSV-Scanner 2.4.0 inspected four lockfiles representing 442 dependency entries and reported no known vulnerabilities.
+- SonarQube CLI secret analysis completed with no findings. Full Sonar code/dependency analysis could not run because the service account has no saved SonarQube connection; repository SonarQube Cloud Automatic Analysis remains unchanged.
+- Semgrep CI reported zero findings, but its Pro cross-file engine hit an internal cache-unmarshal error. A separate scan of all four changed implementation/test files completed with 290 OSS rules, zero findings, and zero scan errors. The pull request Semgrep Cloud check remains mandatory before merge.
+- No public tool contract, child-sheet path normalization, lazy dependency loading, grid snapping, transaction target, warning fields, result strings, or reload ordering changed.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/plans/2026-07-23-schematic-hierarchy-authoring-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-hierarchy-authoring-service.md
@@ -1,0 +1,83 @@
+# Schematic Hierarchy Authoring Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract child-sheet and hierarchy-label authoring from FastMCP registration into a directly testable schematic domain service.
+
+**Architecture:** Add one pure orchestration service and one thin FastMCP adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root by injecting existing target, grid, transaction, serializer, and reload helpers.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, kicad-sch-api, pytest, Ruff, mypy, Pyright, existing architecture and metadata generators.
+
+## Global Constraints
+
+- Preserve the three public tool names, signatures, descriptions, schemas, annotations, profiles, defaults, aliases, and result strings.
+- Preserve lazy dependency loading, child-file behavior, transaction semantics, and reload ordering.
+- Do not add runtime dependencies.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `tools.schematic`.
+
+---
+
+### Task 1: Add the FastMCP-free hierarchy service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/hierarchy_authoring.py`
+- Create: `tests/unit/test_schematic_hierarchy_authoring_service.py`
+
+**Interfaces:**
+- Produces: `SchematicHierarchyAuthoringService.create_sheet(name, filename, x_mm, y_mm, snap_to_grid) -> str`
+- Produces: `SchematicHierarchyAuthoringService.add_hierarchical_label(text, x_mm, y_mm, shape, rotation, snap_to_grid, justify, sheet, sheet_file) -> str`
+- Produces: `SchematicHierarchyAuthoringService.add_global_label(text, x_mm, y_mm, shape, rotation, snap_to_grid, justify, sheet, sheet_file) -> str`
+
+- [ ] Write direct failing tests for missing dependency, duplicate/existing/new child files, failures, snapping, targeting, label block arguments, transaction target, reload order, and exact results.
+- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_hierarchy_authoring_service.py`; expect collection failure because the module is absent.
+- [ ] Implement the minimal injected service while preserving current strings and warning fields.
+- [ ] Run service tests, Ruff, mypy/Pyright for the new module; expect all pass.
+- [ ] Commit with `refactor(schematic): extract hierarchy authoring service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_hierarchy_authoring.py`
+- Create: `tests/unit/test_schematic_hierarchy_authoring_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicHierarchyAuthoringService`
+- Produces: `SchematicHierarchyAuthoringDependencies(service: SchematicHierarchyAuthoringService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicHierarchyAuthoringDependencies) -> None`
+
+- [ ] Write failing adapter tests for exact names, descriptions, defaults, required fields, aliases, validation, metadata, and delegation.
+- [ ] Run the adapter test; expect collection failure because the adapter is absent.
+- [ ] Implement registration and composition wiring; remove the three nested legacy tool functions.
+- [ ] Run service/adapter and focused schematic integration tests; expect all pass.
+- [ ] Commit with `refactor(schematic): delegate hierarchy authoring registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_hierarchy_authoring_architecture.py`
+
+- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [ ] Add both modules to the architecture policy and run the checker.
+- [ ] Compare exact full-server metadata for the three tools against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard hierarchy authoring boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-hierarchy-authoring-service.md`
+
+- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, and full unit gates.
+- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [ ] Commit with `docs(architecture): record hierarchy authoring evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect all bot/agent comments, reviews, and GraphQL review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after all required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/specs/2026-07-23-schematic-hierarchy-authoring-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-hierarchy-authoring-service-design.md
@@ -1,0 +1,75 @@
+# Schematic Hierarchy Authoring Service Design
+
+## Context
+
+`src/kicad_mcp/tools/schematic.py` still owns three related hierarchy-authoring tools:
+
+- `sch_create_sheet`
+- `sch_add_hierarchical_label`
+- `sch_add_global_label`
+
+They combine FastMCP registration with Pydantic validation, target resolution, grid snapping, child-file creation, kicad-sch-api orchestration, transactional S-expression mutation, reload behavior, and user-facing diagnostics.
+
+## Decision
+
+Create a FastMCP-free `SchematicHierarchyAuthoringService` in `src/kicad_mcp/schematic/hierarchy_authoring.py` and a thin registration adapter in `src/kicad_mcp/tools/schematic_hierarchy_authoring.py`.
+
+The service receives explicit callables for:
+
+- active root schematic lookup and optional child-target resolution;
+- grid point snapping and snap diagnostics;
+- lazy child-schematic creation and existing schematic loading;
+- project-name lookup;
+- transactional file writes and reload behavior;
+- label-block generation and placement before sheet instances;
+- warning emission for dependency and authoring failures.
+
+The adapter preserves existing Pydantic models, aliases, defaults, descriptions, annotations, and public signatures. `schematic.py` remains the composition root and injects current helpers and constants.
+
+## Behavior Preservation
+
+The extraction must preserve:
+
+- lazy handling of a missing `kicad-sch-api` dependency and the exact returned message;
+- automatic `.kicad_sch` extension handling;
+- creation of parent directories before child-file creation;
+- duplicate sheet-name detection before file or root mutation;
+- child-sheet creation only when the target file does not exist;
+- project-relative forward-slash sheet filenames;
+- existing sheet dimensions and project-name propagation;
+- exact warning events and user-facing failure strings;
+- reload ordering and result formatting;
+- `text`/`name` aliases for hierarchical and global labels;
+- exact shape, rotation, justify, snap, child-target, transaction, and result behavior.
+
+No public tool surface, profile, backend, or transaction-policy change is permitted.
+
+## Error Handling
+
+Dependency loading remains lazy. Import or factory failures return the current unavailable-dependency string after emitting the current warning event. Sheet authoring exceptions return the current `Could not create child sheet ...` result and warning fields. Label validation and target-resolution errors continue to propagate as they do today.
+
+## Architecture Constraints
+
+- The domain module must not import FastMCP, server composition, KiCad connection modules, or `tools.schematic`.
+- The adapter may import FastMCP, existing Pydantic input models, the service type, and metadata utilities only.
+- The adapter `register()` function must remain at or below 300 lines.
+- `schematic.py` must retain composition wiring only for these tools after extraction.
+
+## Verification
+
+Evidence must include:
+
+- direct service tests without FastMCP;
+- adapter tests for names, schemas, descriptions, aliases, defaults, validation, metadata, and delegation;
+- exact full-server surface comparison against `main`;
+- unchanged committed tool-surface snapshot and generated docs;
+- focused hierarchy and schematic integration tests;
+- architecture boundary checks;
+- formatting, Ruff, mypy, scoped Pyright, full unit, focused coverage, workflow-security, strict documentation, package, security, and representative latency checks.
+
+## Non-Goals
+
+- changing child-sheet serialization or dimensions;
+- adding new sheet ports or hierarchical pins;
+- changing label rendering defaults;
+- extracting pin-label routing, circuit compilation, placement, or rendering tools in this tranche.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -35,6 +35,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "destructive_edit.py",
+    "kicad_mcp.schematic.hierarchy_authoring": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "hierarchy_authoring.py",
     "kicad_mcp.schematic.inspection": SRC_ROOT / "kicad_mcp" / "schematic" / "inspection.py",
     "kicad_mcp.schematic.symbol_mutation": SRC_ROOT
     / "kicad_mcp"
@@ -61,6 +65,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_topology.py",
+    "kicad_mcp.tools.schematic_hierarchy_authoring": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_hierarchy_authoring.py",
     "kicad_mcp.tools.schematic_inspection": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -84,6 +92,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.back_annotation",
     "kicad_mcp.schematic.basic_authoring",
     "kicad_mcp.schematic.destructive_edit",
+    "kicad_mcp.schematic.hierarchy_authoring",
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.topology",
@@ -105,6 +114,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_back_annotation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_basic_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
@@ -114,6 +124,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_back_annotation": 300,
     "kicad_mcp.tools.schematic_basic_authoring": 300,
     "kicad_mcp.tools.schematic_destructive_edit": 300,
+    "kicad_mcp.tools.schematic_hierarchy_authoring": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_topology": 300,

--- a/src/kicad_mcp/schematic/hierarchy_authoring.py
+++ b/src/kicad_mcp/schematic/hierarchy_authoring.py
@@ -1,0 +1,262 @@
+"""FastMCP-free orchestration for schematic hierarchy authoring."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class SchematicTarget(Protocol):
+    """Minimal resolved-target surface used by hierarchy label authoring."""
+
+    @property
+    def path(self) -> Path: ...
+
+    @property
+    def is_root(self) -> bool: ...
+
+
+class ResolveTarget(Protocol):
+    """Resolve an optional child-sheet selector."""
+
+    def __call__(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> SchematicTarget: ...
+
+
+class ChildSchematic(Protocol):
+    """Minimal child schematic created by kicad-sch-api."""
+
+    def save(self, path: Path, preserve_format: bool = True) -> object: ...
+
+
+class SheetManager(Protocol):
+    """Minimal sheet lookup surface exposed by a loaded schematic."""
+
+    def get_sheet_by_name(self, name: str) -> object | None: ...
+
+
+class RootSchematic(Protocol):
+    """Minimal loaded schematic surface required to add a child sheet."""
+
+    sheets: SheetManager
+
+    def add_sheet(
+        self,
+        name: str,
+        filename: str,
+        position: tuple[float, float],
+        size: tuple[float, float],
+        *,
+        project_name: str | None = None,
+    ) -> str: ...
+
+    def save(self, path: Path, preserve_format: bool = True) -> object: ...
+
+
+class LabelBlock(Protocol):
+    """Create a hierarchical or global label S-expression block."""
+
+    def __call__(
+        self,
+        text: str,
+        x: float,
+        y: float,
+        rotation: int,
+        *,
+        kind: str,
+        shape: str,
+        justify: str | None = None,
+    ) -> str: ...
+
+
+class TransactionalWrite(Protocol):
+    """Apply a guarded schematic mutation to a selected file."""
+
+    def __call__(self, mutator: Callable[[str], str], path: Path) -> str: ...
+
+
+class Warn(Protocol):
+    """Emit a structured warning without coupling to a logging implementation."""
+
+    def __call__(self, event: str, **fields: object) -> object: ...
+
+
+type ActiveSchematicFile = Callable[[], Path]
+type ResolveCreateSchematic = Callable[[], Callable[[str], ChildSchematic]]
+type LoadSchematic = Callable[[Path], RootSchematic]
+type SnapPoint = Callable[[float, float, bool], tuple[float, float]]
+type SnapNotice = Callable[[tuple[float, ...], tuple[float, ...]], str]
+type ProjectName = Callable[[], str]
+type AppendBeforeSheetInstances = Callable[[str, str], str]
+type ReloadSchematic = Callable[[], str]
+
+
+@dataclass(frozen=True)
+class SchematicHierarchyAuthoringService:
+    """Compose child-sheet and hierarchy-label operations from injected helpers."""
+
+    active_schematic_file: ActiveSchematicFile
+    resolve_target: ResolveTarget
+    resolve_create_schematic: ResolveCreateSchematic
+    load_schematic: LoadSchematic
+    snap_point: SnapPoint
+    snap_notice: SnapNotice
+    project_name: ProjectName
+    default_sheet_size: tuple[float, float]
+    label_block: LabelBlock
+    append_before_sheet_instances: AppendBeforeSheetInstances
+    transactional_write: TransactionalWrite
+    reload_schematic: ReloadSchematic
+    warn: Warn
+
+    @staticmethod
+    def _format_target_detail(target: SchematicTarget) -> str:
+        kind = "root" if target.is_root else "child"
+        return f"Target schematic ({kind}): {target.path}"
+
+    def create_sheet(
+        self,
+        name: str,
+        filename: str,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool,
+    ) -> str:
+        """Create a child schematic and add it to the active root schematic."""
+        try:
+            create_schematic = self.resolve_create_schematic()
+        except Exception as exc:
+            self.warn("schematic_create_sheet_dependency_missing", error=str(exc))
+            return "kicad-sch-api is unavailable, so child sheet creation could not run."
+
+        top_schematic_path = self.active_schematic_file()
+        sheet_x, sheet_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (sheet_x, sheet_y))
+        child_name = filename
+        if not child_name.endswith(".kicad_sch"):
+            child_name = f"{child_name}.kicad_sch"
+        child_path = top_schematic_path.parent / child_name
+        child_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            schematic = self.load_schematic(top_schematic_path)
+            if schematic.sheets.get_sheet_by_name(name) is not None:
+                return f"Sheet '{name}' already exists."
+            if not child_path.exists():
+                child_schematic = create_schematic(name)
+                child_schematic.save(child_path, preserve_format=True)
+            schematic.add_sheet(
+                name,
+                str(child_path.relative_to(top_schematic_path.parent)).replace("\\", "/"),
+                (sheet_x, sheet_y),
+                self.default_sheet_size,
+                project_name=self.project_name(),
+            )
+            schematic.save(top_schematic_path, preserve_format=True)
+        except Exception as exc:
+            self.warn(
+                "schematic_create_sheet_failed",
+                name=name,
+                filename=str(child_path),
+                error=str(exc),
+            )
+            return f"Could not create child sheet '{name}': {exc}"
+
+        result = self.reload_schematic()
+        detail = f"Created child sheet '{name}' -> {child_path.name}."
+        if snap_note:
+            detail = f"{detail}\n{snap_note}"
+        return f"{result}\n{detail}"
+
+    def _add_label(
+        self,
+        *,
+        kind: str,
+        text: str,
+        x_mm: float,
+        y_mm: float,
+        shape: str,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        label_x, label_y = self.snap_point(x_mm, y_mm, snap_to_grid)
+        snap_note = self.snap_notice((x_mm, y_mm), (label_x, label_y))
+        self.transactional_write(
+            lambda current: self.append_before_sheet_instances(
+                current,
+                self.label_block(
+                    text,
+                    label_x,
+                    label_y,
+                    rotation,
+                    kind=kind,
+                    shape=shape,
+                    justify=justify,
+                ),
+            ),
+            target.path,
+        )
+        result = self.reload_schematic()
+        return "\n".join(
+            part for part in (result, self._format_target_detail(target), snap_note) if part
+        )
+
+    def add_hierarchical_label(
+        self,
+        text: str,
+        x_mm: float,
+        y_mm: float,
+        shape: str,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add a hierarchical label to a resolved schematic target."""
+        return self._add_label(
+            kind="hierarchical_label",
+            text=text,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            shape=shape,
+            rotation=rotation,
+            snap_to_grid=snap_to_grid,
+            justify=justify,
+            sheet=sheet,
+            sheet_file=sheet_file,
+        )
+
+    def add_global_label(
+        self,
+        text: str,
+        x_mm: float,
+        y_mm: float,
+        shape: str,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        """Add a global label to a resolved schematic target."""
+        return self._add_label(
+            kind="global_label",
+            text=text,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            shape=shape,
+            rotation=rotation,
+            snap_to_grid=snap_to_grid,
+            justify=justify,
+            sheet=sheet,
+            sheet_file=sheet_file,
+        )

--- a/src/kicad_mcp/schematic/hierarchy_authoring.py
+++ b/src/kicad_mcp/schematic/hierarchy_authoring.py
@@ -51,11 +51,18 @@ class RootSchematic(Protocol):
         filename: str,
         position: tuple[float, float],
         size: tuple[float, float],
-        *,
+        stroke_width: float | None = None,
+        stroke_type: str = "solid",
         project_name: str | None = None,
+        page_number: str | None = None,
+        uuid: str | None = None,
     ) -> str: ...
 
-    def save(self, path: Path, preserve_format: bool = True) -> object: ...
+    def save(
+        self,
+        file_path: Path | str | None = None,
+        preserve_format: bool = True,
+    ) -> object: ...
 
 
 class LabelBlock(Protocol):
@@ -63,13 +70,13 @@ class LabelBlock(Protocol):
 
     def __call__(
         self,
-        text: str,
+        name: str,
         x: float,
         y: float,
-        rotation: int,
-        *,
-        kind: str,
-        shape: str,
+        rotation: int = 0,
+        global_label: bool = False,
+        shape: str | None = None,
+        kind: str | None = None,
         justify: str | None = None,
     ) -> str: ...
 
@@ -77,7 +84,13 @@ class LabelBlock(Protocol):
 class TransactionalWrite(Protocol):
     """Apply a guarded schematic mutation to a selected file."""
 
-    def __call__(self, mutator: Callable[[str], str], path: Path) -> str: ...
+    def __call__(
+        self,
+        mutator: Callable[[str], str],
+        sch_file: Path | None = None,
+        *,
+        allow_node_loss: bool = False,
+    ) -> str: ...
 
 
 class Warn(Protocol):

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -32,9 +32,6 @@ from ..models.schematic import (
     AddWireInput,
     AnnotateInput,
     AutoPlaceSymbolsInput,
-    CreateSheetInput,
-    GlobalLabelInput,
-    HierarchicalLabelInput,
     PowerSymbolInput,
     RouteWireBetweenPinsInput,
     UpdatePropertiesInput,
@@ -45,6 +42,11 @@ from ..path_safety import resolve_under
 from ..schematic.back_annotation import SchematicBackAnnotationService
 from ..schematic.basic_authoring import SchematicBasicAuthoringService
 from ..schematic.destructive_edit import SchematicDestructiveEditService
+from ..schematic.hierarchy_authoring import (
+    ChildSchematic,
+    RootSchematic,
+    SchematicHierarchyAuthoringService,
+)
 from ..schematic.inspection import SchematicInspectionService
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
 from ..schematic.topology import SchematicTopologyService
@@ -64,6 +66,7 @@ from . import (
     schematic_back_annotation,
     schematic_basic_authoring,
     schematic_destructive_edit,
+    schematic_hierarchy_authoring,
     schematic_inspection,
     schematic_symbol_mutation,
     schematic_topology,
@@ -450,6 +453,16 @@ def _load_kicad_schematic(sch_file: Path) -> _LoadedSchematicLike:
     from kicad_sch_api import load_schematic
 
     return cast(_LoadedSchematicLike, load_schematic(str(sch_file)))
+
+
+def _load_hierarchy_schematic(sch_file: Path) -> RootSchematic:
+    return cast(RootSchematic, _load_kicad_schematic(sch_file))
+
+
+def _resolve_create_schematic() -> Callable[[str], ChildSchematic]:
+    from kicad_sch_api import create_schematic
+
+    return cast(Callable[[str], ChildSchematic], create_schematic)
 
 
 def _component_unit(component: _PlacedComponentLike) -> int:
@@ -5564,6 +5577,28 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    hierarchy_authoring_service = SchematicHierarchyAuthoringService(
+        active_schematic_file=_get_schematic_file,
+        resolve_target=_resolve_schematic_target,
+        resolve_create_schematic=_resolve_create_schematic,
+        load_schematic=_load_hierarchy_schematic,
+        snap_point=_snap_point,
+        snap_notice=_snap_notice,
+        project_name=_project_name,
+        default_sheet_size=(DEFAULT_SHEET_WIDTH_MM, DEFAULT_SHEET_HEIGHT_MM),
+        label_block=label_block,
+        append_before_sheet_instances=_append_before_sheet_instances,
+        transactional_write=transactional_write,
+        reload_schematic=_reload_schematic,
+        warn=logger.warning,
+    )
+    schematic_hierarchy_authoring.register(
+        mcp,
+        schematic_hierarchy_authoring.SchematicHierarchyAuthoringDependencies(
+            service=hierarchy_authoring_service,
+        ),
+    )
+
     @mcp.tool()
     def sch_add_pin_labels(
         connections: list[dict[str, Any]],
@@ -6107,172 +6142,6 @@ def register(mcp: FastMCP) -> None:
     def sch_reload() -> str:
         """Ask KiCad to reload the active schematic."""
         return _reload_schematic()
-
-    @mcp.tool()
-    def sch_create_sheet(
-        name: str,
-        filename: str,
-        x_mm: float,
-        y_mm: float,
-        snap_to_grid: bool = True,
-    ) -> str:
-        """Create a child schematic sheet and add it to the active top-level schematic."""
-        payload = CreateSheetInput(
-            name=name,
-            filename=filename,
-            x_mm=x_mm,
-            y_mm=y_mm,
-            snap_to_grid=snap_to_grid,
-        )
-        try:
-            from kicad_sch_api import create_schematic
-        except Exception as exc:
-            logger.warning("schematic_create_sheet_dependency_missing", error=str(exc))
-            return "kicad-sch-api is unavailable, so child sheet creation could not run."
-
-        top_schematic_path = _get_schematic_file()
-        sheet_x, sheet_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (sheet_x, sheet_y))
-        child_name = payload.filename
-        if not child_name.endswith(".kicad_sch"):
-            child_name = f"{child_name}.kicad_sch"
-        child_path = top_schematic_path.parent / child_name
-        child_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            schematic = _load_kicad_schematic(top_schematic_path)
-            if schematic.sheets.get_sheet_by_name(payload.name) is not None:
-                return f"Sheet '{payload.name}' already exists."
-            if not child_path.exists():
-                child_schematic = create_schematic(payload.name)
-                child_schematic.save(child_path, preserve_format=True)
-            schematic.add_sheet(
-                payload.name,
-                str(child_path.relative_to(top_schematic_path.parent)).replace("\\", "/"),
-                (sheet_x, sheet_y),
-                (DEFAULT_SHEET_WIDTH_MM, DEFAULT_SHEET_HEIGHT_MM),
-                project_name=_project_name(),
-            )
-            schematic.save(top_schematic_path, preserve_format=True)
-        except Exception as exc:
-            logger.warning(
-                "schematic_create_sheet_failed",
-                name=payload.name,
-                filename=str(child_path),
-                error=str(exc),
-            )
-            return f"Could not create child sheet '{payload.name}': {exc}"
-
-        result = _reload_schematic()
-        detail = f"Created child sheet '{payload.name}' -> {child_path.name}."
-        if snap_note:
-            detail = f"{detail}\n{snap_note}"
-        return f"{result}\n{detail}"
-
-    @mcp.tool()
-    def sch_add_hierarchical_label(
-        text: str | None = None,
-        x_mm: float = 0.0,
-        y_mm: float = 0.0,
-        shape: str = "input",
-        rotation: int = 0,
-        snap_to_grid: bool = True,
-        name: str | None = None,
-        justify: str | None = None,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a hierarchical label, preserving the requested shape and rotation.
-
-        By default the text is justified away from the directional icon based
-        on ``rotation`` (0=left, 90=bottom, 180=right, 270=top) so it doesn't
-        render on top of the icon. Pass ``justify`` to override, or "none" to
-        force KiCad's centered default.
-        """
-        label_text = text or name
-        if not label_text:
-            raise ValueError("Either text or name parameter is required.")
-        payload = HierarchicalLabelInput(
-            text=label_text,
-            x_mm=x_mm,
-            y_mm=y_mm,
-            shape=shape,
-            rotation=rotation,
-            snap_to_grid=snap_to_grid,
-            justify=justify,
-        )
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        label_x, label_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (label_x, label_y))
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                label_block(
-                    payload.text,
-                    label_x,
-                    label_y,
-                    payload.rotation,
-                    kind="hierarchical_label",
-                    shape=payload.shape,
-                    justify=payload.justify,
-                ),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
-
-    @mcp.tool()
-    def sch_add_global_label(
-        text: str | None = None,
-        x_mm: float = 0.0,
-        y_mm: float = 0.0,
-        shape: str = "bidirectional",
-        rotation: int = 0,
-        snap_to_grid: bool = True,
-        name: str | None = None,
-        justify: str | None = None,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Add a global label, preserving the requested shape and rotation.
-
-        By default the text is justified away from the directional icon based
-        on ``rotation`` (0=left, 90=bottom, 180=right, 270=top) so it doesn't
-        render on top of the icon. Pass ``justify`` to override, or "none" to
-        force KiCad's centered default.
-        """
-        label_text = text or name
-        if not label_text:
-            raise ValueError("Either text or name parameter is required.")
-        payload = GlobalLabelInput(
-            text=label_text,
-            x_mm=x_mm,
-            y_mm=y_mm,
-            shape=shape,
-            rotation=rotation,
-            snap_to_grid=snap_to_grid,
-            justify=justify,
-        )
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        label_x, label_y = _snap_point(payload.x_mm, payload.y_mm, payload.snap_to_grid)
-        snap_note = _snap_notice((payload.x_mm, payload.y_mm), (label_x, label_y))
-        transactional_write(
-            lambda current: _append_before_sheet_instances(
-                current,
-                label_block(
-                    payload.text,
-                    label_x,
-                    label_y,
-                    payload.rotation,
-                    kind="global_label",
-                    shape=payload.shape,
-                    justify=payload.justify,
-                ),
-            ),
-            target.path,
-        )
-        result = _reload_schematic()
-        return "\n".join(p for p in [result, _format_target_detail(target), snap_note] if p)
 
     @mcp.tool()
     def sch_route_wire_between_pins(

--- a/src/kicad_mcp/tools/schematic_hierarchy_authoring.py
+++ b/src/kicad_mcp/tools/schematic_hierarchy_authoring.py
@@ -1,0 +1,140 @@
+"""Thin FastMCP adapters for schematic hierarchy authoring."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..models.schematic import CreateSheetInput, GlobalLabelInput, HierarchicalLabelInput
+from ..schematic.hierarchy_authoring import SchematicHierarchyAuthoringService
+
+
+@dataclass(frozen=True)
+class SchematicHierarchyAuthoringDependencies:
+    """Hierarchy-authoring service injected by the schematic composition root."""
+
+    service: SchematicHierarchyAuthoringService
+
+
+def register(mcp: FastMCP, dependencies: SchematicHierarchyAuthoringDependencies) -> None:
+    """Register child-sheet and hierarchy-label authoring tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    def sch_create_sheet(
+        name: str,
+        filename: str,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool = True,
+    ) -> str:
+        """Create a child schematic sheet and add it to the active top-level schematic."""
+        payload = CreateSheetInput(
+            name=name,
+            filename=filename,
+            x_mm=x_mm,
+            y_mm=y_mm,
+            snap_to_grid=snap_to_grid,
+        )
+        return service.create_sheet(
+            payload.name,
+            payload.filename,
+            payload.x_mm,
+            payload.y_mm,
+            payload.snap_to_grid,
+        )
+
+    @mcp.tool()
+    def sch_add_hierarchical_label(
+        text: str | None = None,
+        x_mm: float = 0.0,
+        y_mm: float = 0.0,
+        shape: str = "input",
+        rotation: int = 0,
+        snap_to_grid: bool = True,
+        name: str | None = None,
+        justify: str | None = None,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a hierarchical label, preserving the requested shape and rotation.
+
+        By default the text is justified away from the directional icon based
+        on ``rotation`` (0=left, 90=bottom, 180=right, 270=top) so it doesn't
+        render on top of the icon. Pass ``justify`` to override, or "none" to
+        force KiCad's centered default.
+        """
+        label_text = text or name
+        if not label_text:
+            raise ValueError("Either text or name parameter is required.")
+        payload = HierarchicalLabelInput.model_validate(
+            {
+                "text": label_text,
+                "x_mm": x_mm,
+                "y_mm": y_mm,
+                "shape": shape,
+                "rotation": rotation,
+                "snap_to_grid": snap_to_grid,
+                "justify": justify,
+            }
+        )
+        return service.add_hierarchical_label(
+            payload.text,
+            payload.x_mm,
+            payload.y_mm,
+            payload.shape,
+            payload.rotation,
+            payload.snap_to_grid,
+            payload.justify,
+            sheet,
+            sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_add_global_label(
+        text: str | None = None,
+        x_mm: float = 0.0,
+        y_mm: float = 0.0,
+        shape: str = "bidirectional",
+        rotation: int = 0,
+        snap_to_grid: bool = True,
+        name: str | None = None,
+        justify: str | None = None,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add a global label, preserving the requested shape and rotation.
+
+        By default the text is justified away from the directional icon based
+        on ``rotation`` (0=left, 90=bottom, 180=right, 270=top) so it doesn't
+        render on top of the icon. Pass ``justify`` to override, or "none" to
+        force KiCad's centered default.
+        """
+        label_text = text or name
+        if not label_text:
+            raise ValueError("Either text or name parameter is required.")
+        payload = GlobalLabelInput.model_validate(
+            {
+                "text": label_text,
+                "x_mm": x_mm,
+                "y_mm": y_mm,
+                "shape": shape,
+                "rotation": rotation,
+                "snap_to_grid": snap_to_grid,
+                "justify": justify,
+            }
+        )
+        return service.add_global_label(
+            payload.text,
+            payload.x_mm,
+            payload.y_mm,
+            payload.shape,
+            payload.rotation,
+            payload.snap_to_grid,
+            payload.justify,
+            sheet,
+            sheet_file,
+        )

--- a/tests/unit/test_schematic_hierarchy_authoring_architecture.py
+++ b/tests/unit/test_schematic_hierarchy_authoring_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_hierarchy_authoring_modules() -> None:
+    assert "kicad_mcp.schematic.hierarchy_authoring" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.hierarchy_authoring" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_hierarchy_authoring" in boundaries.DOMAIN_MODULES
+
+
+def test_hierarchy_authoring_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_hierarchy_authoring.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_hierarchy_authoring"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_hierarchy_authoring_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_hierarchy_authoring.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_hierarchy_authoring"] == 300

--- a/tests/unit/test_schematic_hierarchy_authoring_registration.py
+++ b/tests/unit/test_schematic_hierarchy_authoring_registration.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_hierarchy_authoring import (
+    SchematicHierarchyAuthoringDependencies,
+    register,
+)
+
+
+class FakeHierarchyAuthoringService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def create_sheet(
+        self,
+        name: str,
+        filename: str,
+        x_mm: float,
+        y_mm: float,
+        snap_to_grid: bool,
+    ) -> str:
+        self.calls.append(("create_sheet", (name, filename, x_mm, y_mm, snap_to_grid)))
+        return "sheet"
+
+    def add_hierarchical_label(
+        self,
+        text: str,
+        x_mm: float,
+        y_mm: float,
+        shape: str,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        self.calls.append(
+            (
+                "add_hierarchical_label",
+                (text, x_mm, y_mm, shape, rotation, snap_to_grid, justify, sheet, sheet_file),
+            )
+        )
+        return "hierarchical"
+
+    def add_global_label(
+        self,
+        text: str,
+        x_mm: float,
+        y_mm: float,
+        shape: str,
+        rotation: int,
+        snap_to_grid: bool,
+        justify: str | None,
+        sheet: str | None,
+        sheet_file: str | None,
+    ) -> str:
+        self.calls.append(
+            (
+                "add_global_label",
+                (text, x_mm, y_mm, shape, rotation, snap_to_grid, justify, sheet, sheet_file),
+            )
+        )
+        return "global"
+
+
+def _registered() -> tuple[FastMCP, FakeHierarchyAuthoringService]:
+    server = FastMCP("schematic-hierarchy-authoring-test")
+    service = FakeHierarchyAuthoringService()
+    register(server, SchematicHierarchyAuthoringDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_defaults() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_create_sheet",
+        "sch_add_hierarchical_label",
+        "sch_add_global_label",
+    }
+    assert tools["sch_create_sheet"].description == (
+        "Create a child schematic sheet and add it to the active top-level schematic."
+    )
+    label_description = (
+        "Add a {kind} label, preserving the requested shape and rotation.\n\n"
+        "By default the text is justified away from the directional icon based\n"
+        "on ``rotation`` (0=left, 90=bottom, 180=right, 270=top) so it doesn't\n"
+        'render on top of the icon. Pass ``justify`` to override, or "none" to\n'
+        "force KiCad's centered default.\n"
+    )
+    assert tools["sch_add_hierarchical_label"].description == label_description.format(
+        kind="hierarchical"
+    )
+    assert tools["sch_add_global_label"].description == label_description.format(kind="global")
+
+    assert tools["sch_create_sheet"].parameters["required"] == [
+        "name",
+        "filename",
+        "x_mm",
+        "y_mm",
+    ]
+    assert tools["sch_create_sheet"].parameters["properties"]["snap_to_grid"]["default"] is True
+    for name, shape in (
+        ("sch_add_hierarchical_label", "input"),
+        ("sch_add_global_label", "bidirectional"),
+    ):
+        parameters = tools[name].parameters
+        assert parameters.get("required") is None
+        assert parameters["properties"]["text"]["default"] is None
+        assert parameters["properties"]["name"]["default"] is None
+        assert parameters["properties"]["x_mm"]["default"] == 0.0
+        assert parameters["properties"]["y_mm"]["default"] == 0.0
+        assert parameters["properties"]["shape"]["default"] == shape
+        assert parameters["properties"]["rotation"]["default"] == 0
+        assert parameters["properties"]["snap_to_grid"]["default"] is True
+        assert parameters["properties"]["justify"]["default"] is None
+        assert parameters["properties"]["sheet"]["default"] is None
+        assert parameters["properties"]["sheet_file"]["default"] is None
+
+
+def test_registration_preserves_no_headless_metadata() -> None:
+    server, _service = _registered()
+    for tool in server._tool_manager.list_tools():
+        assert get_tool_metadata(tool.name) is None
+
+
+def test_registration_delegates_sheet_and_label_aliases() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert (
+        tools["sch_create_sheet"].fn(
+            name="Power",
+            filename="power",
+            x_mm=10.0,
+            y_mm=20.0,
+        )
+        == "sheet"
+    )
+    assert (
+        tools["sch_add_hierarchical_label"].fn(
+            name="OUT",
+            x_mm=1.0,
+            y_mm=2.0,
+            shape="output",
+            rotation=90,
+            snap_to_grid=False,
+            justify="left",
+            sheet="Power",
+        )
+        == "hierarchical"
+    )
+    assert (
+        tools["sch_add_global_label"].fn(
+            text="VCC",
+            x_mm=3.0,
+            y_mm=4.0,
+            shape="passive",
+            rotation=180,
+            sheet_file="child.kicad_sch",
+        )
+        == "global"
+    )
+
+    assert service.calls == [
+        ("create_sheet", ("Power", "power", 10.0, 20.0, True)),
+        (
+            "add_hierarchical_label",
+            ("OUT", 1.0, 2.0, "output", 90, False, "left", "Power", None),
+        ),
+        (
+            "add_global_label",
+            ("VCC", 3.0, 4.0, "passive", 180, True, None, None, "child.kicad_sch"),
+        ),
+    ]
+
+
+def test_registration_preserves_missing_label_and_pydantic_validation() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    with pytest.raises(ValueError, match="Either text or name parameter is required"):
+        tools["sch_add_hierarchical_label"].fn()
+    with pytest.raises(ValueError, match="Either text or name parameter is required"):
+        tools["sch_add_global_label"].fn()
+    with pytest.raises(ValidationError):
+        tools["sch_create_sheet"].fn(name="", filename="power", x_mm=1.0, y_mm=2.0)
+    with pytest.raises(ValidationError):
+        tools["sch_add_global_label"].fn(text="VCC", shape="sideways")

--- a/tests/unit/test_schematic_hierarchy_authoring_service.py
+++ b/tests/unit/test_schematic_hierarchy_authoring_service.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from kicad_mcp.schematic.hierarchy_authoring import SchematicHierarchyAuthoringService
+
+
+class _ChildSchematic:
+    def __init__(self) -> None:
+        self.saved: list[tuple[Path, bool]] = []
+
+    def save(self, path: Path, preserve_format: bool = True) -> None:
+        self.saved.append((path, preserve_format))
+        path.write_text("child", encoding="utf-8")
+
+
+class _SheetManager:
+    def __init__(self, duplicate: bool = False) -> None:
+        self.duplicate = duplicate
+
+    def get_sheet_by_name(self, _name: str) -> dict[str, Any] | None:
+        return {"name": "existing"} if self.duplicate else None
+
+
+class _RootSchematic:
+    def __init__(self, duplicate: bool = False) -> None:
+        self.sheets = _SheetManager(duplicate)
+        self.added: list[dict[str, Any]] = []
+        self.saved: list[tuple[Path, bool]] = []
+
+    def add_sheet(
+        self,
+        name: str,
+        filename: str,
+        position: tuple[float, float],
+        size: tuple[float, float],
+        *,
+        project_name: str | None = None,
+    ) -> str:
+        self.added.append(
+            {
+                "name": name,
+                "filename": filename,
+                "position": position,
+                "size": size,
+                "project_name": project_name,
+            }
+        )
+        return "sheet-uuid"
+
+    def save(self, path: Path, preserve_format: bool = True) -> None:
+        self.saved.append((path, preserve_format))
+
+
+class _TransactionRecorder:
+    def __init__(self, current: str = "(sheet_instances)") -> None:
+        self.current = current
+        self.calls: list[tuple[Path, str]] = []
+
+    def __call__(self, mutator: Callable[[str], str], path: Path) -> str:
+        updated = mutator(self.current)
+        self.calls.append((path, updated))
+        return updated
+
+
+def _service(
+    *,
+    root_path: Path,
+    root: _RootSchematic | None = None,
+    child: _ChildSchematic | None = None,
+    dependency_error: Exception | None = None,
+    load_error: Exception | None = None,
+    transaction: _TransactionRecorder | None = None,
+    warnings: list[tuple[str, dict[str, Any]]] | None = None,
+) -> tuple[
+    SchematicHierarchyAuthoringService,
+    _RootSchematic,
+    _ChildSchematic,
+    _TransactionRecorder,
+    list[tuple[str, dict[str, Any]]],
+]:
+    root_schematic = root or _RootSchematic()
+    child_schematic = child or _ChildSchematic()
+    tx = transaction or _TransactionRecorder()
+    warning_calls = warnings if warnings is not None else []
+
+    def resolve_create_schematic() -> Callable[[str], _ChildSchematic]:
+        if dependency_error is not None:
+            raise dependency_error
+        return lambda _name: child_schematic
+
+    def load_schematic(_path: Path) -> _RootSchematic:
+        if load_error is not None:
+            raise load_error
+        return root_schematic
+
+    return (
+        SchematicHierarchyAuthoringService(
+            active_schematic_file=lambda: root_path,
+            resolve_target=lambda sheet=None, sheet_file=None: SimpleNamespace(
+                path=Path(sheet_file or sheet or root_path),
+                is_root=not bool(sheet or sheet_file),
+            ),
+            resolve_create_schematic=resolve_create_schematic,
+            load_schematic=load_schematic,
+            snap_point=lambda x, y, enabled: (10.16, 20.32) if enabled else (x, y),
+            snap_notice=lambda original, snapped: (
+                "" if original == snapped else f"Grid snap: {original} -> {snapped}"
+            ),
+            project_name=lambda: "DemoProject",
+            default_sheet_size=(30.48, 20.32),
+            label_block=lambda text, x, y, rotation, **kwargs: (
+                f"({kwargs['kind']} {text} {x} {y} {rotation} "
+                f"{kwargs['shape']} {kwargs.get('justify')})"
+            ),
+            append_before_sheet_instances=lambda current, block: current.replace(
+                "(sheet_instances)", f"{block}\n(sheet_instances)", 1
+            ),
+            transactional_write=tx,
+            reload_schematic=lambda: "Reloaded schematic.",
+            warn=lambda event, **fields: warning_calls.append((event, fields)),
+        ),
+        root_schematic,
+        child_schematic,
+        tx,
+        warning_calls,
+    )
+
+
+def test_create_sheet_preserves_missing_dependency_result_and_warning(tmp_path: Path) -> None:
+    service, root, _child, _tx, warnings = _service(
+        root_path=tmp_path / "demo.kicad_sch",
+        dependency_error=ImportError("missing module"),
+    )
+
+    assert service.create_sheet("Power", "power", 10.0, 20.0, True) == (
+        "kicad-sch-api is unavailable, so child sheet creation could not run."
+    )
+    assert root.added == []
+    assert warnings == [("schematic_create_sheet_dependency_missing", {"error": "missing module"})]
+
+
+def test_create_sheet_preserves_duplicate_result_before_child_creation(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    service, root, child, _tx, warnings = _service(
+        root_path=root_path,
+        root=_RootSchematic(duplicate=True),
+    )
+
+    assert service.create_sheet("Power", "power", 10.0, 20.0, True) == (
+        "Sheet 'Power' already exists."
+    )
+    assert child.saved == []
+    assert root.added == []
+    assert warnings == []
+
+
+def test_create_sheet_creates_child_and_root_with_forward_slash_path(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    service, root, child, _tx, warnings = _service(root_path=root_path)
+
+    result = service.create_sheet("Power", "sub/power", 10.0, 20.0, True)
+
+    child_path = tmp_path / "sub" / "power.kicad_sch"
+    assert result == (
+        "Reloaded schematic.\n"
+        "Created child sheet 'Power' -> power.kicad_sch.\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)"
+    )
+    assert child.saved == [(child_path, True)]
+    assert root.added == [
+        {
+            "name": "Power",
+            "filename": "sub/power.kicad_sch",
+            "position": (10.16, 20.32),
+            "size": (30.48, 20.32),
+            "project_name": "DemoProject",
+        }
+    ]
+    assert root.saved == [(root_path, True)]
+    assert warnings == []
+
+
+def test_create_sheet_reuses_existing_child_file(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    child_path = tmp_path / "existing.kicad_sch"
+    child_path.write_text("existing", encoding="utf-8")
+    service, root, child, _tx, _warnings = _service(root_path=root_path)
+
+    service.create_sheet("Existing", "existing.kicad_sch", 1.0, 2.0, False)
+
+    assert child.saved == []
+    assert root.added[0]["filename"] == "existing.kicad_sch"
+    assert root.added[0]["position"] == (1.0, 2.0)
+
+
+def test_create_sheet_preserves_failure_result_and_warning(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    service, _root, _child, _tx, warnings = _service(
+        root_path=root_path,
+        load_error=RuntimeError("cannot parse root"),
+    )
+
+    assert service.create_sheet("Power", "power", 10.0, 20.0, True) == (
+        "Could not create child sheet 'Power': cannot parse root"
+    )
+    assert warnings == [
+        (
+            "schematic_create_sheet_failed",
+            {
+                "name": "Power",
+                "filename": str(tmp_path / "power.kicad_sch"),
+                "error": "cannot parse root",
+            },
+        )
+    ]
+
+
+def test_add_hierarchical_label_preserves_block_target_and_result(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    service, _root, _child, tx, _warnings = _service(root_path=root_path)
+
+    result = service.add_hierarchical_label(
+        "OUT",
+        10.0,
+        20.0,
+        "output",
+        90,
+        True,
+        "left",
+        "Power",
+        None,
+    )
+
+    assert result == (
+        "Reloaded schematic.\n"
+        "Target schematic (child): Power\n"
+        "Grid snap: (10.0, 20.0) -> (10.16, 20.32)"
+    )
+    assert tx.calls == [
+        (Path("Power"), "(hierarchical_label OUT 10.16 20.32 90 output left)\n(sheet_instances)")
+    ]
+
+
+def test_add_global_label_preserves_unsnapped_root_result(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    service, _root, _child, tx, _warnings = _service(root_path=root_path)
+
+    result = service.add_global_label(
+        "VCC",
+        1.0,
+        2.0,
+        "bidirectional",
+        0,
+        False,
+        None,
+        None,
+        None,
+    )
+
+    assert result == f"Reloaded schematic.\nTarget schematic (root): {root_path}"
+    assert tx.calls == [
+        (
+            root_path,
+            "(global_label VCC 1.0 2.0 0 bidirectional None)\n(sheet_instances)",
+        )
+    ]


### PR DESCRIPTION
## Summary

- extract child-sheet creation and hierarchy-label authoring into a FastMCP-independent `SchematicHierarchyAuthoringService`
- register `sch_create_sheet`, `sch_add_hierarchical_label`, and `sch_add_global_label` through a 119-line adapter
- preserve lazy `kicad-sch-api` loading, target resolution, path normalization, grid snapping, transactional writes, warnings, result strings, and reload ordering
- add direct service, registration, and architecture-boundary tests
- reduce the main schematic `register()` span from 2,403 to 2,259 lines

## Contract evidence

- full-server metadata for all three tools is byte-for-byte equivalent to `main`
- the committed tool-surface snapshot passes without regeneration
- the new service and adapter have 100% focused line coverage
- focused service, registration, architecture, and schematic integration suite: 156 tests passed
- full unit suite: 1,670 tests collected, five expected skips, no failures

## Quality and security

- metadata, Ruff, mypy, strict Pyright, architecture, generated docs, workflow policy/security, strict MkDocs, latency benchmark, Bandit, dependency audit, and package build gates pass
- OSV-Scanner 2.4.0 found no known vulnerabilities across the repository lockfiles
- SonarQube CLI secret analysis found no hardcoded secrets
- a focused Semgrep scan ran 290 rules against all changed implementation/test files with zero findings and zero scan errors

This is a bounded tranche of #434; additional schematic-domain extraction remains.

Refs #434