### PR TITLE
refactor(schematic): extract template catalog domain service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-template-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-template-catalog-service.md
@@ -1,0 +1,82 @@
+# Schematic Template Catalog Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract bundled subcircuit template discovery and detail rendering from FastMCP registration into a directly testable catalog service.
+
+**Architecture:** Add one FastMCP-free service and one thin adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root by injecting the bundled template directory and a lazy PyYAML loader.
+
+**Tech Stack:** Python 3.13, FastMCP, PyYAML, pytest, Ruff, mypy, Pyright, existing architecture and metadata generators.
+
+## Global Constraints
+
+- Preserve both public tool names, signatures, descriptions, schemas, annotations, sorting, truncation, ordering, formatting, lazy PyYAML behavior, errors, and result strings.
+- Do not add runtime dependencies or mutation behavior.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `tools.schematic`.
+- Keep full-server metadata and the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free template catalog service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/template_catalog.py`
+- Create: `tests/unit/test_schematic_template_catalog_service.py`
+
+**Interfaces:**
+- Produces: `SchematicTemplateCatalogService.list_templates() -> str`
+- Produces: `SchematicTemplateCatalogService.template_info(template_name: str) -> str`
+
+- [ ] Write direct failing tests for missing and empty directories, filename sorting, name fallback, first-line description truncation, parameter order, per-file parse failures, missing templates, absent PyYAML, parse errors, complete section rendering, and omission of empty sections.
+- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_template_catalog_service.py`; expect collection failure because the module is absent.
+- [ ] Implement the minimal injected service while preserving the legacy output byte-for-byte.
+- [ ] Run service tests, Ruff, mypy, and scoped Pyright; expect all pass.
+- [ ] Commit with `refactor(schematic): extract template catalog service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_template_catalog.py`
+- Create: `tests/unit/test_schematic_template_catalog_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicTemplateCatalogService`
+- Produces: `SchematicTemplateCatalogDependencies(service: SchematicTemplateCatalogService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicTemplateCatalogDependencies) -> None`
+
+- [ ] Write failing adapter tests for exact names, descriptions, required fields, schemas, headless metadata, and delegation.
+- [ ] Run the adapter test; expect collection failure because the adapter is absent.
+- [ ] Implement registration and composition wiring; remove the two nested legacy tool functions.
+- [ ] Run service/adapter and focused template/schematic integration tests; expect all pass.
+- [ ] Commit with `refactor(schematic): delegate template catalog registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_template_catalog_architecture.py`
+
+- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [ ] Add both modules to the architecture policy and run the checker.
+- [ ] Compare exact full-server metadata for the two tools against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard template catalog boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-template-catalog-service.md`
+
+- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, Semgrep, OSV-Scanner, and full unit gates.
+- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [ ] Commit with `docs(architecture): record template catalog evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect all bot/agent comments, reviews, and GraphQL review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after all required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/plans/2026-07-23-schematic-template-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-template-catalog-service.md
@@ -28,11 +28,11 @@
 - Produces: `SchematicTemplateCatalogService.list_templates() -> str`
 - Produces: `SchematicTemplateCatalogService.template_info(template_name: str) -> str`
 
