### PR TITLE
refactor(schematic): extract semantic IR service

### DIFF
--- a/docs/superpowers/plans/2026-07-23-schematic-semantic-ir-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-semantic-ir-service.md
@@ -1,0 +1,84 @@
+# Schematic Semantic IR Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `sch_get_circuit_ir` from the monolithic schematic FastMCP registry into a directly testable service and thin adapter without changing its public contract or lazy import behavior.
+
+**Architecture:** Add one FastMCP-free semantic-IR service with structural protocols and injected parser/linter dependencies, plus one thin registration adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root and retain lazy `kicad_mcp.ir` imports through dependency wrappers to avoid a circular import.
+
+**Tech Stack:** Python 3.13, FastMCP, pytest, Ruff, mypy, Pyright, existing semantic IR and architecture tooling.
+
+## Global Constraints
+
+- Preserve the exact public tool name, signature, description, schema, annotations, ten-second TTL cache, lazy imports, log event, diagnostics, sorting, truncation, formatting, and result text.
+- Do not change IR models, parser behavior, lint rules, output format, or runtime dependencies.
+- Keep the adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Keep the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free semantic IR service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/semantic_ir.py`
+- Create: `tests/unit/test_schematic_semantic_ir_service.py`
+
+**Interfaces:**
+- Consumes: active schematic lookup, circuit parser, lint engine, diagnostic wrapper, and parse-failure callback
+- Produces: `SchematicSemanticIRService.get_summary() -> str`
+
+- [ ] Write direct tests for parse failure/logging/diagnostics, empty circuits, complete component/net/rail/interface rendering, stable sorting, truncation, DNP/NoBOM flags, voltage tags, and lint formatting.
+- [ ] Run the service test; expect collection failure because the module is absent.
+- [ ] Implement structural protocols and the minimal injected service while preserving legacy output byte-for-byte.
+- [ ] Re-run service tests; expect all pass.
+- [ ] Run Ruff, mypy, and scoped Pyright.
+- [ ] Commit with `refactor(schematic): extract semantic IR service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_semantic_ir.py`
+- Create: `tests/unit/test_schematic_semantic_ir_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicSemanticIRService`
+- Produces: `SchematicSemanticIRDependencies(service: SchematicSemanticIRService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicSemanticIRDependencies) -> None`
+
+- [ ] Write adapter tests for exact name, description, empty schema, headless metadata, delegation, and ten-second cache behavior.
+- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
+- [ ] Implement the adapter and lazy parser/linter wrappers, wire the service in the composition root, and remove the nested legacy tool function.
+- [ ] Run service, adapter, focused integration, authoring-surface, and tool-surface tests.
+- [ ] Commit with `refactor(schematic): delegate semantic IR registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_semantic_ir_architecture.py`
+
+- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
+- [ ] Run the architecture test; expect failure because policy entries are absent.
+- [ ] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
+- [ ] Compare exact full-server metadata against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard semantic IR boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-semantic-ir-service.md`
+
+- [ ] Run focused service/adapter coverage and require at least 83%.
+- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
+- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
+- [ ] Commit with `docs(architecture): record semantic IR evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect CI, bot comments, reviews, and review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/plans/2026-07-23-schematic-semantic-ir-service.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-semantic-ir-service.md
@@ -1,6 +1,6 @@
 # Schematic Semantic IR Service Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Extract `sch_get_circuit_ir` from the monolithic schematic FastMCP registry into a directly testable service and thin adapter without changing its public contract or lazy import behavior.
 
@@ -28,12 +28,12 @@
 - Consumes: active schematic lookup, circuit parser, lint engine, diagnostic wrapper, and parse-failure callback
 - Produces: `SchematicSemanticIRService.get_summary() -> str`
 
-- [ ] Write direct tests for parse failure/logging/diagnostics, empty circuits, complete component/net/rail/interface rendering, stable sorting, truncation, DNP/NoBOM flags, voltage tags, and lint formatting.
-- [ ] Run the service test; expect collection failure because the module is absent.
-- [ ] Implement structural protocols and the minimal injected service while preserving legacy output byte-for-byte.
-- [ ] Re-run service tests; expect all pass.
-- [ ] Run Ruff, mypy, and scoped Pyright.
-- [ ] Commit with `refactor(schematic): extract semantic IR service`.
+- [x] Write direct tests for parse failure/logging/diagnostics, empty circuits, complete component/net/rail/interface rendering, stable sorting, truncation, DNP/NoBOM flags, voltage tags, and lint formatting.
+- [x] Run the service test; expect collection failure because the module is absent.
+- [x] Implement structural protocols and the minimal injected service while preserving legacy output byte-for-byte.
+- [x] Re-run service tests; expect all pass.
+- [x] Run Ruff, mypy, and scoped Pyright.
+- [x] Commit with `refactor(schematic): extract semantic IR service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -47,11 +47,11 @@
 - Produces: `SchematicSemanticIRDependencies(service: SchematicSemanticIRService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicSemanticIRDependencies) -> None`
 
