### PR TITLE
refactor(schematic): extract template instantiation service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-template-instantiation-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-template-instantiation-service.md
@@ -29,12 +29,12 @@
 - Consumes: `templates_dir: pathlib.Path` and `yaml_loader_factory: Callable[[], Callable[[TextIO], Any]]`
 - Produces: `SchematicTemplateInstantiationService.instantiate(template_name: str, prefix: str = "", params: dict[str, object] | None = None) -> str`
 
-- [ ] Write direct tests that assert exact missing-template, absent-PyYAML, parse-error, defaults/overrides, prefix trimming, symbol numbering, net rendering, search substitution, empty-search fallback, placement-hint, and final Markdown behavior.
-- [ ] Run `PYTHONPATH="$PWD/src" <python> -m pytest -q tests/unit/test_schematic_template_instantiation_service.py`; expect collection failure because the service module is absent.
-- [ ] Implement the minimal injected service by moving the existing behavior without altering output text.
-- [ ] Re-run the service tests; expect all pass.
-- [ ] Run Ruff, mypy, and scoped Pyright for the new service and test.
-- [ ] Commit with `refactor(schematic): extract template instantiation service`.
+- [x] Write direct tests that assert exact missing-template, absent-PyYAML, parse-error, defaults/overrides, prefix trimming, symbol numbering, net rendering, search substitution, empty-search fallback, placement-hint, and final Markdown behavior.
+- [x] Run `PYTHONPATH="$PWD/src" <python> -m pytest -q tests/unit/test_schematic_template_instantiation_service.py`; expect collection failure because the service module is absent.
+- [x] Implement the minimal injected service by moving the existing behavior without altering output text.
+- [x] Re-run the service tests; expect all pass.
+- [x] Run Ruff, mypy, and scoped Pyright for the new service and test.
+- [x] Commit with `refactor(schematic): extract template instantiation service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -48,11 +48,11 @@
 - Produces: `SchematicTemplateInstantiationDependencies(service: SchematicTemplateInstantiationService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicTemplateInstantiationDependencies) -> None`
 
-- [ ] Write adapter tests for the exact name `sch_instantiate_template`, unchanged docstring/description, schema and required fields, headless metadata, default arguments, argument forwarding, and service delegation.
-- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
-- [ ] Implement the adapter, add service construction and registration to the composition root, and remove the nested legacy tool function.
-- [ ] Run service, adapter, focused integration, schematic-authoring surface, and bundled-template tests; expect all pass.
-- [ ] Commit with `refactor(schematic): delegate template instantiation registration`.
+- [x] Write adapter tests for the exact name `sch_instantiate_template`, unchanged docstring/description, schema and required fields, headless metadata, default arguments, argument forwarding, and service delegation.
+- [x] Run the adapter test; expect collection failure because the adapter module is absent.
+- [x] Implement the adapter, add service construction and registration to the composition root, and remove the nested legacy tool function.
+- [x] Run service, adapter, focused integration, schematic-authoring surface, and bundled-template tests; expect all pass.
+- [x] Commit with `refactor(schematic): delegate template instantiation registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -64,21 +64,35 @@
 - Consumes: architecture policy maps `DOMAIN_MODULES`, `PURE_HELPERS`, `FORBIDDEN_IMPORTS`, and `REGISTER_LINE_LIMITS`
 - Produces: service purity, adapter isolation, and a 300-line registration limit for the new modules
 
-- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding adapter imports from the monolith, and enforcing the 300-line limit.
-- [ ] Run the architecture test; expect failure because policy entries are absent.
-- [ ] Add the new modules to the architecture checker and re-run the focused architecture test plus `scripts/check_architecture_boundaries.py`.
-- [ ] Run the committed tool-surface snapshot and compare the focused tool metadata against `main`; expect exact equality.
-- [ ] Commit with `test(architecture): guard template instantiation boundaries`.
+- [x] Write failing architecture tests requiring the service and adapter to be tracked, forbidding adapter imports from the monolith, and enforcing the 300-line limit.
+- [x] Run the architecture test; expect failure because policy entries are absent.
+- [x] Add the new modules to the architecture checker and re-run the focused architecture test plus `scripts/check_architecture_boundaries.py`.
+- [x] Run the committed tool-surface snapshot and compare the focused tool metadata against `main`; expect exact equality.
+- [x] Commit with `test(architecture): guard template instantiation boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-template-instantiation-service.md`
 
