### PR TITLE
refactor(schematic): extract document settings services

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-document-settings-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-document-settings-service.md
@@ -1,0 +1,83 @@
+# Schematic Document Settings Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract schematic title-block and sheet-size behavior from FastMCP registration into a directly testable document-settings domain service.
+
+**Architecture:** Add one FastMCP-free orchestration service and one thin adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root by injecting the current target, parser, transformation, transaction, reload, paper-size, and geometry dependencies.
+
+**Tech Stack:** Python 3.13, FastMCP, pytest, Ruff, mypy, Pyright, existing transaction models and architecture/metadata generators.
+
+## Global Constraints
+
+- Preserve the three public tool names, signatures, descriptions, schemas, annotations, defaults, field ordering, transaction metadata, hashes, reload ordering, error text, and result strings.
+- Do not add runtime dependencies or change transaction/approval semantics.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `tools.schematic`.
+- Keep full-server metadata and the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free document settings service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/document_settings.py`
+- Create: `tests/unit/test_schematic_document_settings_service.py`
+
+**Interfaces:**
+- Produces: `SchematicDocumentSettingsService.set_title_block_info(...) -> str`
+- Produces: `SchematicDocumentSettingsService.set_sheet_size(paper: str) -> str`
+- Produces: `SchematicDocumentSettingsService.auto_resize_sheet() -> str`
+
+- [ ] Write direct failing tests for empty updates, update ordering, target forwarding, dry-run hashes and verification, committed write/reload order, exact transaction text, invalid paper, already-set paper, missing paper declarations, write failures, usable-grid forwarding, empty symbols, fitting sheets, oversized sheets, and automatic delegation.
+- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_document_settings_service.py`; expect collection failure because the module is absent.
+- [ ] Implement the minimal injected service while preserving the legacy behavior byte-for-byte.
+- [ ] Run service tests, Ruff, mypy, and scoped Pyright; expect all pass.
+- [ ] Commit with `refactor(schematic): extract document settings service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_document_settings.py`
+- Create: `tests/unit/test_schematic_document_settings_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicDocumentSettingsService`
+- Produces: `SchematicDocumentSettingsDependencies(service: SchematicDocumentSettingsService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicDocumentSettingsDependencies) -> None`
+
+- [ ] Write failing adapter tests for exact names, descriptions, defaults, required/optional fields, schemas, headless metadata, and argument delegation.
+- [ ] Run the adapter test; expect collection failure because the adapter is absent.
+- [ ] Implement registration and composition wiring; remove the three nested legacy tool functions.
+- [ ] Run service/adapter and focused schematic integration tests; expect all pass.
+- [ ] Commit with `refactor(schematic): delegate document settings registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_document_settings_architecture.py`
+
+- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [ ] Add both modules to the architecture policy and run the checker.
+- [ ] Compare exact full-server metadata for the three tools against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard document settings boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-document-settings-service.md`
+
+- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, Semgrep, OSV-Scanner, and full unit gates.
+- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [ ] Commit with `docs(architecture): record document settings evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect all bot/agent comments, reviews, and GraphQL review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after all required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/plans/2026-07-23-schematic-document-settings-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-document-settings-service.md
@@ -1,6 +1,6 @@
 # Schematic Document Settings Service Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Extract schematic title-block and sheet-size behavior from FastMCP registration into a directly testable document-settings domain service.
 
@@ -29,11 +29,11 @@
 - Produces: `SchematicDocumentSettingsService.set_sheet_size(paper: str) -> str`
 - Produces: `SchematicDocumentSettingsService.auto_resize_sheet() -> str`
 
-- [ ] Write direct failing tests for empty updates, update ordering, target forwarding, dry-run hashes and verification, committed write/reload order, exact transaction text, invalid paper, already-set paper, missing paper declarations, write failures, usable-grid forwarding, empty symbols, fitting sheets, oversized sheets, and automatic delegation.
-- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_document_settings_service.py`; expect collection failure because the module is absent.
-- [ ] Implement the minimal injected service while preserving the legacy behavior byte-for-byte.
-- [ ] Run service tests, Ruff, mypy, and scoped Pyright; expect all pass.
-- [ ] Commit with `refactor(schematic): extract document settings service`.
+- [x] Write direct failing tests for empty updates, update ordering, target forwarding, dry-run hashes and verification, committed write/reload order, exact transaction text, invalid paper, already-set paper, missing paper declarations, write failures, usable-grid forwarding, empty symbols, fitting sheets, oversized sheets, and automatic delegation.
+- [x] Run `uv run --all-extras pytest -q tests/unit/test_schematic_document_settings_service.py`; expect collection failure because the module is absent.
+- [x] Implement the minimal injected service while preserving the legacy behavior byte-for-byte.
+- [x] Run service tests, Ruff, mypy, and scoped Pyright; expect all pass.
+- [x] Commit with `refactor(schematic): extract document settings service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -47,11 +47,11 @@
 - Produces: `SchematicDocumentSettingsDependencies(service: SchematicDocumentSettingsService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicDocumentSettingsDependencies) -> None`
 
-- [ ] Write failing adapter tests for exact names, descriptions, defaults, required/optional fields, schemas, headless metadata, and argument delegation.
-- [ ] Run the adapter test; expect collection failure because the adapter is absent.
-- [ ] Implement registration and composition wiring; remove the three nested legacy tool functions.
-- [ ] Run service/adapter and focused schematic integration tests; expect all pass.
-- [ ] Commit with `refactor(schematic): delegate document settings registration`.
+- [x] Write failing adapter tests for exact names, descriptions, defaults, required/optional fields, schemas, headless metadata, and argument delegation.
+- [x] Run the adapter test; expect collection failure because the adapter is absent.
+- [x] Implement registration and composition wiring; remove the three nested legacy tool functions.
+- [x] Run service/adapter and focused schematic integration tests; expect all pass.
+- [x] Commit with `refactor(schematic): delegate document settings registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -59,20 +59,33 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_document_settings_architecture.py`
 
-- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
-- [ ] Add both modules to the architecture policy and run the checker.
-- [ ] Compare exact full-server metadata for the three tools against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard document settings boundaries`.
+- [x] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [x] Add both modules to the architecture policy and run the checker.
+- [x] Compare exact full-server metadata for the three tools against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard document settings boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-document-settings-service.md`
 
-- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
-- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, Semgrep, OSV-Scanner, and full unit gates.
-- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
-- [ ] Commit with `docs(architecture): record document settings evidence`.
+- [x] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [x] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, Semgrep, OSV-Scanner, and full unit gates.
+- [x] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [x] Commit with `docs(architecture): record document settings evidence`.
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_set_title_block_info`, `sch_set_sheet_size`, and `sch_auto_resize_sheet` matches `main`: names, descriptions, input schemas, defaults, annotations, and argument ordering are identical.
+- The committed tool-surface snapshot passes without regeneration.
+- The main schematic `register()` span decreased from 2,157 to 1,971 lines; the document-settings adapter `register()` spans 78 lines.
+- Focused service, registration, architecture, schematic integration, extended schematic, and tool-surface coverage passed: 153 tests.
+- The extracted service and adapter have 100% focused line coverage.
+- The full unit suite passed across 1,698 selected tests with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, latency benchmark, Bandit, dependency audit, and package build gates pass.
+- OSV-Scanner 2.4.0 inspected four lockfiles representing 442 dependency entries and reported no known vulnerabilities.
+- Semgrep scanned the five changed implementation, test, and architecture files with 290 rules and reported zero findings.
+- No public tool contract, title-block field ordering, dry-run hashes, transaction metadata, reload ordering, paper-size validation, resize policy, candidate ordering, diagnostics, or result string changed.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/specs/2026-07-23-schematic-document-settings-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-document-settings-service-design.md
@@ -1,0 +1,151 @@
+# Schematic Document Settings Service Design
+
+## Context
+
+Issue #434 is incrementally reducing `src/kicad_mcp/tools/schematic.py` from a domain-heavy registry into a small composition root. The remaining document-level settings tools still combine FastMCP registration, target selection, file transformation, transaction reporting, sheet-size policy, and reload orchestration in one nested scope.
+
+This tranche extracts three related tools:
+
+- `sch_set_title_block_info`
+- `sch_set_sheet_size`
+- `sch_auto_resize_sheet`
+
+They form one stable capability boundary: editing schematic document metadata and selecting the sheet paper size. Rendering, placement, routing, templates, and circuit construction remain outside this tranche.
+
+## Goals
+
+- Make document settings behavior directly unit-testable without constructing FastMCP.
+- Preserve exact public tool names, signatures, descriptions, schemas, defaults, annotations, transaction text, hashes, ordering, and errors.
+- Keep target resolution, parsing, transaction writing, reload behavior, and existing geometry helpers injected from the composition root.
+- Keep the new FastMCP adapter at or below 300 lines.
+- Prevent the service or adapter from importing `kicad_mcp.tools.schematic`.
+
+## Non-goals
+
+- No new paper sizes or title-block fields.
+- No public schema or metadata changes.
+- No change to dry-run semantics, transaction verification, or reload ordering.
+- No change to automatic placement or rendering behavior.
+- No broad extraction of shared constants in this tranche.
+
+## Recommended Architecture
+
+Create `SchematicDocumentSettingsService` in `src/kicad_mcp/schematic/document_settings.py`. It owns the existing orchestration and document transformation behavior while depending on injected callables and immutable configuration values.
+
+Create `src/kicad_mcp/tools/schematic_document_settings.py` as the thin FastMCP adapter. The adapter preserves the current nested function signatures, docstrings, defaults, and `headless_compatible` annotations, then delegates directly to the service.
+
+Keep `src/kicad_mcp/tools/schematic.py` as the composition root. It constructs the service with the existing helpers and registers the adapter before the remaining nested tools.
+
+## Service Interface
+
+```python
+@dataclass(frozen=True)
+class SchematicDocumentSettingsService:
+    def set_title_block_info(
+        self,
+        sheet: str | None,
+        sheet_file: str | None,
+        title: str | None,
+        rev: str | None,
+        date: str | None,
+        company: str | None,
+        comment1: str | None,
+        comment2: str | None,
+        comment3: str | None,
+        comment4: str | None,
+        dry_run: bool,
+    ) -> str: ...
+
+    def set_sheet_size(self, paper: str) -> str: ...
+
+    def auto_resize_sheet(self) -> str: ...
+```
+
+Injected dependencies include:
+
+- active schematic path lookup
+- schematic target resolution
+- schematic parser
+- title-block update transformation
+- transaction writer
+- schematic reload
+- target-detail formatting
+- sheet-paper reader
+- usable column and row calculators
+- paper-size mapping
+- layout origin, margin, and symbol half-size constants
+
+The service may use `Path.read_text`, `hashlib`, and `re` directly. It remains FastMCP-free and does not import the registry module.
+
+## Behavior Preservation
+
+### Title block updates
+
+The service builds the update mapping in the existing field order. Missing values are omitted, and an empty update returns the existing non-error message. It resolves the requested root or child schematic, computes the planned content, and preserves both dry-run and committed `MutatingToolResult` payloads.
+
+Dry-run behavior must preserve:
+
+- changed file and object lists
+- SHA-256 before/after hashes
+- `planned_not_written` verification
+- exact summary text
+- no write and no reload
+
+Committed behavior must preserve:
+
+- transactional write target
+- post-write file read before reload
+- reload ordering
+- formatted target detail
+- `validated` verification
+- exact summary and compatibility text
+
+### Explicit sheet size
+
+The service trims the paper keyword, validates it against the injected paper-size mapping, and preserves the sorted available-size error. It keeps the current regex replacement/insertion behavior and the private no-change sentinel.
+
+It preserves:
+
+- existing paper detection and default to A4
+- exact already-set and write-failure messages
+- reload only after a successful write
+- old/new dimensions
+- usable grid calculations
+- origin and margin text
+- placement follow-up tip
+
+### Automatic sheet size
+
+The service parses symbols and power symbols, computes required dimensions with the existing half-size and margin constants, and selects the first fitting candidate from the current ordered list.
+
+It preserves:
+
+- empty schematic result
+- candidate order
+- no-standard-size result
+- current-size-sufficient result
+- delegation to `set_sheet_size` for the chosen size
+
+## Error Handling
+
+No new exception translation is introduced. Existing title-block helper and target-resolution exceptions continue to propagate as before. Explicit sheet resizing continues to catch its no-change sentinel separately and converts all other write-time exceptions to the existing compatibility string.
+
+## Testing Strategy
+
+Direct service tests cover:
+
+- empty title-block updates
+- field ordering and target selection
+- dry-run hashes, transaction metadata, and absence of writes/reloads
+- committed write/reload order and exact result text
+- valid, invalid, missing, already-set, and failed sheet-size writes
+- usable grid forwarding
+- empty, fitting, oversized, and delegated automatic resize paths
+
+Adapter tests cover exact public names, descriptions, defaults, input schemas, annotations, and argument delegation.
+
+Architecture tests enforce service purity, adapter isolation, and the 300-line registration limit. Full-server metadata is compared byte-for-byte with `main`, and the committed tool-surface snapshot must remain unchanged.
+
+## Expected Result
+
+The main schematic `register()` function loses approximately 200 lines while all observable tool behavior remains unchanged. The extracted service can be tested without FastMCP, and future document-setting changes have a narrow review and regression surface.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -35,6 +35,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "destructive_edit.py",
+    "kicad_mcp.schematic.document_settings": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "document_settings.py",
     "kicad_mcp.schematic.hierarchy_authoring": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -61,6 +65,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_destructive_edit.py",
+    "kicad_mcp.tools.schematic_document_settings": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_document_settings.py",
     "kicad_mcp.tools.schematic_symbol_mutation": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -100,6 +108,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.back_annotation",
     "kicad_mcp.schematic.basic_authoring",
     "kicad_mcp.schematic.destructive_edit",
+    "kicad_mcp.schematic.document_settings",
     "kicad_mcp.schematic.hierarchy_authoring",
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.layout_inspection",
@@ -123,6 +132,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_back_annotation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_basic_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_document_settings": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
@@ -134,6 +144,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_back_annotation": 300,
     "kicad_mcp.tools.schematic_basic_authoring": 300,
     "kicad_mcp.tools.schematic_destructive_edit": 300,
+    "kicad_mcp.tools.schematic_document_settings": 300,
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_layout_inspection": 300,

--- a/src/kicad_mcp/schematic/document_settings.py
+++ b/src/kicad_mcp/schematic/document_settings.py
@@ -1,0 +1,206 @@
+"""FastMCP-independent schematic document settings services."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..models.tool_result import MutatingToolResult, TransactionVerification
+
+
+class TransactionalWrite(Protocol):
+    def __call__(self, mutator: Callable[[str], str], path: Path, /) -> None: ...
+
+
+class _SheetAlreadySetError(Exception):
+    """Signal that the requested paper declaration is already present."""
+
+
+@dataclass(frozen=True)
+class SchematicDocumentSettingsService:
+    """Edit schematic title metadata and sheet paper settings."""
+
+    active_schematic_file: Callable[[], Path]
+    resolve_target: Callable[..., Any]
+    parse_schematic: Callable[[Path], dict[str, Any]]
+    apply_title_block_updates: Callable[[str, dict[str, str]], str]
+    transactional_write: TransactionalWrite
+    reload_schematic: Callable[[], str]
+    format_target_detail: Callable[[Any], str]
+    read_sheet_paper: Callable[[Path], str]
+    sheet_usable_cols: Callable[[str], int]
+    sheet_usable_rows: Callable[[str], int]
+    paper_sizes_mm: Mapping[str, tuple[float, float]]
+    layout_origin_x_mm: float
+    sheet_margin_mm: float
+    symbol_half_width_mm: float
+    symbol_half_height_mm: float
+
+    def set_title_block_info(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        title: str | None = None,
+        rev: str | None = None,
+        date: str | None = None,
+        company: str | None = None,
+        comment1: str | None = None,
+        comment2: str | None = None,
+        comment3: str | None = None,
+        comment4: str | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        updates = {
+            key: value
+            for key, value in {
+                "title": title,
+                "rev": rev,
+                "date": date,
+                "company": company,
+                "comment1": comment1,
+                "comment2": comment2,
+                "comment3": comment3,
+                "comment4": comment4,
+            }.items()
+            if value is not None
+        }
+        if not updates:
+            return "No schematic title block fields specified. Provide at least one field."
+
+        target = self.resolve_target(sheet=sheet, sheet_file=sheet_file)
+        before_text = target.path.read_text(encoding="utf-8")
+        planned_text = self.apply_title_block_updates(before_text, updates)
+        changed = ", ".join(updates)
+        changed_objects = [f"title_block.{field}" for field in updates]
+
+        if dry_run:
+            transaction = MutatingToolResult(
+                changed_files=[str(target.path)],
+                changed_objects=changed_objects,
+                before_hash=hashlib.sha256(before_text.encode("utf-8")).hexdigest(),
+                after_hash=hashlib.sha256(planned_text.encode("utf-8")).hexdigest(),
+                verification=TransactionVerification(roundtrip="planned_not_written"),
+                dry_run=True,
+            )
+            return transaction.to_compat_text(
+                f"Dry run: schematic title block fields would be updated: {changed}."
+            )
+
+        self.transactional_write(
+            lambda current: self.apply_title_block_updates(current, updates),
+            target.path,
+        )
+        after_text = target.path.read_text(encoding="utf-8")
+        result = self.reload_schematic()
+        summary = (
+            f"{result}\n{self.format_target_detail(target)}\n"
+            f"Updated schematic title block fields: {changed}."
+        )
+        transaction = MutatingToolResult(
+            changed_files=[str(target.path)],
+            changed_objects=changed_objects,
+            before_hash=hashlib.sha256(before_text.encode("utf-8")).hexdigest(),
+            after_hash=hashlib.sha256(after_text.encode("utf-8")).hexdigest(),
+            verification=TransactionVerification(roundtrip="validated"),
+        )
+        return transaction.to_compat_text(summary)
+
+    def set_sheet_size(self, paper: str = "A3") -> str:
+        paper = paper.strip()
+        if paper not in self.paper_sizes_mm:
+            available = ", ".join(sorted(self.paper_sizes_mm))
+            return f"Unknown paper size '{paper}'. Available sizes: {available}."
+
+        sch_file = self.active_schematic_file()
+        new_w, new_h = self.paper_sizes_mm[paper]
+        old_paper = "A4"
+
+        def resize_sheet(current: str) -> str:
+            nonlocal old_paper
+            match = re.search(r'\(paper\s+"([^"]+)"(?:\s+[\d.]+\s+[\d.]+)?\)', current)
+            old_paper = match.group(1) if match else "A4"
+
+            if match is not None:
+                new_text = re.sub(
+                    r'\(paper\s+"[^"]+"(?:\s+[\d.]+\s+[\d.]+)?\)',
+                    f'(paper "{paper}")',
+                    current,
+                    count=1,
+                )
+            else:
+                new_text = re.sub(
+                    r"(\(kicad_sch[^\n]*\n)",
+                    rf'\1  (paper "{paper}")\n',
+                    current,
+                    count=1,
+                )
+
+            if new_text == current:
+                raise _SheetAlreadySetError
+            return new_text
+
+        try:
+            self.transactional_write(resize_sheet, sch_file)
+        except _SheetAlreadySetError:
+            return f"Sheet is already '{paper}' ({new_w:.0f} x {new_h:.0f} mm). No change made."
+        except Exception as exc:
+            return f"Could not write schematic file: {exc}"
+
+        result = self.reload_schematic()
+        old_w, old_h = self.paper_sizes_mm.get(old_paper, (0.0, 0.0))
+        usable_cols = self.sheet_usable_cols(paper)
+        usable_rows = self.sheet_usable_rows(paper)
+        return (
+            f"{result}\n"
+            f"Sheet resized: {old_paper} ({old_w:.0f}x{old_h:.0f} mm) "
+            f"-> {paper} ({new_w:.0f}x{new_h:.0f} mm).\n"
+            f"Usable grid: {usable_cols} columns x {usable_rows} rows "
+            f"(origin {self.layout_origin_x_mm} mm, margin {self.sheet_margin_mm} mm).\n"
+            f"Tip: run sch_auto_place_functional to redistribute symbols on the new sheet."
+        )
+
+    def auto_resize_sheet(self) -> str:
+        sch_file = self.active_schematic_file()
+        sch_data = self.parse_schematic(sch_file)
+        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
+
+        if not all_syms:
+            return "No symbols found — sheet size unchanged."
+
+        xs = [float(symbol.get("x", symbol.get("x_mm", 0.0)) or 0.0) for symbol in all_syms]
+        ys = [float(symbol.get("y", symbol.get("y_mm", 0.0)) or 0.0) for symbol in all_syms]
+        required_w = max(xs) + self.symbol_half_width_mm + self.sheet_margin_mm
+        required_h = max(ys) + self.symbol_half_height_mm + self.sheet_margin_mm
+
+        candidates = ["A4", "A3", "A2", "A1", "A0", "B", "C", "D", "E"]
+        chosen = None
+        for size in candidates:
+            width, height = self.paper_sizes_mm[size]
+            if width >= required_w and height >= required_h:
+                chosen = size
+                break
+
+        current_paper = self.read_sheet_paper(sch_file)
+        cur_w, cur_h = self.paper_sizes_mm.get(
+            current_paper,
+            self.paper_sizes_mm["A4"],
+        )
+
+        if chosen is None:
+            return (
+                f"Symbols span {required_w:.0f} x {required_h:.0f} mm — "
+                "no standard size is large enough.  Consider splitting into "
+                "hierarchical sheets (sch_create_sheet)."
+            )
+
+        if chosen == current_paper:
+            return (
+                f"Current sheet '{current_paper}' ({cur_w:.0f}x{cur_h:.0f} mm) "
+                f"already fits all symbols (required {required_w:.0f}x{required_h:.0f} mm)."
+            )
+
+        return str(self.set_sheet_size(paper=chosen))

--- a/src/kicad_mcp/schematic/document_settings.py
+++ b/src/kicad_mcp/schematic/document_settings.py
@@ -13,7 +13,7 @@ from ..models.tool_result import MutatingToolResult, TransactionVerification
 
 
 class TransactionalWrite(Protocol):
-    def __call__(self, mutator: Callable[[str], str], path: Path, /) -> None: ...
+    def __call__(self, mutator: Callable[[str], str], path: Path, /) -> object: ...
 
 
 class _SheetAlreadySetError(Exception):

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -36,12 +36,12 @@ from ..models.schematic import (
     RouteWireBetweenPinsInput,
     UpdatePropertiesInput,
 )
-from ..models.tool_result import MutatingToolResult, TransactionVerification
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
 from ..schematic.back_annotation import SchematicBackAnnotationService
 from ..schematic.basic_authoring import SchematicBasicAuthoringService
 from ..schematic.destructive_edit import SchematicDestructiveEditService
+from ..schematic.document_settings import SchematicDocumentSettingsService
 from ..schematic.hierarchy_authoring import (
     ChildSchematic,
     RootSchematic,
@@ -67,6 +67,7 @@ from . import (
     schematic_back_annotation,
     schematic_basic_authoring,
     schematic_destructive_edit,
+    schematic_document_settings,
     schematic_hierarchy_authoring,
     schematic_inspection,
     schematic_layout_inspection,
@@ -5485,6 +5486,30 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    document_settings_service = SchematicDocumentSettingsService(
+        active_schematic_file=_get_schematic_file,
+        resolve_target=_resolve_schematic_target,
+        parse_schematic=parse_schematic_file,
+        apply_title_block_updates=_apply_title_block_updates,
+        transactional_write=transactional_write,
+        reload_schematic=_reload_schematic,
+        format_target_detail=_format_target_detail,
+        read_sheet_paper=_read_sheet_paper,
+        sheet_usable_cols=_sheet_usable_cols,
+        sheet_usable_rows=_sheet_usable_rows,
+        paper_sizes_mm=PAPER_SIZES_MM,
+        layout_origin_x_mm=AUTO_LAYOUT_ORIGIN_X_MM,
+        sheet_margin_mm=_SHEET_MARGIN_MM,
+        symbol_half_width_mm=_SYMBOL_HALF_W_MM,
+        symbol_half_height_mm=_SYMBOL_HALF_H_MM,
+    )
+    schematic_document_settings.register(
+        mcp,
+        schematic_document_settings.SchematicDocumentSettingsDependencies(
+            service=document_settings_service,
+        ),
+    )
+
     topology_service = SchematicTopologyService(
         load_schematic=_load_kicad_schematic,
         with_diagnostics=_with_schematic_diagnostics,
@@ -6837,216 +6862,6 @@ def register(mcp: FastMCP) -> None:
             **diff_metadata,
         }
         return image_tool_result(diff_file, metadata2)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_set_title_block_info(
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-        title: str | None = None,
-        rev: str | None = None,
-        date: str | None = None,
-        company: str | None = None,
-        comment1: str | None = None,
-        comment2: str | None = None,
-        comment3: str | None = None,
-        comment4: str | None = None,
-        dry_run: bool = False,
-    ) -> str:
-        """Set schematic title block fields on the root sheet or a child sheet.
-
-        Unspecified fields are preserved. Use ``sheet`` for a named child sheet
-        or ``sheet_file`` for a specific ``.kicad_sch`` file; omit both to target
-        the active root schematic.
-        """
-        updates = {
-            key: value
-            for key, value in {
-                "title": title,
-                "rev": rev,
-                "date": date,
-                "company": company,
-                "comment1": comment1,
-                "comment2": comment2,
-                "comment3": comment3,
-                "comment4": comment4,
-            }.items()
-            if value is not None
-        }
-        if not updates:
-            return "No schematic title block fields specified. Provide at least one field."
-
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        before_text = target.path.read_text(encoding="utf-8")
-        planned_text = _apply_title_block_updates(before_text, updates)
-        if dry_run:
-            changed = ", ".join(updates)
-            transaction = MutatingToolResult(
-                changed_files=[str(target.path)],
-                changed_objects=[f"title_block.{field}" for field in updates],
-                before_hash=hashlib.sha256(before_text.encode("utf-8")).hexdigest(),
-                after_hash=hashlib.sha256(planned_text.encode("utf-8")).hexdigest(),
-                verification=TransactionVerification(roundtrip="planned_not_written"),
-                dry_run=True,
-            )
-            return transaction.to_compat_text(
-                f"Dry run: schematic title block fields would be updated: {changed}."
-            )
-        transactional_write(
-            lambda current: _apply_title_block_updates(current, updates),
-            target.path,
-        )
-        after_text = target.path.read_text(encoding="utf-8")
-        result = _reload_schematic()
-        changed = ", ".join(updates)
-        summary = (
-            f"{result}\n{_format_target_detail(target)}\n"
-            f"Updated schematic title block fields: {changed}."
-        )
-        transaction = MutatingToolResult(
-            changed_files=[str(target.path)],
-            changed_objects=[f"title_block.{field}" for field in updates],
-            before_hash=hashlib.sha256(before_text.encode("utf-8")).hexdigest(),
-            after_hash=hashlib.sha256(after_text.encode("utf-8")).hexdigest(),
-            verification=TransactionVerification(roundtrip="validated"),
-        )
-        return transaction.to_compat_text(summary)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_set_sheet_size(
-        paper: str = "A3",
-    ) -> str:
-        """Change the schematic sheet (paper) size.
-
-        Use this when the current sheet is too small to fit all symbols — for
-        example after ``sch_auto_place_functional`` warns that symbols were
-        placed outside the sheet boundary, or when you receive a screenshot
-        showing components outside the red sheet border.
-
-        Supported sizes (landscape): A4, A3, A2, A1, A0, A (letter), B, C, D, E,
-        USLetter, USLegal.
-
-        After resizing you should call ``sch_auto_place_functional`` again so
-        that symbols are re-distributed across the larger sheet.
-
-        Args:
-            paper: Target paper size keyword (default "A3").
-
-        Returns:
-            Confirmation with old and new dimensions.
-        """
-        paper = paper.strip()
-        if paper not in PAPER_SIZES_MM:
-            available = ", ".join(sorted(PAPER_SIZES_MM))
-            return f"Unknown paper size '{paper}'. Available sizes: {available}."
-
-        sch_file = _get_schematic_file()
-        new_w, new_h = PAPER_SIZES_MM[paper]
-        old_paper = "A4"
-
-        class _SheetAlreadySetError(Exception):
-            pass
-
-        def resize_sheet(current: str) -> str:
-            nonlocal old_paper
-            match = re.search(r'\(paper\s+"([^"]+)"(?:\s+[\d.]+\s+[\d.]+)?\)', current)
-            old_paper = match.group(1) if match else "A4"
-
-            if match is not None:
-                new_text = re.sub(
-                    r'\(paper\s+"[^"]+"(?:\s+[\d.]+\s+[\d.]+)?\)',
-                    f'(paper "{paper}")',
-                    current,
-                    count=1,
-                )
-            else:
-                # Insert after the kicad_sch opening tag.
-                new_text = re.sub(
-                    r"(\(kicad_sch[^\n]*\n)",
-                    rf'\1  (paper "{paper}")\n',
-                    current,
-                    count=1,
-                )
-
-            if new_text == current:
-                raise _SheetAlreadySetError
-            return new_text
-
-        try:
-            transactional_write(resize_sheet, sch_file)
-        except _SheetAlreadySetError:
-            return f"Sheet is already '{paper}' ({new_w:.0f} x {new_h:.0f} mm). No change made."
-        except Exception as exc:
-            return f"Could not write schematic file: {exc}"
-
-        result = _reload_schematic()
-        old_w, old_h = PAPER_SIZES_MM.get(old_paper, (0.0, 0.0))
-        usable_cols = _sheet_usable_cols(paper)
-        usable_rows = _sheet_usable_rows(paper)
-        return (
-            f"{result}\n"
-            f"Sheet resized: {old_paper} ({old_w:.0f}x{old_h:.0f} mm) "
-            f"-> {paper} ({new_w:.0f}x{new_h:.0f} mm).\n"
-            f"Usable grid: {usable_cols} columns x {usable_rows} rows "
-            f"(origin {AUTO_LAYOUT_ORIGIN_X_MM} mm, margin {_SHEET_MARGIN_MM} mm).\n"
-            f"Tip: run sch_auto_place_functional to redistribute symbols on the new sheet."
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_auto_resize_sheet() -> str:
-        """Automatically grow the sheet to fit all currently placed symbols.
-
-        Reads the bounding box of all placed symbols and selects the smallest
-        standard paper size (A4 → A3 → A2 → A1) that contains them with the
-        configured margin.  If the current sheet already fits, reports that no
-        change is needed.
-
-        Returns:
-            The chosen paper size and new dimensions, or a message if the
-            current size is already sufficient.
-        """
-        sch_file = _get_schematic_file()
-        sch_data = parse_schematic_file(sch_file)
-        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
-
-        if not all_syms:
-            return "No symbols found — sheet size unchanged."
-
-        xs = [float(s.get("x", s.get("x_mm", 0.0)) or 0.0) for s in all_syms]
-        ys = [float(s.get("y", s.get("y_mm", 0.0)) or 0.0) for s in all_syms]
-
-        required_w = max(xs) + _SYMBOL_HALF_W_MM + _SHEET_MARGIN_MM
-        required_h = max(ys) + _SYMBOL_HALF_H_MM + _SHEET_MARGIN_MM
-
-        # Pick smallest standard size (in landscape) that fits
-        candidates = ["A4", "A3", "A2", "A1", "A0", "B", "C", "D", "E"]
-        chosen = None
-        for size in candidates:
-            w, h = PAPER_SIZES_MM[size]
-            if w >= required_w and h >= required_h:
-                chosen = size
-                break
-
-        current_paper = _read_sheet_paper(sch_file)
-        cur_w, cur_h = PAPER_SIZES_MM.get(current_paper, PAPER_SIZES_MM["A4"])
-
-        if chosen is None:
-            return (
-                f"Symbols span {required_w:.0f} x {required_h:.0f} mm — "
-                "no standard size is large enough.  Consider splitting into "
-                "hierarchical sheets (sch_create_sheet)."
-            )
-
-        if chosen == current_paper:
-            return (
-                f"Current sheet '{current_paper}' ({cur_w:.0f}x{cur_h:.0f} mm) "
-                f"already fits all symbols (required {required_w:.0f}x{required_h:.0f} mm)."
-            )
-
-        # Delegate to sch_set_sheet_size logic
-        return str(sch_set_sheet_size(paper=chosen))
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/schematic_document_settings.py
+++ b/src/kicad_mcp/tools/schematic_document_settings.py
@@ -1,0 +1,99 @@
+"""Thin FastMCP adapters for schematic document settings."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.document_settings import SchematicDocumentSettingsService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicDocumentSettingsDependencies:
+    """Document-settings service injected by the schematic composition root."""
+
+    service: SchematicDocumentSettingsService
+
+
+def register(mcp: FastMCP, dependencies: SchematicDocumentSettingsDependencies) -> None:
+    """Register schematic title-block and paper-size tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_set_title_block_info(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        title: str | None = None,
+        rev: str | None = None,
+        date: str | None = None,
+        company: str | None = None,
+        comment1: str | None = None,
+        comment2: str | None = None,
+        comment3: str | None = None,
+        comment4: str | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        """Set schematic title block fields on the root sheet or a child sheet.
+
+        Unspecified fields are preserved. Use ``sheet`` for a named child sheet
+        or ``sheet_file`` for a specific ``.kicad_sch`` file; omit both to target
+        the active root schematic.
+        """
+        return service.set_title_block_info(
+            sheet,
+            sheet_file,
+            title,
+            rev,
+            date,
+            company,
+            comment1,
+            comment2,
+            comment3,
+            comment4,
+            dry_run,
+        )
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_set_sheet_size(paper: str = "A3") -> str:
+        """Change the schematic sheet (paper) size.
+
+        Use this when the current sheet is too small to fit all symbols — for
+        example after ``sch_auto_place_functional`` warns that symbols were
+        placed outside the sheet boundary, or when you receive a screenshot
+        showing components outside the red sheet border.
+
+        Supported sizes (landscape): A4, A3, A2, A1, A0, A (letter), B, C, D, E,
+        USLetter, USLegal.
+
+        After resizing you should call ``sch_auto_place_functional`` again so
+        that symbols are re-distributed across the larger sheet.
+
+        Args:
+            paper: Target paper size keyword (default "A3").
+
+        Returns:
+            Confirmation with old and new dimensions.
+        """
+        return service.set_sheet_size(paper)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_auto_resize_sheet() -> str:
+        """Automatically grow the sheet to fit all currently placed symbols.
+
+        Reads the bounding box of all placed symbols and selects the smallest
+        standard paper size (A4 → A3 → A2 → A1) that contains them with the
+        configured margin.  If the current sheet already fits, reports that no
+        change is needed.
+
+        Returns:
+            The chosen paper size and new dimensions, or a message if the
+            current size is already sufficient.
+        """
+        return service.auto_resize_sheet()

--- a/tests/unit/test_schematic_document_settings_architecture.py
+++ b/tests/unit/test_schematic_document_settings_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_document_settings_modules() -> None:
+    assert "kicad_mcp.schematic.document_settings" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.document_settings" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_document_settings" in boundaries.DOMAIN_MODULES
+
+
+def test_document_settings_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_document_settings.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_document_settings"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_document_settings_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_document_settings.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_document_settings"] == 300

--- a/tests/unit/test_schematic_document_settings_registration.py
+++ b/tests/unit/test_schematic_document_settings_registration.py
@@ -1,0 +1,211 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_document_settings import (
+    SchematicDocumentSettingsDependencies,
+    register,
+)
+
+
+class FakeDocumentSettingsService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def set_title_block_info(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        title: str | None = None,
+        rev: str | None = None,
+        date: str | None = None,
+        company: str | None = None,
+        comment1: str | None = None,
+        comment2: str | None = None,
+        comment3: str | None = None,
+        comment4: str | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        self.calls.append(
+            (
+                "set_title_block_info",
+                (
+                    sheet,
+                    sheet_file,
+                    title,
+                    rev,
+                    date,
+                    company,
+                    comment1,
+                    comment2,
+                    comment3,
+                    comment4,
+                    dry_run,
+                ),
+            )
+        )
+        return "title"
+
+    def set_sheet_size(self, paper: str = "A3") -> str:
+        self.calls.append(("set_sheet_size", (paper,)))
+        return "size"
+
+    def auto_resize_sheet(self) -> str:
+        self.calls.append(("auto_resize_sheet", ()))
+        return "auto"
+
+
+def _registered() -> tuple[FastMCP, FakeDocumentSettingsService]:
+    server = FastMCP("schematic-document-settings-test")
+    service = FakeDocumentSettingsService()
+    register(server, SchematicDocumentSettingsDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schema_defaults() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_set_title_block_info",
+        "sch_set_sheet_size",
+        "sch_auto_resize_sheet",
+    }
+    assert tools["sch_set_title_block_info"].description == (
+        "Set schematic title block fields on the root sheet or a child sheet.\n\n"
+        "Unspecified fields are preserved. Use ``sheet`` for a named child sheet\n"
+        "or ``sheet_file`` for a specific ``.kicad_sch`` file; omit both to target\n"
+        "the active root schematic.\n"
+    )
+    assert tools["sch_set_sheet_size"].description == (
+        "Change the schematic sheet (paper) size.\n\n"
+        "Use this when the current sheet is too small to fit all symbols — for\n"
+        "example after ``sch_auto_place_functional`` warns that symbols were\n"
+        "placed outside the sheet boundary, or when you receive a screenshot\n"
+        "showing components outside the red sheet border.\n\n"
+        "Supported sizes (landscape): A4, A3, A2, A1, A0, A (letter), B, C, D, E,\n"
+        "USLetter, USLegal.\n\n"
+        "After resizing you should call ``sch_auto_place_functional`` again so\n"
+        "that symbols are re-distributed across the larger sheet.\n\n"
+        "Args:\n"
+        '    paper: Target paper size keyword (default "A3").\n\n'
+        "Returns:\n"
+        "    Confirmation with old and new dimensions.\n"
+    )
+    assert tools["sch_auto_resize_sheet"].description == (
+        "Automatically grow the sheet to fit all currently placed symbols.\n\n"
+        "Reads the bounding box of all placed symbols and selects the smallest\n"
+        "standard paper size (A4 → A3 → A2 → A1) that contains them with the\n"
+        "configured margin.  If the current sheet already fits, reports that no\n"
+        "change is needed.\n\n"
+        "Returns:\n"
+        "    The chosen paper size and new dimensions, or a message if the\n"
+        "    current size is already sufficient.\n"
+    )
+
+    title_schema = tools["sch_set_title_block_info"].parameters
+    assert title_schema.get("required") is None
+    assert list(title_schema["properties"]) == [
+        "sheet",
+        "sheet_file",
+        "title",
+        "rev",
+        "date",
+        "company",
+        "comment1",
+        "comment2",
+        "comment3",
+        "comment4",
+        "dry_run",
+    ]
+    for field in [
+        "sheet",
+        "sheet_file",
+        "title",
+        "rev",
+        "date",
+        "company",
+        "comment1",
+        "comment2",
+        "comment3",
+        "comment4",
+    ]:
+        assert title_schema["properties"][field]["default"] is None
+    assert title_schema["properties"]["dry_run"]["default"] is False
+
+    size_schema = tools["sch_set_sheet_size"].parameters
+    assert size_schema.get("required") is None
+    assert size_schema["properties"]["paper"]["default"] == "A3"
+    assert tools["sch_auto_resize_sheet"].parameters == {
+        "properties": {},
+        "title": "sch_auto_resize_sheetArguments",
+        "type": "object",
+    }
+
+
+def test_registration_preserves_headless_metadata_and_direct_annotations() -> None:
+    server, _service = _registered()
+
+    for tool in server._tool_manager.list_tools():
+        metadata = get_tool_metadata(tool.name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+        assert metadata.requires_kicad_running is False
+        assert tool.annotations is None
+
+
+def test_registration_delegates_defaults_and_explicit_arguments() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_set_title_block_info"].fn() == "title"
+    assert tools["sch_set_sheet_size"].fn() == "size"
+    assert tools["sch_auto_resize_sheet"].fn() == "auto"
+    assert (
+        tools["sch_set_title_block_info"].fn(
+            sheet="power",
+            sheet_file=None,
+            title="Power",
+            rev="B",
+            date="2026-07-23",
+            company="Acme",
+            comment1="One",
+            comment2="Two",
+            comment3="Three",
+            comment4="Four",
+            dry_run=True,
+        )
+        == "title"
+    )
+    assert tools["sch_set_sheet_size"].fn(paper="A2") == "size"
+
+    assert service.calls == [
+        (
+            "set_title_block_info",
+            (None, None, None, None, None, None, None, None, None, None, False),
+        ),
+        ("set_sheet_size", ("A3",)),
+        ("auto_resize_sheet", ()),
+        (
+            "set_title_block_info",
+            (
+                "power",
+                None,
+                "Power",
+                "B",
+                "2026-07-23",
+                "Acme",
+                "One",
+                "Two",
+                "Three",
+                "Four",
+                True,
+            ),
+        ),
+        ("set_sheet_size", ("A2",)),
+    ]

--- a/tests/unit/test_schematic_document_settings_service.py
+++ b/tests/unit/test_schematic_document_settings_service.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kicad_mcp.models.tool_result import MutatingToolResult, TransactionVerification
+from kicad_mcp.schematic.document_settings import SchematicDocumentSettingsService
+
+
+@dataclass(frozen=True)
+class FakeTarget:
+    path: Path
+    is_root: bool = True
+    description: str = "root"
+
+
+PAPER_SIZES = {
+    "A4": (297.0, 210.0),
+    "A3": (420.0, 297.0),
+    "A2": (594.0, 420.0),
+    "A1": (841.0, 594.0),
+    "A0": (1189.0, 841.0),
+    "B": (431.8, 279.4),
+    "C": (558.8, 431.8),
+    "D": (863.6, 558.8),
+    "E": (1117.6, 863.6),
+}
+
+
+def _paper_from_file(path: Path) -> str:
+    match = re.search(r'\(paper\s+"([^"]+)"', path.read_text(encoding="utf-8"))
+    return match.group(1) if match else "A4"
+
+
+def _service(
+    path: Path,
+    *,
+    parse_schematic: Callable[[Path], dict[str, Any]] | None = None,
+    transactional_write: Callable[[Callable[[str], str], Path], None] | None = None,
+    reload_schematic: Callable[[], str] | None = None,
+    resolve_target: Callable[..., FakeTarget] | None = None,
+    apply_title_block_updates: Callable[[str, dict[str, str]], str] | None = None,
+    sheet_usable_cols: Callable[[str], int] | None = None,
+    sheet_usable_rows: Callable[[str], int] | None = None,
+) -> SchematicDocumentSettingsService:
+    def write(mutator: Callable[[str], str], target: Path) -> None:
+        current = target.read_text(encoding="utf-8")
+        target.write_text(mutator(current), encoding="utf-8")
+
+    def default_resolve(
+        *,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> FakeTarget:
+        _ = (sheet, sheet_file)
+        return FakeTarget(path)
+
+    return SchematicDocumentSettingsService(
+        active_schematic_file=lambda: path,
+        resolve_target=resolve_target or default_resolve,
+        parse_schematic=parse_schematic or (lambda _path: {"symbols": [], "power_symbols": []}),
+        apply_title_block_updates=apply_title_block_updates
+        or (
+            lambda current, updates: (
+                current + "|" + ",".join(f"{k}={v}" for k, v in updates.items())
+            )
+        ),
+        transactional_write=transactional_write or write,
+        reload_schematic=reload_schematic or (lambda: "Reloaded."),
+        format_target_detail=lambda target: (
+            f"Target schematic ({'root' if target.is_root else 'child'}): {target.path}"
+        ),
+        read_sheet_paper=_paper_from_file,
+        sheet_usable_cols=sheet_usable_cols or (lambda _paper: 9),
+        sheet_usable_rows=sheet_usable_rows or (lambda _paper: 7),
+        paper_sizes_mm=PAPER_SIZES,
+        layout_origin_x_mm=25.4,
+        sheet_margin_mm=12.7,
+        symbol_half_width_mm=10.0,
+        symbol_half_height_mm=8.0,
+    )
+
+
+def test_title_block_requires_at_least_one_field(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text("root", encoding="utf-8")
+    resolved = False
+
+    def resolve(**_: object) -> FakeTarget:
+        nonlocal resolved
+        resolved = True
+        return FakeTarget(path)
+
+    result = _service(path, resolve_target=resolve).set_title_block_info(
+        None, None, None, None, None, None, None, None, None, None, False
+    )
+
+    assert result == "No schematic title block fields specified. Provide at least one field."
+    assert resolved is False
+
+
+def test_title_block_dry_run_preserves_order_hashes_and_target(tmp_path: Path) -> None:
+    path = tmp_path / "child.kicad_sch"
+    before = "(kicad_sch)"
+    path.write_text(before, encoding="utf-8")
+    target_calls: list[tuple[str | None, str | None]] = []
+    writes: list[Path] = []
+    reloads = 0
+
+    def resolve(*, sheet: str | None = None, sheet_file: str | None = None) -> FakeTarget:
+        target_calls.append((sheet, sheet_file))
+        return FakeTarget(path, is_root=False, description="child")
+
+    def update(current: str, updates: dict[str, str]) -> str:
+        assert list(updates) == ["title", "rev", "company", "comment2"]
+        return current + "|" + ",".join(f"{key}={value}" for key, value in updates.items())
+
+    def write(_mutator: Callable[[str], str], target: Path) -> None:
+        writes.append(target)
+
+    def reload() -> str:
+        nonlocal reloads
+        reloads += 1
+        return "Reloaded."
+
+    service = _service(
+        path,
+        resolve_target=resolve,
+        apply_title_block_updates=update,
+        transactional_write=write,
+        reload_schematic=reload,
+    )
+    result = service.set_title_block_info(
+        "power",
+        None,
+        "Power",
+        "B",
+        None,
+        "Acme",
+        None,
+        "Reviewed",
+        None,
+        None,
+        True,
+    )
+
+    planned = "(kicad_sch)|title=Power,rev=B,company=Acme,comment2=Reviewed"
+    expected = MutatingToolResult(
+        changed_files=[str(path)],
+        changed_objects=[
+            "title_block.title",
+            "title_block.rev",
+            "title_block.company",
+            "title_block.comment2",
+        ],
+        before_hash=hashlib.sha256(before.encode()).hexdigest(),
+        after_hash=hashlib.sha256(planned.encode()).hexdigest(),
+        verification=TransactionVerification(roundtrip="planned_not_written"),
+        dry_run=True,
+    ).to_compat_text(
+        "Dry run: schematic title block fields would be updated: title, rev, company, comment2."
+    )
+    assert result == expected
+    assert target_calls == [("power", None)]
+    assert writes == []
+    assert reloads == 0
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_title_block_commit_preserves_write_reload_and_transaction_text(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    before = "(kicad_sch)"
+    path.write_text(before, encoding="utf-8")
+    events: list[str] = []
+
+    def write(mutator: Callable[[str], str], target: Path) -> None:
+        events.append("write")
+        target.write_text(mutator(target.read_text(encoding="utf-8")), encoding="utf-8")
+
+    def reload() -> str:
+        events.append("reload")
+        return "The schematic was reloaded."
+
+    service = _service(path, transactional_write=write, reload_schematic=reload)
+    result = service.set_title_block_info(
+        None,
+        "root.kicad_sch",
+        "Main",
+        None,
+        "2026-07-23",
+        None,
+        "Approved",
+        None,
+        None,
+        None,
+        False,
+    )
+
+    after = "(kicad_sch)|title=Main,date=2026-07-23,comment1=Approved"
+    expected = MutatingToolResult(
+        changed_files=[str(path)],
+        changed_objects=["title_block.title", "title_block.date", "title_block.comment1"],
+        before_hash=hashlib.sha256(before.encode()).hexdigest(),
+        after_hash=hashlib.sha256(after.encode()).hexdigest(),
+        verification=TransactionVerification(roundtrip="validated"),
+    ).to_compat_text(
+        f"The schematic was reloaded.\nTarget schematic (root): {path}\n"
+        "Updated schematic title block fields: title, date, comment1."
+    )
+    assert result == expected
+    assert events == ["write", "reload"]
+    assert path.read_text(encoding="utf-8") == after
+
+
+def test_set_sheet_size_rejects_unknown_paper_after_trimming(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text('(kicad_sch\n  (paper "A4")\n)', encoding="utf-8")
+
+    result = _service(path).set_sheet_size(" BAD ")
+
+    assert result == "Unknown paper size 'BAD'. Available sizes: A0, A1, A2, A3, A4, B, C, D, E."
+
+
+def test_set_sheet_size_replaces_paper_and_preserves_summary(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text('(kicad_sch\n  (paper "A4")\n)', encoding="utf-8")
+    calls: list[str] = []
+
+    service = _service(
+        path,
+        reload_schematic=lambda: calls.append("reload") or "Reloaded.",
+        sheet_usable_cols=lambda paper: calls.append(f"cols:{paper}") or 14,
+        sheet_usable_rows=lambda paper: calls.append(f"rows:{paper}") or 11,
+    )
+    result = service.set_sheet_size(" A3 ")
+
+    assert '(paper "A3")' in path.read_text(encoding="utf-8")
+    assert calls == ["reload", "cols:A3", "rows:A3"]
+    assert result == (
+        "Reloaded.\n"
+        "Sheet resized: A4 (297x210 mm) -> A3 (420x297 mm).\n"
+        "Usable grid: 14 columns x 11 rows (origin 25.4 mm, margin 12.7 mm).\n"
+        "Tip: run sch_auto_place_functional to redistribute symbols on the new sheet."
+    )
+
+
+def test_set_sheet_size_inserts_missing_declaration(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text("(kicad_sch\n  (version 20231120)\n)", encoding="utf-8")
+
+    result = _service(path).set_sheet_size("A3")
+
+    assert path.read_text(encoding="utf-8").startswith('(kicad_sch\n  (paper "A3")\n')
+    assert "Sheet resized: A4 (297x210 mm) -> A3 (420x297 mm)." in result
+
+
+def test_set_sheet_size_reports_already_set_without_reload(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    original = '(kicad_sch\n  (paper "A3")\n)'
+    path.write_text(original, encoding="utf-8")
+    reloads = 0
+
+    def reload() -> str:
+        nonlocal reloads
+        reloads += 1
+        return "Reloaded."
+
+    result = _service(path, reload_schematic=reload).set_sheet_size("A3")
+
+    assert result == "Sheet is already 'A3' (420 x 297 mm). No change made."
+    assert reloads == 0
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_set_sheet_size_preserves_write_failure_text(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text('(kicad_sch\n  (paper "A4")\n)', encoding="utf-8")
+
+    def fail(_mutator: Callable[[str], str], _target: Path) -> None:
+        raise OSError("disk full")
+
+    assert _service(path, transactional_write=fail).set_sheet_size("A3") == (
+        "Could not write schematic file: disk full"
+    )
+
+
+def test_auto_resize_handles_empty_and_oversized_schematics(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text('(kicad_sch\n  (paper "A4")\n)', encoding="utf-8")
+
+    empty = _service(path).auto_resize_sheet()
+    huge = _service(
+        path,
+        parse_schematic=lambda _path: {
+            "symbols": [{"x": 2000.0, "y": 1000.0}],
+            "power_symbols": [],
+        },
+    ).auto_resize_sheet()
+
+    assert empty == "No symbols found — sheet size unchanged."
+    assert huge == (
+        "Symbols span 2023 x 1021 mm — no standard size is large enough.  "
+        "Consider splitting into hierarchical sheets (sch_create_sheet)."
+    )
+
+
+def test_auto_resize_reports_current_sheet_when_it_already_fits(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text('(kicad_sch\n  (paper "A4")\n)', encoding="utf-8")
+    service = _service(
+        path,
+        parse_schematic=lambda _path: {
+            "symbols": [{"x": 100.0, "y": 80.0}],
+            "power_symbols": [{"x_mm": 120.0, "y_mm": 90.0}],
+        },
+    )
+
+    assert service.auto_resize_sheet() == (
+        "Current sheet 'A4' (297x210 mm) already fits all symbols (required 143x111 mm)."
+    )
+
+
+def test_auto_resize_delegates_to_explicit_resize_for_first_fitting_size(tmp_path: Path) -> None:
+    path = tmp_path / "root.kicad_sch"
+    path.write_text('(kicad_sch\n  (paper "A4")\n)', encoding="utf-8")
+    service = _service(
+        path,
+        parse_schematic=lambda _path: {
+            "symbols": [{"x": 330.0, "y": 170.0}],
+            "power_symbols": [],
+        },
+    )
+
+    result = service.auto_resize_sheet()
+
+    assert '(paper "A3")' in path.read_text(encoding="utf-8")
+    assert "Sheet resized: A4 (297x210 mm) -> A3 (420x297 mm)." in result


### PR DESCRIPTION
## Summary

- extract `sch_set_title_block_info`, `sch_set_sheet_size`, and `sch_auto_resize_sheet` into a FastMCP-independent `SchematicDocumentSettingsService`
- add a thin FastMCP adapter and keep all dependency wiring in the schematic composition root
- add direct service, adapter, architecture, and regression coverage
- reduce the main schematic `register()` span from 2,157 to 1,971 lines while keeping the new adapter at 78 lines

## Compatibility

- preserves exact public tool names, descriptions, input schemas, defaults, annotations, and argument ordering
- preserves title-block field ordering, dry-run hashes, transaction metadata, reload ordering, paper-size validation, resize candidate ordering, diagnostics, and result strings
- keeps the committed tool-surface snapshot unchanged
- introduces no runtime dependency and does not change transaction or approval semantics

## Verification

- 153 focused service/adapter/architecture/integration tests passed
- 1,698 selected unit tests passed with five expected skips
- extracted service and adapter reached 100% focused line coverage
- metadata, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, snapshot, latency, Bandit, dependency audit, and package build gates passed
- Semgrep: 290 rules across five changed files, zero findings
- OSV-Scanner 2.4.0: four lockfiles / 442 dependency entries, zero known vulnerabilities

## Follow-up

Issue #434 remains open for the remaining routing, layout mutation, rendering/preview, template, and orchestration tranches.

Refs #434