-- [ ] Write adapter tests for exact name, description, empty schema, headless metadata, delegation, and ten-second cache behavior.
-- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
-- [ ] Implement the adapter and lazy parser/linter wrappers, wire the service in the composition root, and remove the nested legacy tool function.
-- [ ] Run service, adapter, focused integration, authoring-surface, and tool-surface tests.
-- [ ] Commit with `refactor(schematic): delegate semantic IR registration`.
+- [x] Write adapter tests for exact name, description, empty schema, headless metadata, delegation, and ten-second cache behavior.
+- [x] Run the adapter test; expect collection failure because the adapter module is absent.
+- [x] Implement the adapter and lazy parser/linter wrappers, wire the service in the composition root, and remove the nested legacy tool function.
+- [x] Run service, adapter, focused integration, authoring-surface, and tool-surface tests.
+- [x] Commit with `refactor(schematic): delegate semantic IR registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -59,21 +59,34 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_semantic_ir_architecture.py`
 
-- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
-- [ ] Run the architecture test; expect failure because policy entries are absent.
-- [ ] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
-- [ ] Compare exact full-server metadata against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard semantic IR boundaries`.
+- [x] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
+- [x] Run the architecture test; expect failure because policy entries are absent.
+- [x] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
+- [x] Compare exact full-server metadata against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard semantic IR boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-23-schematic-semantic-ir-service.md`
 