-- [ ] Run focused coverage for the service and adapter and require at least 83%.
-- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, generated-doc checks, tool-surface snapshot, focused integration, and the full unit suite.
-- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes in this plan.
-- [ ] Commit with `docs(architecture): record template instantiation evidence`.
+- [x] Run focused coverage for the service and adapter and require at least 83%.
+- [x] Run formatting, Ruff, mypy, scoped Pyright, architecture, generated-doc checks, tool-surface snapshot, focused integration, and the full unit suite.
+- [x] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes in this plan.
+- [x] Commit with `docs(architecture): record template instantiation evidence`.
+
+## Verification Evidence
+
+- Exact full-server metadata for `sch_instantiate_template` matches `main`: name, description, input schema, required fields, defaults, output schema, annotations, headless metadata, and argument ordering are identical.
+- The committed tool-surface snapshot passes without regeneration.
+- The main schematic `register()` span decreased from 1,843 to 1,745 lines; the template-instantiation adapter `register()` spans 31 lines.
+- Direct service and adapter tests passed with 100% focused line coverage across 70 statements.
+- Focused service, registration, architecture, bundled-template integration, authoring-surface, and tool-surface verification passed across 16 tests.
+- The full unit suite passed with 1,724 selected tests, six expected skips, the existing KiCad CLI availability warnings, and the existing Windows-daemon async-mock warning.
+- Metadata synchronization, MCP manifest, Docker metadata, generated tool docs, capability parity, toolsets, progressive-disclosure profiles, adapter matrix, tool contracts, architecture, compatibility matrix, runtime policy, formatting, Ruff, mypy, scoped strict Pyright, strict MkDocs, and the latency benchmark all pass.
+- Bandit reported no medium/high findings across 59,888 lines, pip-audit reported no known vulnerabilities, GitHub Actions policy passed for 24 workflows, actionlint parsed/linted all 24 workflows, and zizmor reported no high-severity findings.
+- Source and wheel builds plus package metadata validation pass.
+- The repository bootstrap hit an exec-agent filesystem `EPERM` while packaging `actionlint-py`; the remaining 184 dependencies installed from the frozen lock, and the downloaded checksum-backed actionlint binary was used to complete the workflow lint gate.
+- No runtime dependency, template schema, public tool contract, lazy PyYAML behavior, fallback ordering, parameter resolution, reference numbering, search substitution, error message, or Markdown result changed.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/plans/2026-07-23-schematic-template-instantiation-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-template-instantiation-service.md
@@ -1,0 +1,89 @@
+# Schematic Template Instantiation Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `sch_instantiate_template` from the monolithic schematic FastMCP registry into a directly testable service and thin adapter without changing its public contract.
+
+**Architecture:** Add one FastMCP-free template-instantiation service and one thin registration adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root by injecting the bundled template directory and the existing lazy YAML loader factory.
+
+**Tech Stack:** Python 3.13, FastMCP, PyYAML, pytest, Ruff, mypy, Pyright, existing architecture and metadata generators.
+
+## Global Constraints
+
+- Preserve the exact public tool name, signature, description, schema, annotations, argument ordering, lazy PyYAML behavior, error messages, and Markdown output.
+- Do not change template schemas or add direct schematic mutation.
+- Do not change `sch_list_templates`, `sch_get_template_info`, or semantic IR behavior.
+- Keep the adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Keep the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free template instantiation service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/template_instantiation.py`
+- Create: `tests/unit/test_schematic_template_instantiation_service.py`
+
+**Interfaces:**
+- Consumes: `templates_dir: pathlib.Path` and `yaml_loader_factory: Callable[[], Callable[[TextIO], Any]]`
+- Produces: `SchematicTemplateInstantiationService.instantiate(template_name: str, prefix: str = "", params: dict[str, object] | None = None) -> str`
+
+- [ ] Write direct tests that assert exact missing-template, absent-PyYAML, parse-error, defaults/overrides, prefix trimming, symbol numbering, net rendering, search substitution, empty-search fallback, placement-hint, and final Markdown behavior.
+- [ ] Run `PYTHONPATH="$PWD/src" <python> -m pytest -q tests/unit/test_schematic_template_instantiation_service.py`; expect collection failure because the service module is absent.
+- [ ] Implement the minimal injected service by moving the existing behavior without altering output text.
+- [ ] Re-run the service tests; expect all pass.
+- [ ] Run Ruff, mypy, and scoped Pyright for the new service and test.
+- [ ] Commit with `refactor(schematic): extract template instantiation service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_template_instantiation.py`
+- Create: `tests/unit/test_schematic_template_instantiation_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicTemplateInstantiationService`
+- Produces: `SchematicTemplateInstantiationDependencies(service: SchematicTemplateInstantiationService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicTemplateInstantiationDependencies) -> None`
+
+- [ ] Write adapter tests for the exact name `sch_instantiate_template`, unchanged docstring/description, schema and required fields, headless metadata, default arguments, argument forwarding, and service delegation.
+- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
+- [ ] Implement the adapter, add service construction and registration to the composition root, and remove the nested legacy tool function.
+- [ ] Run service, adapter, focused integration, schematic-authoring surface, and bundled-template tests; expect all pass.
+- [ ] Commit with `refactor(schematic): delegate template instantiation registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_template_instantiation_architecture.py`
+
+**Interfaces:**
+- Consumes: architecture policy maps `DOMAIN_MODULES`, `PURE_HELPERS`, `FORBIDDEN_IMPORTS`, and `REGISTER_LINE_LIMITS`
+- Produces: service purity, adapter isolation, and a 300-line registration limit for the new modules
+
+- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding adapter imports from the monolith, and enforcing the 300-line limit.
+- [ ] Run the architecture test; expect failure because policy entries are absent.
+- [ ] Add the new modules to the architecture checker and re-run the focused architecture test plus `scripts/check_architecture_boundaries.py`.
+- [ ] Run the committed tool-surface snapshot and compare the focused tool metadata against `main`; expect exact equality.
+- [ ] Commit with `test(architecture): guard template instantiation boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-template-instantiation-service.md`
+
+- [ ] Run focused coverage for the service and adapter and require at least 83%.
+- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, generated-doc checks, tool-surface snapshot, focused integration, and the full unit suite.
+- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes in this plan.
+- [ ] Commit with `docs(architecture): record template instantiation evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push the branch and open a professional English PR referencing #434.
+- [ ] Inspect CI, bot comments, reviews, and review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/specs/2026-07-23-schematic-template-instantiation-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-template-instantiation-service-design.md
@@ -1,0 +1,73 @@
+# Schematic Template Instantiation Service Design
+
+## Context
+
+Issue #434 is incrementally reducing `src/kicad_mcp/tools/schematic.py` into a small FastMCP composition root. The template catalog tranche extracted read-only discovery and detail rendering, but `sch_instantiate_template` still combines registration, bundled-path resolution, optional YAML loading, parameter resolution, and Markdown action-plan rendering in the monolithic registry.
+
+This tranche extracts only `sch_instantiate_template`.
+
+## Goals
+
+- Make template action-plan generation directly unit-testable without FastMCP.
+- Preserve the exact public tool name, signature, description, schema, annotations, argument ordering, lazy PyYAML behavior, error messages, and Markdown output.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep the service independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Reduce the main schematic `register()` span through one bounded, reviewable change.
+
+## Non-goals
+
+- No template schema changes.
+- No direct schematic mutation or automatic execution of the generated plan.
+- No changes to `sch_list_templates` or `sch_get_template_info`.
+- No semantic circuit IR extraction.
+- No new runtime dependencies.
+
+## Architecture
+
+Create `SchematicTemplateInstantiationService` in `src/kicad_mcp/schematic/template_instantiation.py`. The service receives the fixed bundled template directory and a lazy YAML loader factory. It owns file lookup, parse handling, parameter default/override resolution, reference-prefix formatting, and exact Markdown rendering.
+
+Create `src/kicad_mcp/tools/schematic_template_instantiation.py` as the thin FastMCP adapter. It preserves the existing function signature and docstring and delegates to the service.
+
+Keep `src/kicad_mcp/tools/schematic.py` as the composition root. It constructs the service with the existing bundled template path and `_template_yaml_loader_factory`, registers the adapter, and removes the nested legacy implementation.
+
+## Service Interface
+
+```python
+@dataclass(frozen=True)
+class SchematicTemplateInstantiationService:
+    templates_dir: Path
+    yaml_loader_factory: Callable[[], YamlLoader]
+
+    def instantiate(
+        self,
+        template_name: str,
+        prefix: str = "",
+        params: dict[str, object] | None = None,
+    ) -> str: ...
+```
+
+## Behavior Preservation
+
+- Resolve `<template_name>.yaml` under the fixed bundled catalog directory.
+- Preserve sorted available-template names when the requested file is missing.
+- Import PyYAML lazily and retain the exact installation message.
+- Retain the exact template-specific parse-error message.
+- Resolve declared parameter defaults, then apply caller overrides.
+- Preserve declaration order for parameters, symbols, nets, search hints, and placement hints.
+- Preserve current symbol numbering and prefix trimming.
+- Preserve placeholder substitution in part-search queries.
+- Preserve the existing empty-search fallback and exact Markdown layout.
+
+## Security and Path Scope
+
+The public path behavior remains unchanged. The service joins the caller-provided name with the fixed catalog directory and appends `.yaml`; it does not broaden filesystem access or introduce mutation behavior.
+
+## Testing
+
+Direct service tests cover missing templates, absent PyYAML, parse failures, defaults and overrides, trimmed prefixes, symbol numbering, nets, search substitution, empty search fallback, placement hints, and exact output text.
+
+Adapter tests cover the exact public name, description, schema, required fields, headless metadata, argument forwarding, and delegation. Architecture tests enforce service purity, adapter isolation, and the 300-line registration limit. Focused integration and tool-surface snapshot tests prove that the public contract remains unchanged.
+
+## Expected Result
+
+The main schematic `register()` function loses approximately 100 lines. Template instantiation behavior becomes independently testable while the observable MCP contract remains unchanged.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -56,6 +56,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "template_catalog.py",
+    "kicad_mcp.schematic.template_instantiation": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "template_instantiation.py",
     "kicad_mcp.schematic.topology": SRC_ROOT / "kicad_mcp" / "schematic" / "topology.py",
     "kicad_mcp.tools.schematic_back_annotation": SRC_ROOT
     / "kicad_mcp"