-- [ ] Write direct failing tests for missing and empty directories, filename sorting, name fallback, first-line description truncation, parameter order, per-file parse failures, missing templates, absent PyYAML, parse errors, complete section rendering, and omission of empty sections.
-- [ ] Run `uv run --all-extras pytest -q tests/unit/test_schematic_template_catalog_service.py`; expect collection failure because the module is absent.
-- [ ] Implement the minimal injected service while preserving the legacy output byte-for-byte.
-- [ ] Run service tests, Ruff, mypy, and scoped Pyright; expect all pass.
-- [ ] Commit with `refactor(schematic): extract template catalog service`.
+- [x] Write direct failing tests for missing and empty directories, filename sorting, name fallback, first-line description truncation, parameter order, per-file parse failures, missing templates, absent PyYAML, parse errors, complete section rendering, and omission of empty sections.
+- [x] Run `uv run --all-extras pytest -q tests/unit/test_schematic_template_catalog_service.py`; expect collection failure because the module is absent.
+- [x] Implement the minimal injected service while preserving the legacy output byte-for-byte.
+- [x] Run service tests, Ruff, mypy, and scoped Pyright; expect all pass.
+- [x] Commit with `refactor(schematic): extract template catalog service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -46,11 +46,11 @@
 - Produces: `SchematicTemplateCatalogDependencies(service: SchematicTemplateCatalogService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicTemplateCatalogDependencies) -> None`
 
-- [ ] Write failing adapter tests for exact names, descriptions, required fields, schemas, headless metadata, and delegation.
-- [ ] Run the adapter test; expect collection failure because the adapter is absent.
-- [ ] Implement registration and composition wiring; remove the two nested legacy tool functions.
-- [ ] Run service/adapter and focused template/schematic integration tests; expect all pass.
-- [ ] Commit with `refactor(schematic): delegate template catalog registration`.
+- [x] Write failing adapter tests for exact names, descriptions, required fields, schemas, headless metadata, and delegation.
+- [x] Run the adapter test; expect collection failure because the adapter is absent.
+- [x] Implement registration and composition wiring; remove the two nested legacy tool functions.
+- [x] Run service/adapter and focused template/schematic integration tests; expect all pass.
+- [x] Commit with `refactor(schematic): delegate template catalog registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -58,20 +58,33 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_template_catalog_architecture.py`
 
-- [ ] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
-- [ ] Add both modules to the architecture policy and run the checker.
-- [ ] Compare exact full-server metadata for the two tools against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard template catalog boundaries`.
+- [x] Write failing architecture tests for service purity, adapter isolation, and the 300-line limit.
+- [x] Add both modules to the architecture policy and run the checker.
+- [x] Compare exact full-server metadata for the two tools against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard template catalog boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-template-catalog-service.md`
 
-- [ ] Run focused service/adapter coverage with the two new modules; require at least 83%.
-- [ ] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, Semgrep, OSV-Scanner, and full unit gates.
-- [ ] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
-- [ ] Commit with `docs(architecture): record template catalog evidence`.
+- [x] Run focused service/adapter coverage with the two new modules; require at least 83%.
+- [x] Run metadata, format, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, generated docs, snapshot, latency, Bandit, dependency audit, package build, Semgrep, OSV-Scanner, and full unit gates.
+- [x] Record exact surface equality, focused/full test counts, coverage, register spans, and security/package outcomes.
+- [x] Commit with `docs(architecture): record template catalog evidence`.
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_list_templates` and `sch_get_template_info` matches `main`: names, descriptions, input schemas, required fields, annotations, and argument ordering are identical.
+- The committed tool-surface snapshot passes without regeneration.
+- The main schematic `register()` span decreased from 1,971 to 1,843 lines; the template-catalog adapter `register()` spans 31 lines.
+- Focused service, registration, architecture, bundled-template, schematic integration, extended schematic, and tool-surface checks passed: 155 tests.
+- The extracted service and adapter have 100% focused line coverage.
+- The full unit suite passed across 1,714 selected tests with five expected skips and one pre-existing async-mock warning.
+- Metadata, formatting, Ruff, mypy, scoped strict Pyright, architecture, generated tool documentation, workflow policy/security, strict MkDocs, tool-surface snapshot, latency benchmark, Bandit, dependency audit, and package build gates pass.
+- OSV-Scanner 2.4.0 inspected four lockfiles representing 442 dependency entries and reported no known vulnerabilities.
+- Semgrep scanned the five changed implementation, test, and architecture files with 290 rules and reported zero findings.
+- No public tool contract, filename sorting, YAML loading behavior, fallback name, description truncation, parameter ordering, section rendering, parse error, or result string changed.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/specs/2026-07-23-schematic-template-catalog-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-template-catalog-service-design.md
@@ -1,0 +1,85 @@
+# Schematic Template Catalog Service Design
+
+## Context
+
+Issue #434 is incrementally reducing `src/kicad_mcp/tools/schematic.py` into a small FastMCP composition root. The bundled subcircuit template tools still combine registration, filesystem discovery, optional YAML loading, error handling, and Markdown formatting in nested tool functions.
+
+This tranche extracts:
+
+- `sch_list_templates`
+- `sch_get_template_info`
+
+`sch_get_circuit_ir` is intentionally excluded because it depends on semantic IR parsing and linting rather than the bundled YAML template catalog.
+
+## Goals
+
+- Make template discovery and rendering directly unit-testable without FastMCP.
+- Preserve exact public names, signatures, descriptions, schemas, annotations, sorting, truncation, formatting, error handling, and result strings.
+- Preserve lazy PyYAML behavior so server startup does not require eager template parsing.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Prevent the service and adapter from importing `kicad_mcp.tools.schematic`.
+
+## Non-goals
+
+- No template schema changes.
+- No template creation, editing, or instantiation changes.
+- No semantic circuit IR extraction in this tranche.
+- No new runtime dependencies.
+
+## Architecture
+
+Create `SchematicTemplateCatalogService` in `src/kicad_mcp/schematic/template_catalog.py`. The service receives the template directory and a lazy YAML loader callable. It owns file enumeration, parse error handling, field normalization, and exact Markdown rendering.
+
+Create `src/kicad_mcp/tools/schematic_template_catalog.py` as the thin FastMCP adapter. It preserves the current function signatures and docstrings and delegates to the service.
+
+Keep `src/kicad_mcp/tools/schematic.py` as the composition root. It constructs the service with the existing bundled template path and a lazy loader that imports PyYAML only when called.
+
+## Service Interface
+
+```python
+@dataclass(frozen=True)
+class SchematicTemplateCatalogService:
+    templates_dir: Path
+    load_yaml: Callable[[TextIO], Any]
+
+    def list_templates(self) -> str: ...
+    def template_info(self, template_name: str) -> str: ...
+```
+
+The loader may raise `ModuleNotFoundError` or `ImportError`, which the service translates to the existing PyYAML installation message. Other parse failures retain the existing per-file list fallback or exact template-specific error message.
+
+## Behavior Preservation
+
+### Listing
+
+- Return the existing directory-missing message before importing YAML.
+- Sort `*.yaml` paths by filename.
+- Use the YAML `name` field or filename stem.
+- Collapse description to the first line and truncate it to 80 characters.
+- Preserve parameter declaration order.
+- Convert each unreadable template into the current parse-failure line and continue.
+- Return the existing empty-directory message when no YAML files exist.
+- Preserve the final instantiation hint.
+
+### Template details
+
+- Resolve `<template_name>.yaml` in the bundled catalog.
+- Preserve sorted available-name output when the requested file is missing.
+- Preserve lazy PyYAML failure and parse-error messages.
+- Preserve default name/version values and all Markdown sections.
+- Preserve parameter, symbol, pin, net, placement-hint, and part-search ordering.
+- Preserve omission of empty sections and the exact trailing-newline behavior.
+
+## Security and Path Scope
+
+The public `template_name` behavior remains unchanged. The service joins the provided name with the fixed bundled catalog directory and appends `.yaml`; it does not broaden filesystem access or add mutation behavior.
+
+## Testing
+
+Direct service tests cover missing/empty directories, stable sorting, first-line/truncated descriptions, parameter ordering, per-file parse failures, missing templates, absent PyYAML, parse exceptions, complete section rendering, and omitted sections.
+
+Adapter tests cover exact public names, descriptions, schema requirements, metadata, and delegation. Architecture tests enforce service purity, adapter isolation, and the 300-line limit. Full-server metadata is compared byte-for-byte with `main`, and the committed tool-surface snapshot must remain unchanged.
+
+## Expected Result
+
+The main schematic `register()` function loses approximately 130 lines. Template catalog behavior becomes independently testable while public MCP behavior remains unchanged.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -52,6 +52,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "symbol_mutation.py",
+    "kicad_mcp.schematic.template_catalog": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "template_catalog.py",
     "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
     "kicad_mcp.tools.schematic_back_annotation": SRC_ROOT
     / "kicad_mcp"