-- [ ] Run focused service/adapter coverage and require at least 83%.
-- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
-- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
-- [ ] Commit with `docs(architecture): record semantic IR evidence`.
+- [x] Run focused service/adapter coverage and require at least 83%.
+- [x] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
+- [x] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
+- [x] Commit with `docs(architecture): record semantic IR evidence`.
+
+## Verification Evidence
+
+- TDD red/green evidence was observed for the absent service, absent adapter, and missing architecture-policy entries before implementation.
+- Focused service and adapter suite: 6 tests passed; focused integration, architecture, registration, service, and authoring-surface suite: 12 tests passed.
+- Focused coverage: 117 statements, 100% total (`semantic_ir.py` 101/101; `schematic_semantic_ir.py` 16/16), exceeding the 83% requirement.
+- Exact full-server metadata matches `main` for name, description, input schema, output schema, annotations, MCP metadata, and headless/KiCad-running metadata.
+- Committed tool-surface snapshot passed unchanged.
+- Main schematic `register()` span decreased from 1,745 lines on `main` to 1,657 lines; the new adapter `register()` is 18 lines.
+- Full selected unit gate passed: 1,733 tests collected, 5 skipped, no failures.
+- Focused schematic integration test passed on a populated schematic.
+- Formatting, Ruff, mypy, scoped Pyright, architecture, metadata, generated references, parity, profile, tool-contract, compatibility, runtime-policy, strict MkDocs, latency benchmark, Bandit, dependency audit, GitHub Actions policy, zizmor, actionlint workflow checks, package build, and package metadata checks all passed.
+- The repository bootstrap reproduced the known `actionlint-py` wheel-install `EPERM` on the exec-agent filesystem. Verification used the locked environment with `uv sync --all-extras --frozen --no-install-package actionlint-py` and the exact cached actionlint binary; no source or lockfile changes were required.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/specs/2026-07-23-schematic-semantic-ir-service-design.md
+++ b/docs/superpowers/specs/2026-07-23-schematic-semantic-ir-service-design.md
@@ -1,0 +1,71 @@
+# Schematic Semantic IR Service Design
+
+## Context
+
+Issue #434 is incrementally reducing `src/kicad_mcp/tools/schematic.py` into a small FastMCP composition root. `sch_get_circuit_ir` still combines registration, active-file lookup, lazy semantic-IR imports, parsing, diagnostic fallback, Markdown rendering, lint execution, and result caching inside the monolithic registry.
+
+This tranche extracts only `sch_get_circuit_ir`.
+
+## Goals
+
+- Make semantic-IR orchestration and summary rendering directly unit-testable without FastMCP.
+- Preserve the exact public tool name, signature, description, schema, annotations, cache behavior, lazy import timing, log event, diagnostic fallback, sorting, truncation, formatting, and result text.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep the service independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Avoid introducing an import cycle through `kicad_mcp.ir.from_kicad`, which currently imports schematic compatibility helpers.
+
+## Non-goals
+
+- No semantic IR model, parser, lint-rule, or serialization changes.
+- No JSON output conversion.
+- No new schematic features or public fields.
+- No changes to template catalog or template instantiation tools.
+- No new runtime dependencies.
+
+## Architecture
+
+Create `SchematicSemanticIRService` in `src/kicad_mcp/schematic/semantic_ir.py`. The service receives callables for active-file resolution, semantic-IR parsing, linting, diagnostic wrapping, and parse-failure logging. It owns parse-error translation and exact Markdown summary rendering.
+
+The service uses local structural protocols rather than importing `kicad_mcp.ir` at module import time. This preserves service purity and prevents the existing `ir.from_kicad -> tools.schematic` dependency from becoming a circular import.
+
+Create `src/kicad_mcp/tools/schematic_semantic_ir.py` as the thin FastMCP adapter. It preserves the current no-argument signature, docstring, `headless_compatible` metadata, and ten-second TTL cache and delegates to the service.
+
+Keep `src/kicad_mcp/tools/schematic.py` as the composition root. Add lazy dependency wrappers that import `lint_circuit` and `parse_schematic_to_ir` only when the tool is called, construct the service, register the adapter, and remove the nested legacy function.
+
+## Service Interface
+
+```python
+@dataclass(frozen=True)
+class SchematicSemanticIRService:
+    active_schematic_file: Callable[[], Path]
+    parse_circuit: Callable[[Path], CircuitLike]
+    lint_circuit: Callable[[CircuitLike], Iterable[FindingLike]]
+    with_diagnostics: Callable[[str, Path], str]
+    warn_parse_failure: Callable[[Exception], None]
+
+    def get_summary(self) -> str: ...
+```
+
+`CircuitLike`, component/net/rail/interface protocols, and lint-finding protocols expose only the attributes and methods required by the existing renderer.
+
+## Behavior Preservation
+
+- Resolve the active schematic before parsing.
+- Load pin metadata during semantic-IR parsing exactly as today.
+- On any parse exception, emit the existing `sch_get_circuit_ir parse failed` log event and return `_with_schematic_diagnostics("Could not parse IR: ...", sch_file)`.
+- Preserve title, source path, UUID fallback, summary counts, and blank-line layout.
+- Sort component, net, rail, and interface names exactly as today.
+- Preserve DNP/NoBOM flags, pin counts, power/voltage tags, rail-net truncation to five names, source formatting, interface reference truncation to three names, and role declaration order.
+- Preserve lint ordering from the injected lint engine and exact severity/subject/detail formatting.
+- Preserve omission of empty sections and exact trailing-newline behavior.
+- Preserve the adapter's ten-second TTL cache.
+
+## Testing
+
+Direct service tests cover parse failure/logging/diagnostics, an empty circuit, complete component/net/rail/interface rendering, sorting, truncation, flags, voltage tags, and lint formatting.
+
+Adapter tests cover the exact public name, description, empty schema, headless metadata, TTL cache behavior, and delegation. Architecture tests enforce service purity, adapter isolation, and the 300-line registration limit. Focused integration, metadata equality, and tool-surface snapshot tests prove the public contract remains unchanged.
+
+## Expected Result
+
+The main schematic `register()` function loses approximately 90 lines. Semantic-IR tool behavior becomes independently testable while lazy imports and the observable MCP contract remain unchanged.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -48,6 +48,7 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "layout_inspection.py",
+    "kicad_mcp.schematic.semantic_ir": SRC_ROOT / "kicad_mcp" / "schematic" / "semantic_ir.py",
     "kicad_mcp.schematic.symbol_mutation": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -105,6 +106,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_layout_inspection.py",
+    "kicad_mcp.tools.schematic_semantic_ir": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_semantic_ir.py",
     "kicad_mcp.tools.schematic_constants": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -128,6 +133,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.hierarchy_authoring",
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.layout_inspection",
+    "kicad_mcp.schematic.semantic_ir",
     "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.template_catalog",
     "kicad_mcp.schematic.template_instantiation",
@@ -154,6 +160,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_semantic_ir": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_template_catalog": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_template_instantiation": ("kicad_mcp.tools.schematic",),
@@ -168,6 +175,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_layout_inspection": 300,
+    "kicad_mcp.tools.schematic_semantic_ir": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_template_catalog": 300,
     "kicad_mcp.tools.schematic_template_instantiation": 300,

