### PR TITLE
refactor(schematic): extract layout inspection services

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-layout-inspection-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-layout-inspection-service.md
@@ -1,0 +1,82 @@
+# Schematic Layout Inspection Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract schematic bounding-box and free-placement inspection from FastMCP registration into a directly testable domain service.
+
+**Architecture:** Add one pure orchestration service and one thin FastMCP adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root by injecting the existing parser, diagnostics, geometry, occupancy, keepout, and free-cell helpers.
+
+**Tech Stack:** Python 3.13, FastMCP, pytest, Ruff, mypy, Pyright, existing architecture and metadata generators.
+
+## Global Constraints
+
+- Preserve both public tool names, signatures, descriptions, schemas, annotations, defaults, count clamping, ordering, formatting, diagnostics, and result strings.
+- Do not add runtime dependencies or file mutations.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `tools.schematic`.
+- Keep full-server metadata and the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free layout inspection service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/layout_inspection.py`
+- Create: `tests/unit/test_schematic_layout_inspection_service.py`
+
+**Interfaces:**
+- Produces: `SchematicLayoutInspectionService.bounding_boxes() -> str`
+- Produces: `SchematicLayoutInspectionService.free_placement(count, cell_width_mm, cell_height_mm, keepout_regions) -> str`
+
+- [ ] Write direct failing tests for empty diagnostics, exact table formatting, symbol ordering, count clamping, occupancy forwarding, keepout expansion, coordinate rounding, and exact result strings.
+- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_layout_inspection_service.py`; expect collection failure because the module is absent.
+- [ ] Implement the minimal injected service while preserving the legacy output byte-for-byte.
+- [ ] Run the service tests, Ruff, mypy, and scoped Pyright; expect all pass.
+- [ ] Commit with `refactor(schematic): extract layout inspection service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_layout_inspection.py`
+- Create: `tests/unit/test_schematic_layout_inspection_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicLayoutInspectionService`
+- Produces: `SchematicLayoutInspectionDependencies(service: SchematicLayoutInspectionService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicLayoutInspectionDependencies) -> None`
+
+- [ ] Write failing adapter tests for exact names, descriptions, defaults, schemas, headless metadata, validation, and argument delegation.
+- [ ] Run the adapter test; expect collection failure because the adapter is absent.
+- [ ] Implement registration and composition wiring; remove the two nested legacy tool functions.
+- [ ] Run service/adapter and focused schematic integration tests; expect all pass.
+- [ ] Commit with `refactor(schematic): delegate layout inspection registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_layout_inspection_architecture.py`
+
+- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [ ] Add both modules to the architecture policy and run the checker.
+- [ ] Compare exact full-server metadata for the two tools against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard layout inspection boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-layout-inspection-service.md`
+
+- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, and full unit gates.
+- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [ ] Commit with `docs(architecture): record layout inspection evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect all bot/agent comments, reviews, and GraphQL review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after all required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/plans/2026-07-23-schematic-layout-inspection-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-layout-inspection-service.md
@@ -28,11 +28,11 @@
 - Produces: `SchematicLayoutInspectionService.bounding_boxes() -> str`
 - Produces: `SchematicLayoutInspectionService.free_placement(count, cell_width_mm, cell_height_mm, keepout_regions) -> str`
 
-- [ ] Write direct failing tests for empty diagnostics, exact table formatting, symbol ordering, count clamping, occupancy forwarding, keepout expansion, coordinate rounding, and exact result strings.
-- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_layout_inspection_service.py`; expect collection failure because the module is absent.
-- [ ] Implement the minimal injected service while preserving the legacy output byte-for-byte.
-- [ ] Run the service tests, Ruff, mypy, and scoped Pyright; expect all pass.
-- [ ] Commit with `refactor(schematic): extract layout inspection service`.
+- [x] Write direct failing tests for empty diagnostics, exact table formatting, symbol ordering, count clamping, occupancy forwarding, keepout expansion, coordinate rounding, and exact result strings.
+- [x] Run `uv run --all-extras pytest -q tests/unit/test_schematic_layout_inspection_service.py`; expect collection failure because the module is absent.
+- [x] Implement the minimal injected service while preserving the legacy output byte-for-byte.
+- [x] Run the service tests, Ruff, mypy, and scoped Pyright; expect all pass.
+- [x] Commit with `refactor(schematic): extract layout inspection service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -46,11 +46,11 @@
 - Produces: `SchematicLayoutInspectionDependencies(service: SchematicLayoutInspectionService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicLayoutInspectionDependencies) -> None`
 
-- [ ] Write failing adapter tests for exact names, descriptions, defaults, schemas, headless metadata, validation, and argument delegation.
-- [ ] Run the adapter test; expect collection failure because the adapter is absent.
-- [ ] Implement registration and composition wiring; remove the two nested legacy tool functions.
-- [ ] Run service/adapter and focused schematic integration tests; expect all pass.
-- [ ] Commit with `refactor(schematic): delegate layout inspection registration`.
+- [x] Write failing adapter tests for exact names, descriptions, defaults, schemas, headless metadata, validation, and argument delegation.
+- [x] Run the adapter test; expect collection failure because the adapter is absent.
+- [x] Implement registration and composition wiring; remove the two nested legacy tool functions.
+- [x] Run service/adapter and focused schematic integration tests; expect all pass.
+- [x] Commit with `refactor(schematic): delegate layout inspection registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -58,20 +58,33 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_layout_inspection_architecture.py`
 
-- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
-- [ ] Add both modules to the architecture policy and run the checker.
-- [ ] Compare exact full-server metadata for the two tools against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard layout inspection boundaries`.
+- [x] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [x] Add both modules to the architecture policy and run the checker.
+- [x] Compare exact full-server metadata for the two tools against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard layout inspection boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-layout-inspection-service.md`
 
-- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
-- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, and full unit gates.
-- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
-- [ ] Commit with `docs(architecture): record layout inspection evidence`.
+- [x] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [x] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, and full unit gates.
+- [x] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [x] Commit with `docs(architecture): record layout inspection evidence`.
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_get_bounding_boxes` and `sch_find_free_placement` matches `main`: names, descriptions, input schemas, defaults, tuple constraints, and annotations are identical.
+- The committed tool-surface snapshot passes without regeneration.
+- The main schematic `register()` span decreased from 2,259 to 2,157 lines; the layout-inspection adapter `register()` spans 52 lines.
+- Focused service, registration, architecture, schematic integration, extended schematic, and empty-project read coverage passed: 173 tests.
+- The extracted service and adapter have 100% focused line coverage.
+- The full unit suite passed across 1,681 selected tests with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, latency benchmark, Bandit, dependency audit, and package build gates pass.
+- OSV-Scanner 2.4.0 inspected four lockfiles representing 442 dependency entries and reported no known vulnerabilities.
+- Semgrep scanned the five changed implementation, test, and architecture files with 1,198 rules and reported zero findings.
+- No public tool contract, parser selection, diagnostics, symbol ordering, bounding-box formatting, occupancy behavior, keepout expansion, count clamping, coordinate rounding, or result string changed.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/specs/2026-07-23-schematic-layout-inspection-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-layout-inspection-service-design.md
@@ -1,0 +1,80 @@
+# Schematic Layout Inspection Service Design
+
+## Context
+
+Issue #434 is incrementally extracting schematic domain behavior from the FastMCP registration monolith without changing the public MCP contract. After the hierarchy-authoring tranche, `src/kicad_mcp/tools/schematic.py::register()` still contains 24 nested tools and spans 2,259 lines.
+
+`sch_get_bounding_boxes` and `sch_find_free_placement` form a small, read-only layout-inspection boundary. Both parse the active schematic and use the same symbol geometry and occupancy helpers. They do not mutate files, reload KiCad, or depend on GUI state.
+
+## Scope
+
+Extract exactly these public tools:
+
+- `sch_get_bounding_boxes`
+- `sch_find_free_placement`
+
+The tranche must preserve tool names, signatures, descriptions, defaults, schemas, headless metadata, count clamping, formatting, diagnostics, coordinate ordering, keepout behavior, and result strings.
+
+The tranche does not move symbol placement, automatic layout, rendering, readability fixes, sheet resizing, or functional placement.
+
+## Architecture
+
+Create a FastMCP-independent `SchematicLayoutInspectionService` in `kicad_mcp.schematic.layout_inspection`. The service receives existing behavior through constructor-injected callables:
+
+- active schematic path resolution
+- schematic parsing
+- empty-result diagnostics
+- symbol bounding-box estimation
+- occupied-cell estimation
+- keepout-cell expansion
+- next-free-cell search
+
+Create `kicad_mcp.tools.schematic_layout_inspection` as a thin FastMCP adapter. It owns only the two public function signatures, exact docstrings, headless metadata, and delegation.
+
+Keep `kicad_mcp.tools.schematic` as the composition root. It constructs the service from the existing private helpers, registers the adapter once, and removes the two legacy nested functions.
+
+## Data Flow
+
+### Bounding boxes
+
+1. Resolve the active schematic path.
+2. Parse the schematic and concatenate normal and power symbols in the existing order.
+3. Return the existing diagnostic-wrapped empty message when no symbols exist.
+4. Estimate each symbol bounding box with the injected existing helper.
+5. Render the existing fixed-width table and occupied-region summary exactly.
+
+### Free placement
+
+1. Clamp `count` to the existing inclusive range of 1 through 64.
+2. Resolve and parse the active schematic.
+3. Build occupied cells from normal and power symbols.
+4. Expand optional rectangular keepouts into occupied cells.
+5. Request coordinates sequentially from the injected next-free-cell helper, preserving its mutation of the occupied set.
+6. Round coordinates to four decimals and render the existing summary and invocation hint exactly.
+
+## Error Handling
+
+No new exception translation is introduced. Parser, geometry, invalid cell-size, and malformed keepout behavior remains owned by the injected existing helpers. Empty schematics retain the existing diagnostic behavior for bounding boxes and the existing coordinate-generation behavior for free placement.
+
+## Testing
+
+Direct service tests cover:
+
+- empty schematic diagnostics
+- exact bounding-box table formatting and occupied summary
+- normal/power symbol ordering
+- count clamping to 1 and 64
+- existing-symbol avoidance
+- keepout expansion and forwarding
+- sequential coordinate allocation and rounding
+- exact result strings
+
+Adapter tests cover exact names, descriptions, defaults, schemas, headless metadata, Pydantic validation, and argument delegation.
+
+Architecture tests require the service to remain pure, forbid the adapter from importing the schematic monolith, and enforce a 300-line adapter `register()` limit.
+
+Full-server metadata comparison and the committed tool-surface snapshot must remain unchanged. Focused coverage must meet the repository threshold, and all repository quality, security, documentation, package, performance, and unit gates must pass.
+
+## Security and Compatibility
+
+This tranche adds no runtime dependency and performs no new file or network access. OSV, Sonar secret analysis, Semgrep Cloud, CodeQL, dependency review, Socket, and the existing workflow-security gates remain part of verification. The pull request references #434 without closing it because further extraction tranches remain.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -40,6 +40,10 @@ DOMAIN_MODULES = {
     / "schematic"
     / "hierarchy_authoring.py",
     "kicad_mcp.schematic.inspection": SRC_ROOT / "kicad_mcp" / "schematic" / "inspection.py",
+    "kicad_mcp.schematic.layout_inspection": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "layout_inspection.py",
     "kicad_mcp.schematic.symbol_mutation": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -73,6 +77,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_inspection.py",
+    "kicad_mcp.tools.schematic_layout_inspection": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_layout_inspection.py",
     "kicad_mcp.tools.schematic_constants": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -94,6 +102,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.destructive_edit",
     "kicad_mcp.schematic.hierarchy_authoring",
     "kicad_mcp.schematic.inspection",
+    "kicad_mcp.schematic.layout_inspection",
     "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.topology",
     "kicad_mcp.tools.schematic_constants",
@@ -116,6 +125,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
 }
@@ -126,6 +136,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_destructive_edit": 300,
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
+    "kicad_mcp.tools.schematic_layout_inspection": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_topology": 300,
 }

--- a/src/kicad_mcp/schematic/layout_inspection.py
+++ b/src/kicad_mcp/schematic/layout_inspection.py
@@ -1,0 +1,129 @@
+"""FastMCP-independent schematic layout inspection services."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class EstimateOccupiedCells(Protocol):
+    def __call__(
+        self,
+        symbols: list[dict[str, Any]],
+        cell_w: float,
+        cell_h: float,
+    ) -> set[tuple[int, int]]: ...
+
+
+class KeepoutOccupiedCells(Protocol):
+    def __call__(
+        self,
+        keepout_regions: list[tuple[float, float, float, float]],
+        *,
+        cell_w: float,
+        cell_h: float,
+    ) -> set[tuple[int, int]]: ...
+
+
+class NextFreeCell(Protocol):
+    def __call__(
+        self,
+        occupied: set[tuple[int, int]],
+        cell_w: float,
+        cell_h: float,
+    ) -> tuple[float, float]: ...
+
+
+@dataclass(frozen=True)
+class SchematicLayoutInspectionService:
+    """Inspect occupied schematic geometry and suggest free placement slots."""
+
+    active_schematic_file: Callable[[], Path]
+    parse_schematic: Callable[[Path], dict[str, Any]]
+    with_diagnostics: Callable[[str, Path], str]
+    symbol_bbox_bounds: Callable[[dict[str, Any]], tuple[float, float, float, float]]
+    estimate_occupied_cells: EstimateOccupiedCells
+    keepout_occupied_cells: KeepoutOccupiedCells
+    next_free_cell: NextFreeCell
+
+    def bounding_boxes(self) -> str:
+        sch_file = self.active_schematic_file()
+        sch_data = self.parse_schematic(sch_file)
+        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
+
+        if not all_syms:
+            return self.with_diagnostics(
+                "The active schematic contains no symbols.",
+                sch_file,
+            )
+
+        lines = [
+            f"Schematic bounding boxes ({len(all_syms)} symbols):",
+            (
+                f"{'Ref':<10} {'Value':<16} {'X':>8} {'Y':>8} "
+                f"{'X_min':>8} {'Y_min':>8} {'X_max':>8} {'Y_max':>8}"
+            ),
+            "-" * 76,
+        ]
+        extents: list[tuple[float, float, float, float]] = []
+        for sym in all_syms:
+            ref = str(sym.get("reference", "?"))
+            val = str(sym.get("value", ""))[:16]
+            x = float(sym.get("x", sym.get("x_mm", 0.0)) or 0.0)
+            y = float(sym.get("y", sym.get("y_mm", 0.0)) or 0.0)
+            x_min, y_min, x_max, y_max = self.symbol_bbox_bounds(sym)
+            extents.append((x_min, y_min, x_max, y_max))
+            lines.append(
+                f"{ref:<10} {val:<16} {x:>8.2f} {y:>8.2f} "
+                f"{x_min:>8.2f} {y_min:>8.2f} {x_max:>8.2f} {y_max:>8.2f}"
+            )
+
+        lines += [
+            "",
+            f"Sheet occupied region: X=[{min(item[0] for item in extents):.1f}, "
+            f"{max(item[2] for item in extents):.1f}] "
+            f"Y=[{min(item[1] for item in extents):.1f}, "
+            f"{max(item[3] for item in extents):.1f}] mm",
+            "Tip: use sch_find_free_placement to get safe coordinates for new symbols.",
+        ]
+        return "\n".join(lines)
+
+    def free_placement(
+        self,
+        count: int,
+        cell_width_mm: float,
+        cell_height_mm: float,
+        keepout_regions: list[tuple[float, float, float, float]] | None,
+    ) -> str:
+        count = max(1, min(count, 64))
+        sch_file = self.active_schematic_file()
+        sch_data = self.parse_schematic(sch_file)
+        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
+
+        occupied = self.estimate_occupied_cells(all_syms, cell_width_mm, cell_height_mm)
+        keepouts = keepout_regions or []
+        if keepouts:
+            occupied.update(
+                self.keepout_occupied_cells(
+                    keepouts,
+                    cell_w=cell_width_mm,
+                    cell_h=cell_height_mm,
+                )
+            )
+
+        coords: list[tuple[float, float]] = []
+        for _ in range(count):
+            x, y = self.next_free_cell(occupied, cell_width_mm, cell_height_mm)
+            coords.append((round(x, 4), round(y, 4)))
+
+        lines = [
+            f"Free placement coordinates ({count} slot(s) requested, "
+            f"{len(all_syms)} existing symbol(s) avoided, "
+            f"{len(keepouts)} keepout region(s) respected):",
+        ]
+        for index, (x, y) in enumerate(coords, start=1):
+            lines.append(f"  Slot {index}: x_mm={x}, y_mm={y}")
+        lines.append("\nPass these coordinates directly to sch_add_symbol(x_mm=..., y_mm=...).")
+        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -48,6 +48,7 @@ from ..schematic.hierarchy_authoring import (
     SchematicHierarchyAuthoringService,
 )
 from ..schematic.inspection import SchematicInspectionService
+from ..schematic.layout_inspection import SchematicLayoutInspectionService
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
 from ..schematic.topology import SchematicTopologyService
 from ..utils.cache import clear_ttl_cache, ttl_cache
@@ -68,6 +69,7 @@ from . import (
     schematic_destructive_edit,
     schematic_hierarchy_authoring,
     schematic_inspection,
+    schematic_layout_inspection,
     schematic_symbol_mutation,
     schematic_topology,
 )
@@ -5467,6 +5469,22 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    layout_inspection_service = SchematicLayoutInspectionService(
+        active_schematic_file=_get_schematic_file,
+        parse_schematic=parse_schematic_file,
+        with_diagnostics=_with_schematic_diagnostics,
+        symbol_bbox_bounds=_symbol_bbox_bounds,
+        estimate_occupied_cells=_estimate_occupied_cells,
+        keepout_occupied_cells=_keepout_occupied_cells,
+        next_free_cell=_next_free_cell,
+    )
+    schematic_layout_inspection.register(
+        mcp,
+        schematic_layout_inspection.SchematicLayoutInspectionDependencies(
+            service=layout_inspection_service,
+        ),
+    )
+
     topology_service = SchematicTopologyService(
         load_schematic=_load_kicad_schematic,
         with_diagnostics=_with_schematic_diagnostics,
@@ -6469,124 +6487,6 @@ def register(mcp: FastMCP) -> None:
     # -----------------------------------------------------------------------
     # Spatial awareness tools (v2.1.0)
     # -----------------------------------------------------------------------
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_get_bounding_boxes() -> str:
-        """Return the estimated bounding box of every symbol in the active schematic.
-
-        Use this before calling sch_add_symbol or sch_build_circuit to understand
-        which areas of the schematic sheet are already occupied.  The bounding boxes
-        are heuristic estimates (KiCad does not expose exact extents via the file API)
-        but are conservative enough to avoid overlap in practice.
-
-        Returns:
-            A table of all symbols with their centre position and estimated
-            bounding-box corners (x_min, y_min, x_max, y_max) in mm, plus an
-            occupied-area summary.
-        """
-        sch_file = _get_schematic_file()
-        sch_data = parse_schematic_file(sch_file)
-        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
-
-        if not all_syms:
-            return _with_schematic_diagnostics(
-                "The active schematic contains no symbols.",
-                sch_file,
-            )
-
-        lines = [
-            f"Schematic bounding boxes ({len(all_syms)} symbols):",
-            (
-                f"{'Ref':<10} {'Value':<16} {'X':>8} {'Y':>8} "
-                f"{'X_min':>8} {'Y_min':>8} {'X_max':>8} {'Y_max':>8}"
-            ),
-            "-" * 76,
-        ]
-        extents: list[tuple[float, float, float, float]] = []
-        for sym in all_syms:
-            ref = str(sym.get("reference", "?"))
-            val = str(sym.get("value", ""))[:16]
-            x = float(sym.get("x", sym.get("x_mm", 0.0)) or 0.0)
-            y = float(sym.get("y", sym.get("y_mm", 0.0)) or 0.0)
-            x_min, y_min, x_max, y_max = _symbol_bbox_bounds(sym)
-            extents.append((x_min, y_min, x_max, y_max))
-            lines.append(
-                f"{ref:<10} {val:<16} {x:>8.2f} {y:>8.2f} "
-                f"{x_min:>8.2f} {y_min:>8.2f} {x_max:>8.2f} {y_max:>8.2f}"
-            )
-
-        if extents:
-            lines += [
-                "",
-                f"Sheet occupied region: X=[{min(item[0] for item in extents):.1f}, "
-                f"{max(item[2] for item in extents):.1f}] "
-                f"Y=[{min(item[1] for item in extents):.1f}, "
-                f"{max(item[3] for item in extents):.1f}] mm",
-                "Tip: use sch_find_free_placement to get safe coordinates for new symbols.",
-            ]
-
-        return "\n".join(lines)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_find_free_placement(
-        count: int = 1,
-        cell_width_mm: float = AUTO_LAYOUT_COLUMN_SPACING_MM,
-        cell_height_mm: float = AUTO_LAYOUT_ROW_SPACING_MM,
-        keepout_regions: list[tuple[float, float, float, float]] | None = None,
-    ) -> str:
-        """Find N collision-free placement coordinates for new symbols.
-
-        Reads the current schematic, builds an occupancy grid from all existing
-        symbols, and returns ``count`` coordinate pairs that do not overlap with
-        any placed symbol.  Call this before sch_add_symbol to get safe (x, y)
-        values.
-
-        Args:
-            count: Number of free coordinate slots to return (default 1, max 64).
-            cell_width_mm: Grid cell width in mm (default 25.4 — one 10-mil grid unit).
-            cell_height_mm: Grid cell height in mm (default 17.78).
-            keepout_regions: Optional rectangular keepouts as
-                ``[(x_min, y_min, x_max, y_max), ...]`` in mm.
-
-        Returns:
-            A list of (x_mm, y_mm) coordinate pairs, one per requested slot.
-        """
-        count = max(1, min(count, 64))
-        sch_file = _get_schematic_file()
-        sch_data = parse_schematic_file(sch_file)
-        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
-
-        occupied = _estimate_occupied_cells(all_syms, cell_w=cell_width_mm, cell_h=cell_height_mm)
-        keepouts = keepout_regions or []
-        if keepouts:
-            occupied.update(
-                _keepout_occupied_cells(
-                    keepouts,
-                    cell_w=cell_width_mm,
-                    cell_h=cell_height_mm,
-                )
-            )
-
-        coords: list[tuple[float, float]] = []
-        for _ in range(count):
-            x, y = _next_free_cell(
-                occupied,
-                cell_w=cell_width_mm,
-                cell_h=cell_height_mm,
-            )
-            coords.append((round(x, 4), round(y, 4)))
-
-        lines = [
-            f"Free placement coordinates ({count} slot(s) requested, "
-            f"{len(all_syms)} existing symbol(s) avoided, "
-            f"{len(keepouts)} keepout region(s) respected):",
-        ]
-        for i, (x, y) in enumerate(coords, start=1):
-            lines.append(f"  Slot {i}: x_mm={x}, y_mm={y}")
-        lines.append("\nPass these coordinates directly to sch_add_symbol(x_mm=..., y_mm=...).")
-        return "\n".join(lines)
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/schematic_layout_inspection.py
+++ b/src/kicad_mcp/tools/schematic_layout_inspection.py
@@ -10,7 +10,9 @@ from mcp.server.fastmcp import FastMCP
 
 from ..schematic.layout_inspection import SchematicLayoutInspectionService
 from .metadata import headless_compatible
-from .schematic_constants import AUTO_LAYOUT_COLUMN_SPACING_MM, AUTO_LAYOUT_ROW_SPACING_MM
+
+_DEFAULT_CELL_WIDTH_MM = 25.4
+_DEFAULT_CELL_HEIGHT_MM = 17.78
 
 
 @dataclass(frozen=True)
@@ -45,8 +47,8 @@ def register(mcp: FastMCP, dependencies: SchematicLayoutInspectionDependencies) 
     @headless_compatible
     def sch_find_free_placement(
         count: int = 1,
-        cell_width_mm: float = AUTO_LAYOUT_COLUMN_SPACING_MM,
-        cell_height_mm: float = AUTO_LAYOUT_ROW_SPACING_MM,
+        cell_width_mm: float = _DEFAULT_CELL_WIDTH_MM,
+        cell_height_mm: float = _DEFAULT_CELL_HEIGHT_MM,
         keepout_regions: list[tuple[float, float, float, float]] | None = None,
     ) -> str:
         """Find N collision-free placement coordinates for new symbols.

--- a/src/kicad_mcp/tools/schematic_layout_inspection.py
+++ b/src/kicad_mcp/tools/schematic_layout_inspection.py
@@ -1,0 +1,74 @@
+"""Thin FastMCP adapters for schematic layout inspection."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.layout_inspection import SchematicLayoutInspectionService
+from .metadata import headless_compatible
+from .schematic_constants import AUTO_LAYOUT_COLUMN_SPACING_MM, AUTO_LAYOUT_ROW_SPACING_MM
+
+
+@dataclass(frozen=True)
+class SchematicLayoutInspectionDependencies:
+    """Layout-inspection service injected by the schematic composition root."""
+
+    service: SchematicLayoutInspectionService
+
+
+def register(mcp: FastMCP, dependencies: SchematicLayoutInspectionDependencies) -> None:
+    """Register read-only schematic layout inspection tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_get_bounding_boxes() -> str:
+        """Return the estimated bounding box of every symbol in the active schematic.
+
+        Use this before calling sch_add_symbol or sch_build_circuit to understand
+        which areas of the schematic sheet are already occupied.  The bounding boxes
+        are heuristic estimates (KiCad does not expose exact extents via the file API)
+        but are conservative enough to avoid overlap in practice.
+
+        Returns:
+            A table of all symbols with their centre position and estimated
+            bounding-box corners (x_min, y_min, x_max, y_max) in mm, plus an
+            occupied-area summary.
+        """
+        return service.bounding_boxes()
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_find_free_placement(
+        count: int = 1,
+        cell_width_mm: float = AUTO_LAYOUT_COLUMN_SPACING_MM,
+        cell_height_mm: float = AUTO_LAYOUT_ROW_SPACING_MM,
+        keepout_regions: list[tuple[float, float, float, float]] | None = None,
+    ) -> str:
+        """Find N collision-free placement coordinates for new symbols.
+
+        Reads the current schematic, builds an occupancy grid from all existing
+        symbols, and returns ``count`` coordinate pairs that do not overlap with
+        any placed symbol.  Call this before sch_add_symbol to get safe (x, y)
+        values.
+
+        Args:
+            count: Number of free coordinate slots to return (default 1, max 64).
+            cell_width_mm: Grid cell width in mm (default 25.4 — one 10-mil grid unit).
+            cell_height_mm: Grid cell height in mm (default 17.78).
+            keepout_regions: Optional rectangular keepouts as
+                ``[(x_min, y_min, x_max, y_max), ...]`` in mm.
+
+        Returns:
+            A list of (x_mm, y_mm) coordinate pairs, one per requested slot.
+        """
+        return service.free_placement(
+            count,
+            cell_width_mm,
+            cell_height_mm,
+            keepout_regions,
+        )

--- a/tests/unit/test_schematic_layout_inspection_architecture.py
+++ b/tests/unit/test_schematic_layout_inspection_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_layout_inspection_modules() -> None:
+    assert "kicad_mcp.schematic.layout_inspection" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.layout_inspection" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_layout_inspection" in boundaries.DOMAIN_MODULES
+
+
+def test_layout_inspection_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_layout_inspection.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_layout_inspection"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_layout_inspection_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_layout_inspection.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_layout_inspection"] == 300

--- a/tests/unit/test_schematic_layout_inspection_registration.py
+++ b/tests/unit/test_schematic_layout_inspection_registration.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_layout_inspection import (
+    SchematicLayoutInspectionDependencies,
+    register,
+)
+
+
+class FakeLayoutInspectionService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def bounding_boxes(self) -> str:
+        self.calls.append(("bounding_boxes", ()))
+        return "boxes"
+
+    def free_placement(
+        self,
+        count: int,
+        cell_width_mm: float,
+        cell_height_mm: float,
+        keepout_regions: list[tuple[float, float, float, float]] | None,
+    ) -> str:
+        self.calls.append(
+            (
+                "free_placement",
+                (count, cell_width_mm, cell_height_mm, keepout_regions),
+            )
+        )
+        return "free"
+
+
+def _registered() -> tuple[FastMCP, FakeLayoutInspectionService]:
+    server = FastMCP("schematic-layout-inspection-test")
+    service = FakeLayoutInspectionService()
+    register(server, SchematicLayoutInspectionDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {"sch_get_bounding_boxes", "sch_find_free_placement"}
+    assert tools["sch_get_bounding_boxes"].description == (
+        "Return the estimated bounding box of every symbol in the active schematic.\n\n"
+        "Use this before calling sch_add_symbol or sch_build_circuit to understand\n"
+        "which areas of the schematic sheet are already occupied.  The bounding boxes\n"
+        "are heuristic estimates (KiCad does not expose exact extents via the file API)\n"
+        "but are conservative enough to avoid overlap in practice.\n\n"
+        "Returns:\n"
+        "    A table of all symbols with their centre position and estimated\n"
+        "    bounding-box corners (x_min, y_min, x_max, y_max) in mm, plus an\n"
+        "    occupied-area summary.\n"
+    )
+    assert tools["sch_find_free_placement"].description == (
+        "Find N collision-free placement coordinates for new symbols.\n\n"
+        "Reads the current schematic, builds an occupancy grid from all existing\n"
+        "symbols, and returns ``count`` coordinate pairs that do not overlap with\n"
+        "any placed symbol.  Call this before sch_add_symbol to get safe (x, y)\n"
+        "values.\n\n"
+        "Args:\n"
+        "    count: Number of free coordinate slots to return (default 1, max 64).\n"
+        "    cell_width_mm: Grid cell width in mm (default 25.4 — one 10-mil grid unit).\n"
+        "    cell_height_mm: Grid cell height in mm (default 17.78).\n"
+        "    keepout_regions: Optional rectangular keepouts as\n"
+        "        ``[(x_min, y_min, x_max, y_max), ...]`` in mm.\n\n"
+        "Returns:\n"
+        "    A list of (x_mm, y_mm) coordinate pairs, one per requested slot.\n"
+    )
+    assert tools["sch_get_bounding_boxes"].parameters == {
+        "properties": {},
+        "title": "sch_get_bounding_boxesArguments",
+        "type": "object",
+    }
+    free = tools["sch_find_free_placement"].parameters
+    assert free.get("required") is None
+    assert free["properties"]["count"]["default"] == 1
+    assert free["properties"]["cell_width_mm"]["default"] == 25.4
+    assert free["properties"]["cell_height_mm"]["default"] == 17.78
+    tuple_schema = free["properties"]["keepout_regions"]["anyOf"][0]["items"]
+    assert tuple_schema["minItems"] == 4
+    assert tuple_schema["maxItems"] == 4
+    assert len(tuple_schema["prefixItems"]) == 4
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+
+    for tool in server._tool_manager.list_tools():
+        metadata = get_tool_metadata(tool.name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+        assert metadata.requires_kicad_running is False
+
+
+def test_registration_delegates_defaults_and_explicit_arguments() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_get_bounding_boxes"].fn() == "boxes"
+    assert tools["sch_find_free_placement"].fn() == "free"
+    keepouts = [(1.0, 2.0, 3.0, 4.0)]
+    assert (
+        tools["sch_find_free_placement"].fn(
+            count=3,
+            cell_width_mm=20.0,
+            cell_height_mm=10.0,
+            keepout_regions=keepouts,
+        )
+        == "free"
+    )
+    assert service.calls == [
+        ("bounding_boxes", ()),
+        ("free_placement", (1, 25.4, 17.78, None)),
+        ("free_placement", (3, 20.0, 10.0, keepouts)),
+    ]

--- a/tests/unit/test_schematic_layout_inspection_service.py
+++ b/tests/unit/test_schematic_layout_inspection_service.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from kicad_mcp.schematic.layout_inspection import SchematicLayoutInspectionService
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.path = Path("/project/demo.kicad_sch")
+        self.parsed: dict[str, Any] = {"symbols": [], "power_symbols": []}
+        self.diagnostics: list[tuple[str, Path]] = []
+        self.bbox_refs: list[str] = []
+        self.occupied_inputs: list[tuple[list[dict[str, Any]], float, float]] = []
+        self.keepout_inputs: list[tuple[list[tuple[float, float, float, float]], float, float]] = []
+        self.next_inputs: list[tuple[set[tuple[int, int]], float, float]] = []
+        self.next_values: list[tuple[float, float]] = [(25.4, 25.4)]
+
+    def active_schematic_file(self) -> Path:
+        return self.path
+
+    def parse_schematic(self, path: Path) -> dict[str, Any]:
+        assert path == self.path
+        return self.parsed
+
+    def with_diagnostics(self, text: str, path: Path) -> str:
+        self.diagnostics.append((text, path))
+        return f"diagnostic:{text}"
+
+    def symbol_bbox_bounds(self, symbol: dict[str, Any]) -> tuple[float, float, float, float]:
+        ref = str(symbol["reference"])
+        self.bbox_refs.append(ref)
+        return {
+            "U1": (8.0, 18.0, 12.0, 22.0),
+            "#PWR01": (28.0, 38.0, 32.0, 42.0),
+        }[ref]
+
+    def estimate_occupied_cells(
+        self,
+        symbols: list[dict[str, Any]],
+        cell_w: float,
+        cell_h: float,
+    ) -> set[tuple[int, int]]:
+        self.occupied_inputs.append((symbols, cell_w, cell_h))
+        return {(0, 0)}
+
+    def keepout_occupied_cells(
+        self,
+        keepout_regions: list[tuple[float, float, float, float]],
+        *,
+        cell_w: float,
+        cell_h: float,
+    ) -> set[tuple[int, int]]:
+        self.keepout_inputs.append((keepout_regions, cell_w, cell_h))
+        return {(2, 3)}
+
+    def next_free_cell(
+        self,
+        occupied: set[tuple[int, int]],
+        cell_w: float,
+        cell_h: float,
+    ) -> tuple[float, float]:
+        self.next_inputs.append((set(occupied), cell_w, cell_h))
+        value = self.next_values.pop(0)
+        occupied.add((len(self.next_inputs), len(self.next_inputs)))
+        return value
+
+
+def _service(recorder: _Recorder) -> SchematicLayoutInspectionService:
+    return SchematicLayoutInspectionService(
+        active_schematic_file=recorder.active_schematic_file,
+        parse_schematic=recorder.parse_schematic,
+        with_diagnostics=recorder.with_diagnostics,
+        symbol_bbox_bounds=recorder.symbol_bbox_bounds,
+        estimate_occupied_cells=recorder.estimate_occupied_cells,
+        keepout_occupied_cells=recorder.keepout_occupied_cells,
+        next_free_cell=recorder.next_free_cell,
+    )
+
+
+def test_bounding_boxes_for_empty_schematic_preserves_diagnostics() -> None:
+    recorder = _Recorder()
+
+    assert _service(recorder).bounding_boxes() == (
+        "diagnostic:The active schematic contains no symbols."
+    )
+    assert recorder.diagnostics == [("The active schematic contains no symbols.", recorder.path)]
+
+
+def test_bounding_boxes_preserves_order_table_and_occupied_summary() -> None:
+    recorder = _Recorder()
+    recorder.parsed = {
+        "symbols": [{"reference": "U1", "value": "Microcontroller-long", "x": 10.0, "y": 20.0}],
+        "power_symbols": [{"reference": "#PWR01", "value": "VCC", "x_mm": 30.0, "y_mm": 40.0}],
+    }
+
+    result = _service(recorder).bounding_boxes()
+
+    assert result == "\n".join(
+        [
+            "Schematic bounding boxes (2 symbols):",
+            "Ref        Value                   X        Y    X_min    Y_min    X_max    Y_max",
+            "----------------------------------------------------------------------------",
+            "U1         Microcontroller-    10.00    20.00     8.00    18.00    12.00    22.00",
+            "#PWR01     VCC                 30.00    40.00    28.00    38.00    32.00    42.00",
+            "",
+            "Sheet occupied region: X=[8.0, 32.0] Y=[18.0, 42.0] mm",
+            "Tip: use sch_find_free_placement to get safe coordinates for new symbols.",
+        ]
+    )
+    assert recorder.bbox_refs == ["U1", "#PWR01"]
+
+
+def test_free_placement_clamps_low_count_and_uses_default_empty_keepouts() -> None:
+    recorder = _Recorder()
+    recorder.parsed = {"symbols": [{"reference": "R1"}], "power_symbols": []}
+
+    result = _service(recorder).free_placement(
+        count=0,
+        cell_width_mm=25.4,
+        cell_height_mm=17.78,
+        keepout_regions=None,
+    )
+
+    assert result == "\n".join(
+        [
+            "Free placement coordinates (1 slot(s) requested, "
+            "1 existing symbol(s) avoided, 0 keepout region(s) respected):",
+            "  Slot 1: x_mm=25.4, y_mm=25.4",
+            "\nPass these coordinates directly to sch_add_symbol(x_mm=..., y_mm=...).",
+        ]
+    )
+    assert recorder.keepout_inputs == []
+    assert recorder.occupied_inputs[0][1:] == (25.4, 17.78)
+
+
+def test_free_placement_respects_keepouts_allocates_sequentially_and_rounds() -> None:
+    recorder = _Recorder()
+    symbols = [{"reference": "R1"}, {"reference": "#PWR01"}]
+    recorder.parsed = {"symbols": symbols[:1], "power_symbols": symbols[1:]}
+    recorder.next_values = [(12.34567, 23.45678), (40.0, 50.0)]
+    keepouts = [(1.0, 2.0, 3.0, 4.0)]
+
+    result = _service(recorder).free_placement(
+        count=2,
+        cell_width_mm=20.0,
+        cell_height_mm=10.0,
+        keepout_regions=keepouts,
+    )
+
+    assert result == "\n".join(
+        [
+            "Free placement coordinates (2 slot(s) requested, "
+            "2 existing symbol(s) avoided, 1 keepout region(s) respected):",
+            "  Slot 1: x_mm=12.3457, y_mm=23.4568",
+            "  Slot 2: x_mm=40.0, y_mm=50.0",
+            "\nPass these coordinates directly to sch_add_symbol(x_mm=..., y_mm=...).",
+        ]
+    )
+    assert recorder.occupied_inputs == [(symbols, 20.0, 10.0)]
+    assert recorder.keepout_inputs == [(keepouts, 20.0, 10.0)]
+    assert recorder.next_inputs == [
+        ({(0, 0), (2, 3)}, 20.0, 10.0),
+        ({(0, 0), (1, 1), (2, 3)}, 20.0, 10.0),
+    ]
+
+
+def test_free_placement_clamps_high_count_to_64() -> None:
+    recorder = _Recorder()
+    recorder.next_values = [(float(index), float(index)) for index in range(64)]
+
+    result = _service(recorder).free_placement(
+        count=100,
+        cell_width_mm=25.4,
+        cell_height_mm=17.78,
+        keepout_regions=[],
+    )
+
+    assert result.startswith("Free placement coordinates (64 slot(s) requested")
+    assert len(recorder.next_inputs) == 64


### PR DESCRIPTION
## Summary

- extract `sch_get_bounding_boxes` and `sch_find_free_placement` into a FastMCP-independent `SchematicLayoutInspectionService`
- add a thin FastMCP adapter and keep dependency wiring in the schematic composition root
- add direct service, adapter, architecture, and regression coverage
- reduce the main schematic `register()` span from 2,259 to 2,157 lines while keeping the new adapter at 52 lines

## Compatibility

- preserves exact public tool names, descriptions, input schemas, defaults, tuple constraints, annotations, diagnostics, ordering, formatting, count clamping, and result strings
- keeps the committed tool-surface snapshot unchanged
- introduces no runtime dependency and no mutation behavior

## Verification

- 173 focused service/adapter/architecture/integration tests passed
- 1,681 selected unit tests passed with five expected skips
- extracted service and adapter reached 100% focused line coverage
- metadata, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, snapshot, latency, Bandit, dependency audit, and package build gates passed
- Semgrep: 1,198 rules across five changed files, zero findings
- OSV-Scanner 2.4.0: four lockfiles / 442 dependency entries, zero known vulnerabilities

## Follow-up

Issue #434 remains open for the remaining routing, layout mutation, rendering/preview, template, and orchestration tranches.

Refs #434