@@ -73,6 +77,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_symbol_mutation.py",
+    "kicad_mcp.tools.schematic_template_catalog": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_template_catalog.py",
     "kicad_mcp.tools.schematic_topology": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -113,6 +121,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.layout_inspection",
     "kicad_mcp.schematic.symbol_mutation",
+    "kicad_mcp.schematic.template_catalog",
     "kicad_mcp.schematic.topology",
     "kicad_mcp.tools.schematic_constants",
 }
@@ -137,6 +146,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_template_catalog": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
 }
 
@@ -149,6 +159,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_layout_inspection": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
+    "kicad_mcp.tools.schematic_template_catalog": 300,
     "kicad_mcp.tools.schematic_topology": 300,
 }
 

--- a/src/kicad_mcp/schematic/template_catalog.py
+++ b/src/kicad_mcp/schematic/template_catalog.py
@@ -1,0 +1,128 @@
+"""FastMCP-independent bundled subcircuit template catalog services."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+YamlLoader = Callable[[TextIO], Any]
+
+
+@dataclass(frozen=True)
+class SchematicTemplateCatalogService:
+    """Discover and render bundled subcircuit template metadata."""
+
+    templates_dir: Path
+    yaml_loader_factory: Callable[[], YamlLoader]
+
+    def list_templates(self) -> str:
+        if not self.templates_dir.exists():
+            return "No subcircuit templates are available."
+
+        try:
+            load_yaml = self.yaml_loader_factory()
+        except ImportError:
+            return "Template tools require PyYAML. Install it to inspect bundled templates."
+
+        lines = ["# Available Subcircuit Templates", ""]
+        for yaml_file in sorted(self.templates_dir.glob("*.yaml")):
+            try:
+                with yaml_file.open(encoding="utf-8") as stream:
+                    data = load_yaml(stream)
+                name = data.get("name", yaml_file.stem)
+                description = str(data.get("description", "")).strip().split("\n")[0][:80]
+                parameters = list(data.get("parameters", {}).keys())
+                lines.append(f"**{name}**")
+                lines.append(f"  {description}")
+                if parameters:
+                    lines.append(f"  Parameters: {', '.join(parameters)}")
+                lines.append("")
+            except Exception:
+                lines.append(f"**{yaml_file.stem}** — (could not parse template)")
+                lines.append("")
+
+        if len(lines) == 2:
+            return "No subcircuit templates were found."
+
+        lines.append("Use sch_instantiate_template(template_name, prefix, params) to add.")
+        return "\n".join(lines)
+
+    def template_info(self, template_name: str) -> str:
+        yaml_file = self.templates_dir / f"{template_name}.yaml"
+        if not yaml_file.exists():
+            available = [path.stem for path in self.templates_dir.glob("*.yaml")]
+            return (
+                f"Template '{template_name}' not found. Available: {', '.join(sorted(available))}"
+            )
+
+        try:
+            load_yaml = self.yaml_loader_factory()
+            with yaml_file.open(encoding="utf-8") as stream:
+                data = load_yaml(stream)
+        except ImportError:
+            return "Template tools require PyYAML. Install it to inspect bundled templates."
+        except Exception as exc:
+            return f"Could not parse template '{template_name}': {exc}"
+
+        lines = [
+            f"# Template: {data.get('name', template_name)}",
+            f"Version: {data.get('version', '1.0')}",
+            "",
+            data.get("description", "").strip(),
+            "",
+        ]
+
+        parameters = data.get("parameters", {})
+        if parameters:
+            lines += ["## Parameters", ""]
+            for parameter_name, definition in parameters.items():
+                lines.append(
+                    f"- **{parameter_name}** ({definition.get('type', 'any')}): "
+                    f"{definition.get('description', '')} "
+                    f"[default: {definition.get('default', '—')}]"
+                )
+            lines.append("")
+
+        symbols = data.get("symbols", [])
+        if symbols:
+            lines += [f"## Symbols ({len(symbols)})", ""]
+            for symbol in symbols:
+                lines.append(
+                    f"- **{symbol.get('ref_prefix', '?')}?** "
+                    f"{symbol.get('value', '?')} — {symbol.get('comment', '')}"
+                )
+                left_pins = ", ".join(str(pin) for pin in symbol.get("pins_left", []))
+                right_pins = ", ".join(str(pin) for pin in symbol.get("pins_right", []))
+                pin_parts: list[str] = []
+                if left_pins:
+                    pin_parts.append(f"left: {left_pins}")
+                if right_pins:
+                    pin_parts.append(f"right: {right_pins}")
+                if pin_parts:
+                    lines.append(f"  Pins: {' | '.join(pin_parts)}")
+            lines.append("")
+
+        nets = data.get("nets", [])
+        if nets:
+            lines += ["## Nets", ""]
+            for net in nets:
+                note = f" — {net['note']}" if net.get("note") else ""
+                lines.append(f"- `{net['name']}` ({net.get('type', 'signal')}){note}")
+            lines.append("")
+
+        placement_hints = data.get("placement_hints", [])
+        if placement_hints:
+            lines += ["## Placement Hints", ""]
+            for hint in placement_hints:
+                lines.append(f"- {hint}")
+            lines.append("")
+
+        search_hints = data.get("part_search_hints", {})
+        if search_hints:
+            lines += ["## Part Search Hints (use with lib_recommend_part())", ""]
+            for role, query in search_hints.items():
+                lines.append(f"- {role}: `{query}`")
+
+        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Literal, Protocol, TypedDict, cast
+from typing import Any, Literal, Protocol, TextIO, TypedDict, cast
 
 import structlog
 from mcp.server.fastmcp import FastMCP
@@ -50,6 +50,7 @@ from ..schematic.hierarchy_authoring import (
 from ..schematic.inspection import SchematicInspectionService
 from ..schematic.layout_inspection import SchematicLayoutInspectionService
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
+from ..schematic.template_catalog import SchematicTemplateCatalogService
 from ..schematic.topology import SchematicTopologyService
 from ..utils.cache import clear_ttl_cache, ttl_cache
 from ..utils.field_placer import FieldSpec, autoplace_fields
@@ -72,6 +73,7 @@ from . import (
     schematic_inspection,
     schematic_layout_inspection,
     schematic_symbol_mutation,
+    schematic_template_catalog,
     schematic_topology,
 )
 from .metadata import headless_compatible
@@ -5452,6 +5454,13 @@ def _reload_schematic() -> str:
     return get_schematic_backend().reload_schematic()
 
 
+def _template_yaml_loader_factory() -> Callable[[TextIO], Any]:
+    """Return PyYAML's safe loader without importing it during server startup."""
+    import yaml
+
+    return yaml.safe_load
+
+
 def register(mcp: FastMCP) -> None:
     """Register schematic tools."""
     inspection_service = SchematicInspectionService(
@@ -5507,6 +5516,17 @@ def register(mcp: FastMCP) -> None:
         mcp,
         schematic_document_settings.SchematicDocumentSettingsDependencies(
             service=document_settings_service,
+        ),
+    )
+
+    template_catalog_service = SchematicTemplateCatalogService(
+        templates_dir=Path(__file__).parent.parent / "templates" / "subcircuits",
+        yaml_loader_factory=_template_yaml_loader_factory,
+    )
+    schematic_template_catalog.register(
+        mcp,
+        schematic_template_catalog.SchematicTemplateCatalogDependencies(
+            service=template_catalog_service,
         ),
     )
 