--- a/src/kicad_mcp/schematic/semantic_ir.py
+++ b/src/kicad_mcp/schematic/semantic_ir.py
@@ -1,0 +1,159 @@
+"""FastMCP-independent semantic circuit IR summary services."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class SeverityLike(Protocol):
+    value: str
+
+
+class FindingLike(Protocol):
+    severity: SeverityLike
+    rule_id: str
+    subject: str
+    message: str
+    detail: str
+
+
+class ComponentLike(Protocol):
+    lib_id: str
+    value: str
+    footprint: str
+    pins: Sequence[object]
+    dnp: bool
+    in_bom: bool
+
+
+class NetLike(Protocol):
+    connections: Iterable[tuple[str, str]]
+    is_power: bool
+    voltage: float | None
+
+
+class PowerRailLike(Protocol):
+    voltage: float
+    net_names: Iterable[str]
+    source_ref: str | None
+    source_pin: str | None
+
+
+class InterfaceLike(Protocol):
+    kind: str
+    net_roles: Mapping[str, str]
+    refs: Iterable[str]
+
+
+class CircuitLike(Protocol):
+    source_path: str | None
+    source_uuid: str | None
+    title: str
+    components: Mapping[str, ComponentLike]
+    nets: Mapping[str, NetLike]
+    power_rails: Mapping[str, PowerRailLike]
+    interfaces: Mapping[str, InterfaceLike]
+
+    def component_count(self) -> int: ...
+
+    def pin_count(self) -> int: ...
+
+    def net_count(self) -> int: ...
+
+    def interface_count(self) -> int: ...
+
+
+@dataclass(frozen=True)
+class SchematicSemanticIRService:
+    """Parse and render a semantic circuit IR summary."""
+
+    active_schematic_file: Callable[[], Path]
+    parse_circuit: Callable[[Path], CircuitLike]
+    lint_circuit: Callable[[CircuitLike], Iterable[FindingLike]]
+    with_diagnostics: Callable[[str, Path], str]
+    warn_parse_failure: Callable[[Exception], None]
+
+    def get_summary(self) -> str:
+        schematic_file = self.active_schematic_file()
+        try:
+            circuit = self.parse_circuit(schematic_file)
+        except Exception as exc:
+            self.warn_parse_failure(exc)
+            return self.with_diagnostics(f"Could not parse IR: {exc}", schematic_file)
+
+        lines = [
+            f"# Semantic Circuit IR — {circuit.title}",
+            f"Source: {circuit.source_path}",
+            f"UUID: {circuit.source_uuid or 'N/A'}",
+            "",
+            f"**Summary:** {circuit.component_count()} components, "
+            f"{circuit.pin_count()} pins, "
+            f"{circuit.net_count()} nets, "
+            f"{len(circuit.power_rails)} rails, "
+            f"{circuit.interface_count()} interfaces",
+        ]
+
+        if circuit.components:
+            lines += ["", f"## Components ({circuit.component_count()})"]
+            for reference in sorted(circuit.components):
+                component = circuit.components[reference]
+                flags = ""
+                if component.dnp:
+                    flags += " [DNP]"
+                if not component.in_bom:
+                    flags += " [NoBOM]"
+                lines.append(
+                    f"- {reference}: {component.lib_id} = {component.value} "
+                    f"({component.footprint}){flags}  ({len(component.pins)} pins)"
+                )
+
+        if circuit.nets:
+            power_nets = sum(1 for net in circuit.nets.values() if net.is_power)
+            signal_nets = circuit.net_count() - power_nets
+            lines += [
+                "",
+                f"## Nets ({circuit.net_count()} total: {signal_nets} signal, {power_nets} power)",
+            ]
+            for name in sorted(circuit.nets):
+                net = circuit.nets[name]
+                pin_count = len(tuple(net.connections))
+                power_tag = " [POWER]" if net.is_power else ""
+                voltage_tag = f" {net.voltage}V" if net.voltage is not None else ""
+                lines.append(f"- `{name}`{power_tag}{voltage_tag} ({pin_count} connections)")
+
+        if circuit.power_rails:
+            lines += ["", f"## Power Rails ({len(circuit.power_rails)})"]
+            for name in sorted(circuit.power_rails):
+                rail = circuit.power_rails[name]
+                net_names = sorted(rail.net_names)
+                nets_text = ", ".join(net_names[:5])
+                if len(net_names) > 5:
+                    nets_text += f" … (+{len(net_names) - 5} more)"
+                source = f" from {rail.source_ref}.{rail.source_pin}" if rail.source_ref else ""
+                lines.append(f"- {name}: {rail.voltage}V{source}  nets=[{nets_text}]")
+
+        if circuit.interfaces:
+            lines += ["", f"## Interfaces ({circuit.interface_count()})"]
+            for name in sorted(circuit.interfaces):
+                interface = circuit.interfaces[name]
+                refs = ", ".join(sorted(interface.refs)[:3])
+                roles = ", ".join(
+                    f"{role}={net_name}" for role, net_name in interface.net_roles.items()
+                )
+                lines.append(f"- {name} ({interface.kind}): [{roles}]  refs=[{refs}]")
+
+        findings = list(self.lint_circuit(circuit))
+        if findings:
+            lines += ["", f"## IR Lint Findings ({len(findings)})"]
+            for finding in findings:
+                subject_tag = f" ({finding.subject})" if finding.subject else ""
+                detail_tag = f" — {finding.detail}" if finding.detail else ""
+                lines.append(
+                    f"- [{finding.severity.value.upper()}] {finding.rule_id}"
+                    f"{subject_tag}: {finding.message}{detail_tag}"
+                )
+
+        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -49,11 +49,16 @@ from ..schematic.hierarchy_authoring import (
 )
 from ..schematic.inspection import SchematicInspectionService
 from ..schematic.layout_inspection import SchematicLayoutInspectionService
+from ..schematic.semantic_ir import (
+    CircuitLike,
+    FindingLike,
+    SchematicSemanticIRService,
+)
 from ..schematic.symbol_mutation import SchematicSymbolMutationService
 from ..schematic.template_catalog import SchematicTemplateCatalogService
 from ..schematic.template_instantiation import SchematicTemplateInstantiationService
 from ..schematic.topology import SchematicTopologyService
-from ..utils.cache import clear_ttl_cache, ttl_cache
+from ..utils.cache import clear_ttl_cache
 from ..utils.field_placer import FieldSpec, autoplace_fields
 from ..utils.geometry import Box as GeoBox
 from ..utils.geometry import body_box_from_pins, text_extent
@@ -73,6 +78,7 @@ from . import (
     schematic_hierarchy_authoring,
     schematic_inspection,
     schematic_layout_inspection,
+    schematic_semantic_ir,
     schematic_symbol_mutation,
     schematic_template_catalog,
     schematic_template_instantiation,
@@ -5463,6 +5469,20 @@ def _template_yaml_loader_factory() -> Callable[[TextIO], Any]:
     return yaml.safe_load
 
 
+def _parse_semantic_ir(schematic_file: Path) -> CircuitLike:
+    """Parse semantic IR lazily to avoid the existing compatibility import cycle."""
+    from ..ir import parse_schematic_to_ir
+
+    return cast(CircuitLike, parse_schematic_to_ir(schematic_file, load_pin_metadata=True))
+
+
+def _lint_semantic_ir(circuit: CircuitLike) -> Iterable[FindingLike]:
+    """Run semantic IR lint lazily to avoid importing IR during server startup."""
+    from ..ir import IRCircuit, lint_circuit
+
+    return cast(Iterable[FindingLike], lint_circuit(cast(IRCircuit, circuit)))
+
+
 def register(mcp: FastMCP) -> None:
     """Register schematic tools."""
     inspection_service = SchematicInspectionService(
@@ -5540,6 +5560,22 @@ def register(mcp: FastMCP) -> None:
         mcp,
         schematic_template_instantiation.SchematicTemplateInstantiationDependencies(
             service=template_instantiation_service,
+        ),
+    )
+
+    semantic_ir_service = SchematicSemanticIRService(
+        active_schematic_file=_get_schematic_file,
+        parse_circuit=_parse_semantic_ir,
+        lint_circuit=_lint_semantic_ir,
+        with_diagnostics=_with_schematic_diagnostics,
+        warn_parse_failure=lambda exc: logger.warning(
+            "sch_get_circuit_ir parse failed", error=str(exc)
+        ),
+    )
+    schematic_semantic_ir.register(
+        mcp,
+        schematic_semantic_ir.SchematicSemanticIRDependencies(
+            service=semantic_ir_service,
         ),
     )
 
@@ -7104,107 +7140,3 @@ def register(mcp: FastMCP) -> None:
             f"\nFunctional spacing target: {functional_spacing_mm:.2f} mm."
             f"{anchor_suffix}{missing_suffix}{overflow_note}"
         )
-
-    # -----------------------------------------------------------------------
-    # Subcircuit template tools (v2.1.0)
-    # -----------------------------------------------------------------------
-
-    @mcp.tool()
-    @headless_compatible
-    @ttl_cache(ttl_seconds=10)
-    def sch_get_circuit_ir() -> str:
-        """Return the semantic circuit IR for the active schematic.
-
-        The IR decouples 'what the circuit is' (components, nets, pin
-        roles, power domains, interfaces) from 'how KiCad stores it'
-        (geometry, UUIDs, file format).  Wiring is expressed in terms
-        of pin names and roles, not coordinates.
-
-        The output is a structured text summary of the IR.
-        """
-        sch_file = _get_schematic_file()
-        try:
-            from ..ir import lint_circuit, parse_schematic_to_ir
-
-            ir = parse_schematic_to_ir(sch_file, load_pin_metadata=True)
-        except Exception as exc:
-            logger.warning("sch_get_circuit_ir parse failed", error=str(exc))
-            return _with_schematic_diagnostics(
-                f"Could not parse IR: {exc}",
-                sch_file,
-            )
-
-        lines = [
-            f"# Semantic Circuit IR — {ir.title}",
-            f"Source: {ir.source_path}",
-            f"UUID: {ir.source_uuid or 'N/A'}",
-            "",
-            f"**Summary:** {ir.component_count()} components, "
-            f"{ir.pin_count()} pins, "
-            f"{ir.net_count()} nets, "
-            f"{len(ir.power_rails)} rails, "
-            f"{ir.interface_count()} interfaces",
-        ]
-
-        # Components
-        if ir.components:
-            lines += ["", f"## Components ({ir.component_count()})"]
-            for ref in sorted(ir.components):
-                c = ir.components[ref]
-                flags = ""
-                if c.dnp:
-                    flags += " [DNP]"
-                if not c.in_bom:
-                    flags += " [NoBOM]"
-                lines.append(
-                    f"- {ref}: {c.lib_id} = {c.value} ({c.footprint}){flags}  ({len(c.pins)} pins)"
-                )
-
-        # Nets
-        if ir.nets:
-            power_nets = sum(1 for n in ir.nets.values() if n.is_power)
-            signal_nets = ir.net_count() - power_nets
-            lines += [
-                "",
-                f"## Nets ({ir.net_count()} total: {signal_nets} signal, {power_nets} power)",
-            ]
-            for name in sorted(ir.nets):
-                net = ir.nets[name]
-                pin_count = len(net.connections)
-                power_tag = " [POWER]" if net.is_power else ""
-                voltage_tag = f" {net.voltage}V" if net.voltage is not None else ""
-                lines.append(f"- `{name}`{power_tag}{voltage_tag} ({pin_count} connections)")
-
-        # Power rails
-        if ir.power_rails:
-            lines += ["", f"## Power Rails ({len(ir.power_rails)})"]
-            for name in sorted(ir.power_rails):
-                rail = ir.power_rails[name]
-                nets_str = ", ".join(sorted(rail.net_names)[:5])
-                if len(rail.net_names) > 5:
-                    nets_str += f" … (+{len(rail.net_names) - 5} more)"
-                source = f" from {rail.source_ref}.{rail.source_pin}" if rail.source_ref else ""
-                lines.append(f"- {name}: {rail.voltage}V{source}  nets=[{nets_str}]")
-
-        # Interfaces
-        if ir.interfaces:
-            lines += ["", f"## Interfaces ({ir.interface_count()})"]
-            for name in sorted(ir.interfaces):
-                iface = ir.interfaces[name]
-                refs = ", ".join(sorted(iface.refs)[:3])
-                roles = ", ".join(f"{k}={v}" for k, v in iface.net_roles.items())
-                lines.append(f"- {name} ({iface.kind}): [{roles}]  refs=[{refs}]")
-
-        # Lint findings
-        findings = lint_circuit(ir)
-        if findings:
-            lines += ["", f"## IR Lint Findings ({len(findings)})"]
-            for f in findings:
-                subject_tag = f" ({f.subject})" if f.subject else ""
-                detail_tag = f" — {f.detail}" if f.detail else ""
-                lines.append(
-                    f"- [{f.severity.value.upper()}] {f.rule_id}"
-                    f"{subject_tag}: {f.message}{detail_tag}"
-                )
-
-        return "\n".join(lines)

--- a/src/kicad_mcp/tools/schematic_semantic_ir.py
+++ b/src/kicad_mcp/tools/schematic_semantic_ir.py
@@ -1,0 +1,40 @@
+"""Thin FastMCP adapter for semantic schematic IR summaries."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.semantic_ir import SchematicSemanticIRService
+from ..utils.cache import ttl_cache
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicSemanticIRDependencies:
+    """Semantic-IR service injected by the schematic composition root."""
+
+    service: SchematicSemanticIRService
+
+
+def register(mcp: FastMCP, dependencies: SchematicSemanticIRDependencies) -> None:
+    """Register semantic circuit IR tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    @ttl_cache(ttl_seconds=10)
+    def sch_get_circuit_ir() -> str:
+        """Return the semantic circuit IR for the active schematic.
+
+        The IR decouples 'what the circuit is' (components, nets, pin
+        roles, power domains, interfaces) from 'how KiCad stores it'
+        (geometry, UUIDs, file format).  Wiring is expressed in terms
+        of pin names and roles, not coordinates.
+
+        The output is a structured text summary of the IR.
+        """
+        return service.get_summary()

--- a/tests/unit/test_schematic_semantic_ir_architecture.py
+++ b/tests/unit/test_schematic_semantic_ir_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_semantic_ir_modules() -> None:
+    assert "kicad_mcp.schematic.semantic_ir" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.semantic_ir" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_semantic_ir" in boundaries.DOMAIN_MODULES
+
+
+def test_semantic_ir_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_semantic_ir.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_semantic_ir"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_semantic_ir_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_semantic_ir.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_semantic_ir"] == 300

--- a/tests/unit/test_schematic_semantic_ir_registration.py
+++ b/tests/unit/test_schematic_semantic_ir_registration.py
@@ -1,0 +1,70 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_semantic_ir import (
+    SchematicSemanticIRDependencies,
+    register,
+)
+from kicad_mcp.utils.cache import clear_ttl_cache
+
+
+class FakeSemanticIRService:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_summary(self) -> str:
+        self.calls += 1
+        return f"summary-{self.calls}"
+
+
+def _registered() -> tuple[FastMCP, FakeSemanticIRService]:
+    clear_ttl_cache()
+    server = FastMCP("schematic-semantic-ir-test")
+    service = FakeSemanticIRService()
+    register(server, SchematicSemanticIRDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_name_description_and_schema() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {"sch_get_circuit_ir"}
+    tool = tools["sch_get_circuit_ir"]
+    assert tool.description == (
+        "Return the semantic circuit IR for the active schematic.\n\n"
+        "The IR decouples 'what the circuit is' (components, nets, pin\n"
+        "roles, power domains, interfaces) from 'how KiCad stores it'\n"
+        "(geometry, UUIDs, file format).  Wiring is expressed in terms\n"
+        "of pin names and roles, not coordinates.\n\n"
+        "The output is a structured text summary of the IR.\n"
+    )
+    assert tool.parameters == {
+        "properties": {},
+        "title": "sch_get_circuit_irArguments",
+        "type": "object",
+    }
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+    tool = server._tool_manager.list_tools()[0]
+    metadata = get_tool_metadata(tool.name)
+
+    assert metadata is not None
+    assert metadata.headless_compatible is True
+    assert metadata.requires_kicad_running is False
+    assert tool.annotations is None
+
+
+def test_registration_delegates_and_preserves_ten_second_cache() -> None:
+    server, service = _registered()
+    tool = server._tool_manager.list_tools()[0]
+
+    assert tool.fn() == "summary-1"
+    assert tool.fn() == "summary-1"
+    assert service.calls == 1

--- a/tests/unit/test_schematic_semantic_ir_service.py
+++ b/tests/unit/test_schematic_semantic_ir_service.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+
+from kicad_mcp.schematic.semantic_ir import SchematicSemanticIRService
+
+
+@dataclass
+class FakeCircuit:
+    source_path: str | None = None
+    source_uuid: str | None = None
+    title: str = ""
+    components: dict[str, object] = field(default_factory=dict)
+    nets: dict[str, object] = field(default_factory=dict)
+    power_rails: dict[str, object] = field(default_factory=dict)
+    interfaces: dict[str, object] = field(default_factory=dict)
+
+    def component_count(self) -> int:
+        return len(self.components)
+
+    def pin_count(self) -> int:
+        return sum(len(component.pins) for component in self.components.values())  # type: ignore[attr-defined]
+
+    def net_count(self) -> int:
+        return len(self.nets)
+
+    def interface_count(self) -> int:
+        return len(self.interfaces)
+
+
+def test_get_summary_logs_and_wraps_parse_failures(tmp_path: Path) -> None:
+    schematic = tmp_path / "demo.kicad_sch"
+    warnings: list[str] = []
+    diagnostics: list[tuple[str, Path]] = []
+
+    def parse(_path: Path) -> FakeCircuit:
+        raise ValueError("broken IR")
+
+    def with_diagnostics(message: str, path: Path) -> str:
+        diagnostics.append((message, path))
+        return f"diagnostic: {message}"
+
+    service = SchematicSemanticIRService(
+        active_schematic_file=lambda: schematic,
+        parse_circuit=parse,
+        lint_circuit=lambda _circuit: [],
+        with_diagnostics=with_diagnostics,
+        warn_parse_failure=lambda exc: warnings.append(str(exc)),
+    )
+
+    assert service.get_summary() == "diagnostic: Could not parse IR: broken IR"
+    assert warnings == ["broken IR"]
+    assert diagnostics == [("Could not parse IR: broken IR", schematic)]
+
+
+def test_get_summary_renders_empty_circuit_without_optional_sections(tmp_path: Path) -> None:
+    schematic = tmp_path / "empty.kicad_sch"
+    circuit = FakeCircuit()
+    service = SchematicSemanticIRService(
+        active_schematic_file=lambda: schematic,
+        parse_circuit=lambda _path: circuit,
+        lint_circuit=lambda _circuit: [],
+        with_diagnostics=lambda message, _path: message,
+        warn_parse_failure=lambda _exc: None,
+    )
+
+    assert service.get_summary() == "\n".join(
+        [
+            "# Semantic Circuit IR — ",
+            "Source: None",
+            "UUID: N/A",
+            "",
+            "**Summary:** 0 components, 0 pins, 0 nets, 0 rails, 0 interfaces",
+        ]
+    )
+
+
+def test_get_summary_preserves_complete_rendering_and_sorting(tmp_path: Path) -> None:
+    schematic = tmp_path / "demo.kicad_sch"
+    circuit = FakeCircuit(
+        source_path="/project/demo.kicad_sch",
+        source_uuid="abc-123",
+        title="Demo Board",
+        components={
+            "U1": SimpleNamespace(
+                lib_id="MCU:STM32",
+                value="STM32F0",
+                footprint="Package_QFP:LQFP-48",
+                pins=(1,),
+                dnp=False,
+                in_bom=True,
+            ),
+            "R2": SimpleNamespace(
+                lib_id="Device:R",
+                value="10k",
+                footprint="Resistor_SMD:R_0603",
+                pins=(1, 2),
+                dnp=True,
+                in_bom=False,
+            ),
+        },
+        nets={
+            "VCC": SimpleNamespace(
+                connections=frozenset({("U1", "1")}),
+                is_power=True,
+                voltage=3.3,
+            ),
+            "SIGNAL": SimpleNamespace(
+                connections=frozenset({("U1", "2"), ("R2", "1")}),
+                is_power=False,
+                voltage=None,
+            ),
+        },
+        power_rails={
+            "VCC": SimpleNamespace(
+                voltage=3.3,
+                net_names=frozenset({"VCC", "VCC_A", "VCC_B", "VCC_C", "VCC_D", "VCC_E", "VCC_F"}),
+                source_ref="U1",
+                source_pin="1",
+            )
+        },
+        interfaces={
+            "SPI1": SimpleNamespace(
+                kind="spi",
+                net_roles={"mosi": "SPI1_MOSI", "miso": "SPI1_MISO"},
+                refs=("U3", "U1", "U4", "U2"),
+            )
+        },
+    )
+    findings = [
+        SimpleNamespace(
+            severity=SimpleNamespace(value="warning"),
+            rule_id="ir-005",
+            subject="SIGNAL",
+            message="Dangling net",
+            detail="one endpoint",
+        ),
+        SimpleNamespace(
+            severity=SimpleNamespace(value="info"),
+            rule_id="ir-006",
+            subject="",
+            message="No pin metadata",
+            detail="",
+        ),
+    ]
+    service = SchematicSemanticIRService(
+        active_schematic_file=lambda: schematic,
+        parse_circuit=lambda _path: circuit,
+        lint_circuit=lambda _circuit: findings,
+        with_diagnostics=lambda message, _path: message,
+        warn_parse_failure=lambda _exc: None,
+    )
+
+    assert service.get_summary() == "\n".join(
+        [
+            "# Semantic Circuit IR — Demo Board",
+            "Source: /project/demo.kicad_sch",
+            "UUID: abc-123",
+            "",
+            "**Summary:** 2 components, 3 pins, 2 nets, 1 rails, 1 interfaces",
+            "",
+            "## Components (2)",
+            "- R2: Device:R = 10k (Resistor_SMD:R_0603) [DNP] [NoBOM]  (2 pins)",
+            "- U1: MCU:STM32 = STM32F0 (Package_QFP:LQFP-48)  (1 pins)",
+            "",
+            "## Nets (2 total: 1 signal, 1 power)",
+            "- `SIGNAL` (2 connections)",
+            "- `VCC` [POWER] 3.3V (1 connections)",
+            "",
+            "## Power Rails (1)",
+            "- VCC: 3.3V from U1.1  nets=[VCC, VCC_A, VCC_B, VCC_C, VCC_D … (+2 more)]",
+            "",
+            "## Interfaces (1)",
+            "- SPI1 (spi): [mosi=SPI1_MOSI, miso=SPI1_MISO]  refs=[U1, U2, U3]",
+            "",
+            "## IR Lint Findings (2)",
+            "- [WARNING] ir-005 (SIGNAL): Dangling net — one endpoint",
+            "- [INFO] ir-006: No pin metadata",
+        ]
+    )


### PR DESCRIPTION
## Summary

- extract `sch_get_circuit_ir` orchestration and Markdown rendering into a FastMCP-independent `SchematicSemanticIRService`
- register the public tool through a thin adapter while preserving lazy IR imports and the ten-second TTL cache
- add direct service, adapter, integration, metadata, and architecture-boundary coverage
- document exact contract and repository-gate evidence

## Architecture impact

- `src/kicad_mcp/tools/schematic.py` remains the composition root
- its `register()` span decreases from 1,745 to 1,657 lines
- the new adapter `register()` is 18 lines
- the service has no FastMCP or schematic registry dependency

## Contract preservation

Exact full-server metadata matches `main` for the tool name, description, input/output schemas, annotations, MCP metadata, and headless/KiCad-running metadata. The committed tool-surface snapshot is unchanged.

## Verification

- 1,733 selected unit tests collected; full unit gate passed with 5 skips and no failures
- focused semantic IR service/adapter coverage: 117 statements, 100%
- focused schematic integration and tool-surface snapshot passed
- Ruff format/check, mypy, scoped Pyright, architecture checks, generated metadata/docs, strict MkDocs, latency benchmark, Bandit, dependency audit, GitHub Actions policy, zizmor, actionlint, package build, and package metadata checks passed

Closes part of #434.