@@ -81,6 +85,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_template_catalog.py",
+    "kicad_mcp.tools.schematic_template_instantiation": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_template_instantiation.py",
     "kicad_mcp.tools.schematic_topology": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -122,6 +130,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.layout_inspection",
     "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.template_catalog",
+    "kicad_mcp.schematic.template_instantiation",
     "kicad_mcp.schematic.topology",
     "kicad_mcp.tools.schematic_constants",
 }
@@ -147,6 +156,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_template_catalog": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_template_instantiation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_topology": ("kicad_mcp.tools.schematic",),
 }
 
@@ -160,6 +170,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_layout_inspection": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_template_catalog": 300,
+    "kicad_mcp.tools.schematic_template_instantiation": 300,
     "kicad_mcp.tools.schematic_topology": 300,
 }
 

--- a/src/kicad_mcp/schematic/template_instantiation.py
+++ b/src/kicad_mcp/schematic/template_instantiation.py
@@ -1,0 +1,108 @@
+"""FastMCP-independent bundled subcircuit template instantiation services."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+YamlLoader = Callable[[TextIO], Any]
+
+
+@dataclass(frozen=True)
+class SchematicTemplateInstantiationService:
+    """Render action plans for bundled subcircuit templates."""
+
+    templates_dir: Path
+    yaml_loader_factory: Callable[[], YamlLoader]
+
+    def instantiate(
+        self,
+        template_name: str,
+        prefix: str = "",
+        params: dict[str, object] | None = None,
+    ) -> str:
+        yaml_file = self.templates_dir / f"{template_name}.yaml"
+        if not yaml_file.exists():
+            available = [path.stem for path in self.templates_dir.glob("*.yaml")]
+            return (
+                f"Template '{template_name}' not found. Available: {', '.join(sorted(available))}"
+            )
+
+        try:
+            load_yaml = self.yaml_loader_factory()
+            with yaml_file.open(encoding="utf-8") as stream:
+                data = load_yaml(stream)
+        except ImportError:
+            return "Template tools require PyYAML. Install it to instantiate templates."
+        except Exception as exc:
+            return f"Could not parse template '{template_name}': {exc}"
+
+        params = params or {}
+        defaults = {key: value.get("default") for key, value in data.get("parameters", {}).items()}
+        resolved = {**defaults, **params}
+
+        symbols = data.get("symbols", [])
+        nets = data.get("nets", [])
+        hints = data.get("placement_hints", [])
+        search = data.get("part_search_hints", {})
+        prefix_str = prefix.strip()
+
+        lines = [
+            f"# Instantiation Plan: {data.get('name', template_name)}",
+            f"Prefix: `{prefix_str or '(none)'}`",
+            "",
+            "## Parameters",
+        ]
+        for key, value in resolved.items():
+            lines.append(f"- {key}: **{value}**")
+
+        lines += [
+            "",
+            "## Step 1: Add Symbols",
+            "Call sch_add_symbol() for each symbol below:",
+            "",
+        ]
+        for index, symbol in enumerate(symbols, start=1):
+            reference = f"{prefix_str}{symbol.get('ref_prefix', 'X')}{index}"
+            lines.append(
+                f"- `sch_add_symbol(reference={reference!r}, value={symbol.get('value', '?')!r})`"
+            )
+            lines.append(f"  Comment: {symbol.get('comment', '')}")
+            lines.append(f"  Footprint hint: {symbol.get('default_footprint', '—')}")
+
+        lines += [
+            "",
+            "## Step 2: Add Nets / Wires",
+            "Call sch_add_power_symbol() and sch_add_wire() to connect:",
+            "",
+        ]
+        for net in nets:
+            note = f" ({net['note']})" if net.get("note") else ""
+            lines.append(f"- `{net['name']}` — {net.get('type', 'signal')}{note}")
+
+        lines += ["", "## Step 3: Part Selection"]
+        if search:
+            for role, query_template in search.items():
+                query = str(query_template)
+                for key, value in resolved.items():
+                    query = query.replace(f"{{{key}}}", str(value))
+                lines.append(f"- **{role}**: `lib_recommend_part(category={query!r})`")
+        else:
+            lines.append("- Use lib_search_components() or lib_recommend_part() for each symbol.")
+
+        lines += [
+            "",
+            "## Step 4: Footprint Assignment",
+            (
+                "For each symbol: `lib_bind_part_to_symbol(sym_ref, lcsc_code, "
+                "auto_assign_footprint=True)`"
+            ),
+            "",
+            "## Placement Hints",
+        ]
+        for hint in hints:
+            lines.append(f"- {hint}")
+
+        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -51,6 +51,7 @@ from ..schematic.inspection import SchematicInspectionService
 from ..schematic.layout_inspection import SchematicLayoutInspectionService
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
 from ..schematic.template_catalog import SchematicTemplateCatalogService
+from ..schematic.template_instantiation import SchematicTemplateInstantiationService
 from ..schematic.topology import SchematicTopologyService
 from ..utils.cache import clear_ttl_cache, ttl_cache
 from ..utils.field_placer import FieldSpec, autoplace_fields
@@ -74,6 +75,7 @@ from . import (
     schematic_layout_inspection,
     schematic_symbol_mutation,
     schematic_template_catalog,
+    schematic_template_instantiation,
     schematic_topology,
 )
 from .metadata import headless_compatible
@@ -5530,6 +5532,17 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    template_instantiation_service = SchematicTemplateInstantiationService(
+        templates_dir=Path(__file__).parent.parent / "templates" / "subcircuits",
+        yaml_loader_factory=_template_yaml_loader_factory,
+    )
+    schematic_template_instantiation.register(
+        mcp,
+        schematic_template_instantiation.SchematicTemplateInstantiationDependencies(
+            service=template_instantiation_service,
+        ),
+    )
+
     topology_service = SchematicTopologyService(
         load_schematic=_load_kicad_schematic,
         with_diagnostics=_with_schematic_diagnostics,
@@ -7193,114 +7206,5 @@ def register(mcp: FastMCP) -> None:
                     f"- [{f.severity.value.upper()}] {f.rule_id}"
                     f"{subject_tag}: {f.message}{detail_tag}"
                 )
-
-        return "\n".join(lines)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_instantiate_template(
-        template_name: str,
-        prefix: str = "",
-        params: dict[str, object] | None = None,
-    ) -> str:
-        """Instantiate a subcircuit template — returns a structured action plan.
-
-        This tool returns a structured plan describing the symbols, connections,
-        and part-search steps needed to add the subcircuit to the schematic.
-        It does NOT directly edit the schematic (use the plan as a guide for
-        calling sch_add_symbol, sch_add_wire, lib_recommend_part, etc.).
-
-        Args:
-            template_name: Template name (from sch_list_templates()).
-            prefix: Reference prefix applied to all template refs (e.g. ``"PWR_"``
-                produces ``PWR_U1``, ``PWR_L1``, etc.).
-            params: Dict of parameter overrides (e.g. ``{"vout_v": 5.0}``).
-
-        Returns:
-            Step-by-step instantiation plan in markdown format.
-        """
-        from pathlib import Path as _Path
-
-        templates_dir = _Path(__file__).parent.parent / "templates" / "subcircuits"
-        yaml_file = templates_dir / f"{template_name}.yaml"
-        if not yaml_file.exists():
-            available = [f.stem for f in templates_dir.glob("*.yaml")]
-            return (
-                f"Template '{template_name}' not found. Available: {', '.join(sorted(available))}"
-            )
-
-        try:
-            import yaml
-
-            with yaml_file.open(encoding="utf-8") as fh:
-                data = yaml.safe_load(fh)
-        except ImportError:
-            return "Template tools require PyYAML. Install it to instantiate templates."
-        except Exception as exc:
-            return f"Could not parse template '{template_name}': {exc}"
-
-        params = params or {}
-        defaults = {k: v.get("default") for k, v in data.get("parameters", {}).items()}
-        resolved = {**defaults, **params}
-
-        symbols = data.get("symbols", [])
-        nets = data.get("nets", [])
-        hints = data.get("placement_hints", [])
-        search = data.get("part_search_hints", {})
-        prefix_str = prefix.strip()
-
-        lines = [
-            f"# Instantiation Plan: {data.get('name', template_name)}",
-            f"Prefix: `{prefix_str or '(none)'}`",
-            "",
-            "## Parameters",
-        ]
-        for k, v in resolved.items():
-            lines.append(f"- {k}: **{v}**")
-
-        lines += [
-            "",
-            "## Step 1: Add Symbols",
-            "Call sch_add_symbol() for each symbol below:",
-            "",
-        ]
-        for i, sym in enumerate(symbols, start=1):
-            ref = f"{prefix_str}{sym.get('ref_prefix', 'X')}{i}"
-            lines.append(f"- `sch_add_symbol(reference={ref!r}, value={sym.get('value', '?')!r})`")
-            lines.append(f"  Comment: {sym.get('comment', '')}")
-            lines.append(f"  Footprint hint: {sym.get('default_footprint', '—')}")
-
-        lines += [
-            "",
-            "## Step 2: Add Nets / Wires",
-            "Call sch_add_power_symbol() and sch_add_wire() to connect:",
-            "",
-        ]
-        for net in nets:
-            note = f" ({net['note']})" if net.get("note") else ""
-            lines.append(f"- `{net['name']}` — {net.get('type', 'signal')}{note}")
-
-        lines += ["", "## Step 3: Part Selection"]
-        if search:
-            for role, query_template in search.items():
-                query = str(query_template)
-                for k, v in resolved.items():
-                    query = query.replace(f"{{{k}}}", str(v))
-                lines.append(f"- **{role}**: `lib_recommend_part(category={query!r})`")
-        else:
-            lines.append("- Use lib_search_components() or lib_recommend_part() for each symbol.")
-
-        lines += [
-            "",
-            "## Step 4: Footprint Assignment",
-            (
-                "For each symbol: `lib_bind_part_to_symbol(sym_ref, lcsc_code, "
-                "auto_assign_footprint=True)`"
-            ),
-            "",
-            "## Placement Hints",
-        ]
-        for hint in hints:
-            lines.append(f"- {hint}")
 
         return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic_template_instantiation.py
+++ b/src/kicad_mcp/tools/schematic_template_instantiation.py
@@ -1,0 +1,52 @@
+"""Thin FastMCP adapter for schematic template instantiation."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.template_instantiation import SchematicTemplateInstantiationService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicTemplateInstantiationDependencies:
+    """Template-instantiation service injected by the schematic composition root."""
+
+    service: SchematicTemplateInstantiationService
+
+
+def register(
+    mcp: FastMCP,
+    dependencies: SchematicTemplateInstantiationDependencies,
+) -> None:
+    """Register bundled subcircuit template instantiation tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_instantiate_template(
+        template_name: str,
+        prefix: str = "",
+        params: dict[str, object] | None = None,
+    ) -> str:
+        """Instantiate a subcircuit template — returns a structured action plan.
+
+        This tool returns a structured plan describing the symbols, connections,
+        and part-search steps needed to add the subcircuit to the schematic.
+        It does NOT directly edit the schematic (use the plan as a guide for
+        calling sch_add_symbol, sch_add_wire, lib_recommend_part, etc.).
+
+        Args:
+            template_name: Template name (from sch_list_templates()).
+            prefix: Reference prefix applied to all template refs (e.g. ``"PWR_"``
+                produces ``PWR_U1``, ``PWR_L1``, etc.).
+            params: Dict of parameter overrides (e.g. ``{"vout_v": 5.0}``).
+
+        Returns:
+            Step-by-step instantiation plan in markdown format.
+        """
+        return service.instantiate(template_name, prefix, params)

--- a/tests/unit/test_schematic_template_instantiation_architecture.py
+++ b/tests/unit/test_schematic_template_instantiation_architecture.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_template_instantiation_modules() -> None:
+    assert "kicad_mcp.schematic.template_instantiation" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.template_instantiation" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_template_instantiation" in boundaries.DOMAIN_MODULES
+
+
+def test_template_instantiation_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_template_instantiation.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_template_instantiation"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_template_instantiation_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_template_instantiation.py"
+    assert _function_span(adapter, "register") <= 300
+    assert (
+        boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_template_instantiation"] == 300
+    )

--- a/tests/unit/test_schematic_template_instantiation_registration.py
+++ b/tests/unit/test_schematic_template_instantiation_registration.py
@@ -1,0 +1,101 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_template_instantiation import (
+    SchematicTemplateInstantiationDependencies,
+    register,
+)
+
+
+class FakeTemplateInstantiationService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def instantiate(
+        self,
+        template_name: str,
+        prefix: str = "",
+        params: dict[str, object] | None = None,
+    ) -> str:
+        self.calls.append((template_name, prefix, params))
+        return "plan"
+
+
+def _registered() -> tuple[FastMCP, FakeTemplateInstantiationService]:
+    server = FastMCP("schematic-template-instantiation-test")
+    service = FakeTemplateInstantiationService()
+    register(server, SchematicTemplateInstantiationDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_name_description_and_schema() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {"sch_instantiate_template"}
+    tool = tools["sch_instantiate_template"]
+    assert tool.description == (
+        "Instantiate a subcircuit template — returns a structured action plan.\n\n"
+        "This tool returns a structured plan describing the symbols, connections,\n"
+        "and part-search steps needed to add the subcircuit to the schematic.\n"
+        "It does NOT directly edit the schematic (use the plan as a guide for\n"
+        "calling sch_add_symbol, sch_add_wire, lib_recommend_part, etc.).\n\n"
+        "Args:\n"
+        "    template_name: Template name (from sch_list_templates()).\n"
+        '    prefix: Reference prefix applied to all template refs (e.g. ``"PWR_"``\n'
+        "        produces ``PWR_U1``, ``PWR_L1``, etc.).\n"
+        '    params: Dict of parameter overrides (e.g. ``{"vout_v": 5.0}``).\n\n'
+        "Returns:\n"
+        "    Step-by-step instantiation plan in markdown format.\n"
+    )
+    assert tool.parameters == {
+        "properties": {
+            "template_name": {"title": "Template Name", "type": "string"},
+            "prefix": {"default": "", "title": "Prefix", "type": "string"},
+            "params": {
+                "anyOf": [
+                    {"additionalProperties": True, "type": "object"},
+                    {"type": "null"},
+                ],
+                "default": None,
+                "title": "Params",
+            },
+        },
+        "required": ["template_name"],
+        "title": "sch_instantiate_templateArguments",
+        "type": "object",
+    }
+
+
+def test_registration_preserves_headless_metadata_and_annotations() -> None:
+    server, _service = _registered()
+    tool = server._tool_manager.list_tools()[0]
+    metadata = get_tool_metadata(tool.name)
+
+    assert metadata is not None
+    assert metadata.headless_compatible is True
+    assert metadata.requires_kicad_running is False
+    assert tool.annotations is None
+
+
+def test_registration_delegates_defaults_and_arguments() -> None:
+    server, service = _registered()
+    tool = server._tool_manager.list_tools()[0]
+
+    assert tool.fn(template_name="minimal") == "plan"
+    assert (
+        tool.fn(
+            template_name="buzzer_nmos_driver",
+            prefix="AUD_",
+            params={"supply_v": 5.0},
+        )
+        == "plan"
+    )
+    assert service.calls == [
+        ("minimal", "", None),
+        ("buzzer_nmos_driver", "AUD_", {"supply_v": 5.0}),
+    ]

--- a/tests/unit/test_schematic_template_instantiation_service.py
+++ b/tests/unit/test_schematic_template_instantiation_service.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import TextIO
+
+from kicad_mcp.schematic.template_instantiation import (
+    SchematicTemplateInstantiationService,
+)
+
+YamlLoader = Callable[[TextIO], object]
+
+
+def _service(
+    templates_dir: Path,
+    *,
+    documents: Mapping[str, object] | None = None,
+    loader_factory: Callable[[], YamlLoader] | None = None,
+) -> SchematicTemplateInstantiationService:
+    data = documents or {}
+
+    def load(stream: TextIO) -> object:
+        return data[Path(stream.name).name]
+
+    return SchematicTemplateInstantiationService(
+        templates_dir=templates_dir,
+        yaml_loader_factory=loader_factory or (lambda: load),
+    )
+
+
+def test_instantiate_reports_missing_name_with_sorted_available_files(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "zeta.yaml").write_text("ignored", encoding="utf-8")
+    (templates / "alpha.yaml").write_text("ignored", encoding="utf-8")
+    loaded = False
+
+    def factory() -> YamlLoader:
+        nonlocal loaded
+        loaded = True
+        raise AssertionError("loader must not be requested")
+
+    result = _service(templates, loader_factory=factory).instantiate("missing", prefix=" TEST ")
+
+    assert result == "Template 'missing' not found. Available: alpha, zeta"
+    assert loaded is False
+
+
+def test_instantiate_preserves_pyyaml_and_parse_errors(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "demo.yaml").write_text("ignored", encoding="utf-8")
+
+    def missing_factory() -> YamlLoader:
+        raise ModuleNotFoundError("yaml")
+
+    def bad_load(_stream: TextIO) -> object:
+        raise ValueError("invalid mapping")
+
+    assert _service(templates, loader_factory=missing_factory).instantiate("demo") == (
+        "Template tools require PyYAML. Install it to instantiate templates."
+    )
+    assert _service(templates, loader_factory=lambda: bad_load).instantiate("demo") == (
+        "Could not parse template 'demo': invalid mapping"
+    )
+
+
+def test_instantiate_renders_exact_action_plan_with_overrides(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "demo.yaml").write_text("ignored", encoding="utf-8")
+    documents: dict[str, object] = {
+        "demo.yaml": {
+            "name": "Demo Supply",
+            "parameters": {
+                "vin": {"default": 12},
+                "mode": {"default": "eco"},
+            },
+            "symbols": [
+                {
+                    "ref_prefix": "U",
+                    "value": "REG",
+                    "comment": "Controller",
+                    "default_footprint": "Package_SO:SOIC-8",
+                },
+                {
+                    "value": "C",
+                    "comment": "Output capacitor",
+                },
+            ],
+            "nets": [
+                {"name": "VIN", "type": "power", "note": "Input rail"},
+                {"name": "SW"},
+            ],
+            "part_search_hints": {
+                "controller": "{vin}V {mode} regulator",
+                "capacitor": "capacitor {extra}",
+            },
+            "placement_hints": ["Keep loop short", "Place capacitor close"],
+        }
+    }
+
+    result = _service(templates, documents=documents).instantiate(
+        "demo",
+        prefix="  AUD_  ",
+        params={"vin": 5.0, "extra": "low-esr"},
+    )
+
+    assert result == "\n".join(
+        [
+            "# Instantiation Plan: Demo Supply",
+            "Prefix: `AUD_`",
+            "",
+            "## Parameters",
+            "- vin: **5.0**",
+            "- mode: **eco**",
+            "- extra: **low-esr**",
+            "",
+            "## Step 1: Add Symbols",
+            "Call sch_add_symbol() for each symbol below:",
+            "",
+            "- `sch_add_symbol(reference='AUD_U1', value='REG')`",
+            "  Comment: Controller",
+            "  Footprint hint: Package_SO:SOIC-8",
+            "- `sch_add_symbol(reference='AUD_X2', value='C')`",
+            "  Comment: Output capacitor",
+            "  Footprint hint: —",
+            "",
+            "## Step 2: Add Nets / Wires",
+            "Call sch_add_power_symbol() and sch_add_wire() to connect:",
+            "",
+            "- `VIN` — power (Input rail)",
+            "- `SW` — signal",
+            "",
+            "## Step 3: Part Selection",
+            "- **controller**: `lib_recommend_part(category='5.0V eco regulator')`",
+            "- **capacitor**: `lib_recommend_part(category='capacitor low-esr')`",
+            "",
+            "## Step 4: Footprint Assignment",
+            (
+                "For each symbol: `lib_bind_part_to_symbol(sym_ref, lcsc_code, "
+                "auto_assign_footprint=True)`"
+            ),
+            "",
+            "## Placement Hints",
+            "- Keep loop short",
+            "- Place capacitor close",
+        ]
+    )
+
+
+def test_instantiate_preserves_empty_search_and_hint_fallbacks(tmp_path: Path) -> None:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "minimal.yaml").write_text("ignored", encoding="utf-8")
+    documents: dict[str, object] = {
+        "minimal.yaml": {
+            "symbols": [],
+            "nets": [],
+            "parameters": {},
+        }
+    }
+
+    result = _service(templates, documents=documents).instantiate("minimal")
+
+    assert result == "\n".join(
+        [
+            "# Instantiation Plan: minimal",
+            "Prefix: `(none)`",
+            "",
+            "## Parameters",
+            "",
+            "## Step 1: Add Symbols",
+            "Call sch_add_symbol() for each symbol below:",
+            "",
+            "",
+            "## Step 2: Add Nets / Wires",
+            "Call sch_add_power_symbol() and sch_add_wire() to connect:",
+            "",
+            "",
+            "## Step 3: Part Selection",
+            "- Use lib_search_components() or lib_recommend_part() for each symbol.",
+            "",
+            "## Step 4: Footprint Assignment",
+            (
+                "For each symbol: `lib_bind_part_to_symbol(sym_ref, lcsc_code, "
+                "auto_assign_footprint=True)`"
+            ),
+            "",
+            "## Placement Hints",
+        ]
+    )


### PR DESCRIPTION
## Summary

- extract `sch_instantiate_template` behavior into a FastMCP-independent domain service
- add a thin registration adapter and keep `schematic.py` as the composition root
- add direct service, registration, and architecture boundary tests
- preserve the complete public MCP contract and generated tool surface

## Verification

- exact full-server metadata equality with `main`
- 100% focused coverage across the new service and adapter
- 1,724 selected unit tests passed with expected skips/warnings only
- formatting, Ruff, mypy, scoped Pyright, architecture, generated metadata/docs, compatibility, strict MkDocs, latency, security, workflow, and package gates passed

## Architecture impact

- `src/kicad_mcp/tools/schematic.py::register` reduced from 1,843 to 1,745 lines
- new adapter `register()` spans 31 lines

Part of #434.