@@ -7075,145 +7095,6 @@ def register(mcp: FastMCP) -> None:
     # -----------------------------------------------------------------------
     # Subcircuit template tools (v2.1.0)
     # -----------------------------------------------------------------------
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_list_templates() -> str:
-        """List all available reference subcircuit templates.
-
-        Templates are pre-wired subcircuit blueprints for common building blocks
-        (buck converter, LDO, USB Type-C, MCU decoupling, Ethernet with magnetics).
-
-        Call sch_get_template_info() for full parameter and placement details,
-        then sch_instantiate_template() to add the subcircuit to the schematic.
-        """
-        from pathlib import Path as _Path
-
-        templates_dir = _Path(__file__).parent.parent / "templates" / "subcircuits"
-        if not templates_dir.exists():
-            return "No subcircuit templates are available."
-
-        try:
-            import yaml
-        except ImportError:
-            return "Template tools require PyYAML. Install it to inspect bundled templates."
-
-        lines = ["# Available Subcircuit Templates", ""]
-        for yaml_file in sorted(templates_dir.glob("*.yaml")):
-            try:
-                with yaml_file.open(encoding="utf-8") as fh:
-                    data = yaml.safe_load(fh)
-                name = data.get("name", yaml_file.stem)
-                desc = str(data.get("description", "")).strip().split("\n")[0][:80]
-                params = list(data.get("parameters", {}).keys())
-                lines.append(f"**{name}**")
-                lines.append(f"  {desc}")
-                if params:
-                    lines.append(f"  Parameters: {', '.join(params)}")
-                lines.append("")
-            except Exception:
-                lines.append(f"**{yaml_file.stem}** — (could not parse template)")
-                lines.append("")
-
-        if len(lines) == 2:
-            return "No subcircuit templates were found."
-
-        lines.append("Use sch_instantiate_template(template_name, prefix, params) to add.")
-        return "\n".join(lines)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_get_template_info(template_name: str) -> str:
-        """Return full details for a subcircuit template.
-
-        Args:
-            template_name: Template name as returned by sch_list_templates()
-                (e.g. ``"buck_converter_generic"``).
-
-        Returns:
-            Structured template description including parameters, symbols,
-            nets, and placement hints.
-        """
-        from pathlib import Path as _Path
-
-        templates_dir = _Path(__file__).parent.parent / "templates" / "subcircuits"
-        yaml_file = templates_dir / f"{template_name}.yaml"
-        if not yaml_file.exists():
-            available = [f.stem for f in templates_dir.glob("*.yaml")]
-            return (
-                f"Template '{template_name}' not found. Available: {', '.join(sorted(available))}"
-            )
-
-        try:
-            import yaml
-
-            with yaml_file.open(encoding="utf-8") as fh:
-                data = yaml.safe_load(fh)
-        except ImportError:
-            return "Template tools require PyYAML. Install it to inspect bundled templates."
-        except Exception as exc:
-            return f"Could not parse template '{template_name}': {exc}"
-
-        lines = [
-            f"# Template: {data.get('name', template_name)}",
-            f"Version: {data.get('version', '1.0')}",
-            "",
-            data.get("description", "").strip(),
-            "",
-        ]
-
-        params = data.get("parameters", {})
-        if params:
-            lines += ["## Parameters", ""]
-            for pname, pdef in params.items():
-                lines.append(
-                    f"- **{pname}** ({pdef.get('type', 'any')}): "
-                    f"{pdef.get('description', '')} "
-                    f"[default: {pdef.get('default', '—')}]"
-                )
-            lines.append("")
-
-        symbols = data.get("symbols", [])
-        if symbols:
-            lines += [f"## Symbols ({len(symbols)})", ""]
-            for sym in symbols:
-                lines.append(
-                    f"- **{sym.get('ref_prefix', '?')}?** "
-                    f"{sym.get('value', '?')} — {sym.get('comment', '')}"
-                )
-                left_pins = ", ".join(str(pin) for pin in sym.get("pins_left", []))
-                right_pins = ", ".join(str(pin) for pin in sym.get("pins_right", []))
-                pin_parts: list[str] = []
-                if left_pins:
-                    pin_parts.append(f"left: {left_pins}")
-                if right_pins:
-                    pin_parts.append(f"right: {right_pins}")
-                if pin_parts:
-                    lines.append(f"  Pins: {' | '.join(pin_parts)}")
-            lines.append("")
-
-        nets = data.get("nets", [])
-        if nets:
-            lines += ["## Nets", ""]
-            for net in nets:
-                note = f" — {net['note']}" if net.get("note") else ""
-                lines.append(f"- `{net['name']}` ({net.get('type', 'signal')}){note}")
-            lines.append("")
-
-        hints = data.get("placement_hints", [])
-        if hints:
-            lines += ["## Placement Hints", ""]
-            for hint in hints:
-                lines.append(f"- {hint}")
-            lines.append("")
-
-        search = data.get("part_search_hints", {})
-        if search:
-            lines += ["## Part Search Hints (use with lib_recommend_part())", ""]
-            for role, query in search.items():
-                lines.append(f"- {role}: `{query}`")
-
-        return "\n".join(lines)
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/schematic_template_catalog.py
+++ b/src/kicad_mcp/tools/schematic_template_catalog.py
@@ -1,0 +1,52 @@
+"""Thin FastMCP adapters for the schematic template catalog."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.template_catalog import SchematicTemplateCatalogService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicTemplateCatalogDependencies:
+    """Template-catalog service injected by the schematic composition root."""
+
+    service: SchematicTemplateCatalogService
+
+
+def register(mcp: FastMCP, dependencies: SchematicTemplateCatalogDependencies) -> None:
+    """Register bundled subcircuit template inspection tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_list_templates() -> str:
+        """List all available reference subcircuit templates.
+
+        Templates are pre-wired subcircuit blueprints for common building blocks
+        (buck converter, LDO, USB Type-C, MCU decoupling, Ethernet with magnetics).
+
+        Call sch_get_template_info() for full parameter and placement details,
+        then sch_instantiate_template() to add the subcircuit to the schematic.
+        """
+        return service.list_templates()
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_get_template_info(template_name: str) -> str:
+        """Return full details for a subcircuit template.
+
+        Args:
+            template_name: Template name as returned by sch_list_templates()
+                (e.g. ``"buck_converter_generic"``).
+
+        Returns:
+            Structured template description including parameters, symbols,
+            nets, and placement hints.
+        """
+        return service.template_info(template_name)

--- a/tests/unit/test_schematic_template_catalog_architecture.py
+++ b/tests/unit/test_schematic_template_catalog_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_template_catalog_modules() -> None:
+    assert "kicad_mcp.schematic.template_catalog" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.template_catalog" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_template_catalog" in boundaries.DOMAIN_MODULES
+
+
+def test_template_catalog_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_template_catalog.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_template_catalog"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_template_catalog_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_template_catalog.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_template_catalog"] == 300

--- a/tests/unit/test_schematic_template_catalog_registration.py
+++ b/tests/unit/test_schematic_template_catalog_registration.py
@@ -1,0 +1,87 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_template_catalog import (
+    SchematicTemplateCatalogDependencies,
+    register,
+)
+
+
+class FakeTemplateCatalogService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[str, ...]]] = []
+
+    def list_templates(self) -> str:
+        self.calls.append(("list_templates", ()))
+        return "listing"
+
+    def template_info(self, template_name: str) -> str:
+        self.calls.append(("template_info", (template_name,)))
+        return "details"
+
+
+def _registered() -> tuple[FastMCP, FakeTemplateCatalogService]:
+    server = FastMCP("schematic-template-catalog-test")
+    service = FakeTemplateCatalogService()
+    register(server, SchematicTemplateCatalogDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {"sch_list_templates", "sch_get_template_info"}
+    assert tools["sch_list_templates"].description == (
+        "List all available reference subcircuit templates.\n\n"
+        "Templates are pre-wired subcircuit blueprints for common building blocks\n"
+        "(buck converter, LDO, USB Type-C, MCU decoupling, Ethernet with magnetics).\n\n"
+        "Call sch_get_template_info() for full parameter and placement details,\n"
+        "then sch_instantiate_template() to add the subcircuit to the schematic.\n"
+    )
+    assert tools["sch_get_template_info"].description == (
+        "Return full details for a subcircuit template.\n\n"
+        "Args:\n"
+        "    template_name: Template name as returned by sch_list_templates()\n"
+        '        (e.g. ``"buck_converter_generic"``).\n\n'
+        "Returns:\n"
+        "    Structured template description including parameters, symbols,\n"
+        "    nets, and placement hints.\n"
+    )
+    assert tools["sch_list_templates"].parameters == {
+        "properties": {},
+        "title": "sch_list_templatesArguments",
+        "type": "object",
+    }
+    info_schema = tools["sch_get_template_info"].parameters
+    assert info_schema["required"] == ["template_name"]
+    assert info_schema["properties"] == {
+        "template_name": {"title": "Template Name", "type": "string"}
+    }
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+
+    for tool in server._tool_manager.list_tools():
+        metadata = get_tool_metadata(tool.name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+        assert metadata.requires_kicad_running is False
+        assert tool.annotations is None
+
+
+def test_registration_delegates_all_calls() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_list_templates"].fn() == "listing"
+    assert tools["sch_get_template_info"].fn(template_name="buck_converter_generic") == "details"
+    assert service.calls == [
+        ("list_templates", ()),
+        ("template_info", ("buck_converter_generic",)),
+    ]

--- a/tests/unit/test_schematic_template_catalog_service.py
+++ b/tests/unit/test_schematic_template_catalog_service.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import TextIO
+
+from kicad_mcp.schematic.template_catalog import SchematicTemplateCatalogService
+
+YamlLoader = Callable[[TextIO], object]
+
+
+def _service(
+    templates_dir: Path,
+    *,
+    documents: Mapping[str, object] | None = None,
+    loader_factory: Callable[[], YamlLoader] | None = None,
+) -> SchematicTemplateCatalogService:
+    data = documents or {}
+
+    def load(stream: TextIO) -> object:
+        return data[Path(stream.name).name]
+
+    return SchematicTemplateCatalogService(
+        templates_dir=templates_dir,
+        yaml_loader_factory=loader_factory or (lambda: load),
+    )
+
+
+def test_list_templates_returns_missing_directory_before_loading_yaml(tmp_path: Path) -> None:
+    loaded = False
+
+    def factory() -> YamlLoader:
+        nonlocal loaded
+        loaded = True
+        raise AssertionError("loader must not be requested")
+
+    result = _service(tmp_path / "missing", loader_factory=factory).list_templates()
+
+    assert result == "No subcircuit templates are available."
+    assert loaded is False
+
+
+def test_list_templates_preserves_lazy_pyyaml_error(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+
+    def factory() -> YamlLoader:
+        raise ModuleNotFoundError("yaml")
+
+    assert _service(templates, loader_factory=factory).list_templates() == (
+        "Template tools require PyYAML. Install it to inspect bundled templates."
+    )
+
+
+def test_list_templates_returns_empty_catalog_message(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+
+    assert _service(templates).list_templates() == "No subcircuit templates were found."
+
+
+def test_list_templates_sorts_files_and_preserves_formatting(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "zeta.yaml").write_text("ignored", encoding="utf-8")
+    (templates / "alpha.yaml").write_text("ignored", encoding="utf-8")
+    long_first_line = "A" * 90
+    documents: dict[str, object] = {
+        "alpha.yaml": {
+            "description": f"{long_first_line}\nsecond line",
+            "parameters": {"vin": {}, "vout": {}},
+        },
+        "zeta.yaml": {
+            "name": "Zeta Template",
+            "description": "Simple template",
+            "parameters": {},
+        },
+    }
+
+    result = _service(templates, documents=documents).list_templates()
+
+    assert result == "\n".join(
+        [
+            "# Available Subcircuit Templates",
+            "",
+            "**alpha**",
+            f"  {'A' * 80}",
+            "  Parameters: vin, vout",
+            "",
+            "**Zeta Template**",
+            "  Simple template",
+            "",
+            "Use sch_instantiate_template(template_name, prefix, params) to add.",
+        ]
+    )
+
+
+def test_list_templates_continues_after_per_file_parse_failure(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "bad.yaml").write_text("bad", encoding="utf-8")
+    (templates / "good.yaml").write_text("good", encoding="utf-8")
+
+    def load(stream: TextIO) -> object:
+        if Path(stream.name).name == "bad.yaml":
+            raise ValueError("broken yaml")
+        return {"name": "Good", "description": "Works"}
+
+    result = _service(templates, loader_factory=lambda: load).list_templates()
+
+    assert result == "\n".join(
+        [
+            "# Available Subcircuit Templates",
+            "",
+            "**bad** — (could not parse template)",
+            "",
+            "**Good**",
+            "  Works",
+            "",
+            "Use sch_instantiate_template(template_name, prefix, params) to add.",
+        ]
+    )
+
+
+def test_template_info_reports_missing_name_with_sorted_available_files(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "zeta.yaml").write_text("ignored", encoding="utf-8")
+    (templates / "alpha.yaml").write_text("ignored", encoding="utf-8")
+
+    assert _service(templates).template_info("missing") == (
+        "Template 'missing' not found. Available: alpha, zeta"
+    )
+
+
+def test_template_info_checks_existence_before_loading_yaml(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    loaded = False
+
+    def factory() -> YamlLoader:
+        nonlocal loaded
+        loaded = True
+        raise ModuleNotFoundError("yaml")
+
+    result = _service(templates, loader_factory=factory).template_info("missing")
+
+    assert result == "Template 'missing' not found. Available: "
+    assert loaded is False
+
+
+def test_template_info_preserves_pyyaml_and_parse_errors(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "demo.yaml").write_text("ignored", encoding="utf-8")
+
+    def missing_factory() -> YamlLoader:
+        raise ImportError("yaml")
+
+    def bad_load(_stream: TextIO) -> object:
+        raise ValueError("invalid mapping")
+
+    assert _service(templates, loader_factory=missing_factory).template_info("demo") == (
+        "Template tools require PyYAML. Install it to inspect bundled templates."
+    )
+    assert _service(templates, loader_factory=lambda: bad_load).template_info("demo") == (
+        "Could not parse template 'demo': invalid mapping"
+    )
+
+
+def test_template_info_renders_all_sections_in_source_order(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "demo.yaml").write_text("ignored", encoding="utf-8")
+    documents: dict[str, object] = {
+        "demo.yaml": {
+            "name": "Demo Supply",
+            "version": "2.1",
+            "description": "Two-line description.\nSecond line.",
+            "parameters": {
+                "vin": {
+                    "type": "voltage",
+                    "description": "Input voltage",
+                    "default": 12,
+                },
+                "mode": {"description": "Operating mode"},
+            },
+            "symbols": [
+                {
+                    "ref_prefix": "U",
+                    "value": "REG",
+                    "comment": "Controller",
+                    "pins_left": ["VIN", 2],
+                    "pins_right": ["VOUT"],
+                },
+                {
+                    "value": "C",
+                    "pins_left": [],
+                    "pins_right": [],
+                },
+            ],
+            "nets": [
+                {"name": "VIN", "type": "power", "note": "Input rail"},
+                {"name": "SW"},
+            ],
+            "placement_hints": ["Keep loop short", "Place capacitor close"],
+            "part_search_hints": {
+                "controller": "buck regulator",
+                "inductor": "shielded inductor",
+            },
+        }
+    }
+
+    result = _service(templates, documents=documents).template_info("demo")
+
+    assert result == "\n".join(
+        [
+            "# Template: Demo Supply",
+            "Version: 2.1",
+            "",
+            "Two-line description.\nSecond line.",
+            "",
+            "## Parameters",
+            "",
+            "- **vin** (voltage): Input voltage [default: 12]",
+            "- **mode** (any): Operating mode [default: —]",
+            "",
+            "## Symbols (2)",
+            "",
+            "- **U?** REG — Controller",
+            "  Pins: left: VIN, 2 | right: VOUT",
+            "- **??** C — ",
+            "",
+            "## Nets",
+            "",
+            "- `VIN` (power) — Input rail",
+            "- `SW` (signal)",
+            "",
+            "## Placement Hints",
+            "",
+            "- Keep loop short",
+            "- Place capacitor close",
+            "",
+            "## Part Search Hints (use with lib_recommend_part())",
+            "",
+            "- controller: `buck regulator`",
+            "- inductor: `shielded inductor`",
+        ]
+    )
+
+
+def test_template_info_uses_defaults_and_omits_empty_sections(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "minimal.yaml").write_text("ignored", encoding="utf-8")
+
+    result = _service(
+        templates,
+        documents={"minimal.yaml": {"description": "  Minimal  "}},
+    ).template_info("minimal")
+
+    assert result == "\n".join(
+        [
+            "# Template: minimal",
+            "Version: 1.0",
+            "",
+            "Minimal",
+            "",
+        ]
+    )


### PR DESCRIPTION
## Summary

- extract `sch_list_templates` and `sch_get_template_info` into a FastMCP-independent `SchematicTemplateCatalogService`
- add a thin FastMCP adapter and keep bundled-template path and lazy PyYAML wiring in the schematic composition root
- add direct service, adapter, architecture, and regression coverage
- reduce the main schematic `register()` span from 1,971 to 1,843 lines while keeping the new adapter at 31 lines

## Compatibility

- preserves exact public tool names, descriptions, input schemas, required fields, annotations, sorting, truncation, ordering, formatting, lazy PyYAML behavior, errors, and result strings
- keeps the committed tool-surface snapshot unchanged
- introduces no runtime dependency and no mutation behavior

## Verification

- 155 focused service/adapter/architecture/template/integration checks passed
- 1,714 selected unit tests passed with five expected skips
- extracted service and adapter reached 100% focused line coverage
- metadata, Ruff, mypy, scoped Pyright, architecture, workflow security, strict MkDocs, snapshot, latency, Bandit, dependency audit, and package build gates passed
- Semgrep: 290 rules across five changed files, zero findings
- OSV-Scanner 2.4.0: four lockfiles / 442 dependency entries, zero known vulnerabilities

## Follow-up

Issue #434 remains open for the remaining semantic IR, orchestration, routing, placement, rendering/preview, and template-instantiation tranches.

Refs #434