### PR TITLE
refactor(schematic): extract rendering service

### DIFF
--- a/docs/superpowers/plans/2026-07-24-schematic-rendering-service.md
+++ b/docs/superpowers/plans/2026-07-24-schematic-rendering-service.md
@@ -1,0 +1,86 @@
+# Schematic Rendering Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `sch_live_preview`, `sch_render_png`, and `sch_render_visual_diff` from the monolithic schematic FastMCP registry into a directly testable service and thin adapter without changing their public contracts or compatibility seams.
+
+**Architecture:** Add one FastMCP-free rendering service with an internal response data object and explicit injected dependencies, plus one thin registration adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root and inject lazy wrappers around existing helper functions so post-registration monkeypatch behavior remains intact.
+
+**Tech Stack:** Python 3.13, FastMCP, pytest, Ruff, mypy, Pyright, existing schematic rendering and architecture tooling.
+
+## Global Constraints
+
+- Preserve exact public names, signatures, descriptions, schemas, annotations, validation messages, metadata, state transitions, artifact paths, image/text response selection, and observable behavior.
+- Do not change renderer algorithms, live-preview contracts, mutation snapshots, target resolution, or runtime dependencies.
+- Keep the adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Keep the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free rendering service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/rendering.py`
+- Create: `tests/unit/test_schematic_rendering_service.py`
+
+**Interfaces:**
+- Produces: `SchematicRenderingResponse`
+- Produces: `SchematicRenderingService.live_preview(...)`
+- Produces: `SchematicRenderingService.render_png(...)`
+- Produces: `SchematicRenderingService.render_visual_diff(...)`
+
+- [ ] Write direct tests for argument validation, empty and successful PNG rendering, output/render failures, visual-diff snapshot states and success, live-preview initialization/no-change/debounce/forced/render/reload paths, state writes, and image selection.
+- [ ] Run the service test; expect collection failure because the module is absent.
+- [ ] Implement structural protocols, response data object, and minimal injected service while preserving legacy output byte-for-byte.
+- [ ] Re-run service tests; expect all pass.
+- [ ] Run Ruff, mypy, and scoped Pyright.
+- [ ] Commit with `refactor(schematic): extract rendering service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_rendering.py`
+- Create: `tests/unit/test_schematic_rendering_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+**Interfaces:**
+- Consumes: `SchematicRenderingService`
+- Produces: `SchematicRenderingDependencies(service: SchematicRenderingService)`
+- Produces: `register(mcp: FastMCP, dependencies: SchematicRenderingDependencies) -> None`
+
+- [ ] Write adapter tests for exact names, descriptions, schemas, headless annotations, delegation, and text/image response conversion.
+- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
+- [ ] Implement the adapter, wire lazy compatibility dependencies in the composition root, and remove the three nested legacy tool functions.
+- [ ] Run service, adapter, focused integration, live-preview fallback, protocol-contract, and tool-surface tests.
+- [ ] Commit with `refactor(schematic): delegate rendering registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_rendering_architecture.py`
+
+- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
+- [ ] Run the architecture test; expect failure because policy entries are absent.
+- [ ] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
+- [ ] Compare exact full-server metadata for all three tools against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard rendering boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-24-schematic-rendering-service.md`
+
+- [ ] Run focused service/adapter coverage and require at least 83%.
+- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
+- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
+- [ ] Commit with `docs(architecture): record rendering evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect CI, bot comments, reviews, and review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/plans/2026-07-24-schematic-rendering-service.md
+++ b/docs/superpowers/plans/2026-07-24-schematic-rendering-service.md
@@ -1,6 +1,6 @@
 # Schematic Rendering Service Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Extract `sch_live_preview`, `sch_render_png`, and `sch_render_visual_diff` from the monolithic schematic FastMCP registry into a directly testable service and thin adapter without changing their public contracts or compatibility seams.
 
@@ -30,12 +30,12 @@
 - Produces: `SchematicRenderingService.render_png(...)`
 - Produces: `SchematicRenderingService.render_visual_diff(...)`
 
-- [ ] Write direct tests for argument validation, empty and successful PNG rendering, output/render failures, visual-diff snapshot states and success, live-preview initialization/no-change/debounce/forced/render/reload paths, state writes, and image selection.
-- [ ] Run the service test; expect collection failure because the module is absent.
-- [ ] Implement structural protocols, response data object, and minimal injected service while preserving legacy output byte-for-byte.
-- [ ] Re-run service tests; expect all pass.
-- [ ] Run Ruff, mypy, and scoped Pyright.
-- [ ] Commit with `refactor(schematic): extract rendering service`.
+- [x] Write direct tests for argument validation, empty and successful PNG rendering, output/render failures, visual-diff snapshot states and success, live-preview initialization/no-change/debounce/forced/render/reload paths, state writes, and image selection.
+- [x] Run the service test; expect collection failure because the module is absent.
+- [x] Implement structural protocols, response data object, and minimal injected service while preserving legacy output byte-for-byte.
+- [x] Re-run service tests; expect all pass.
+- [x] Run Ruff, mypy, and scoped Pyright.
+- [x] Commit with `refactor(schematic): extract rendering service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -49,11 +49,11 @@
 - Produces: `SchematicRenderingDependencies(service: SchematicRenderingService)`
 - Produces: `register(mcp: FastMCP, dependencies: SchematicRenderingDependencies) -> None`
 
-- [ ] Write adapter tests for exact names, descriptions, schemas, headless annotations, delegation, and text/image response conversion.
-- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
-- [ ] Implement the adapter, wire lazy compatibility dependencies in the composition root, and remove the three nested legacy tool functions.
-- [ ] Run service, adapter, focused integration, live-preview fallback, protocol-contract, and tool-surface tests.
-- [ ] Commit with `refactor(schematic): delegate rendering registration`.
+- [x] Write adapter tests for exact names, descriptions, schemas, headless annotations, delegation, and text/image response conversion.
+- [x] Run the adapter test; expect collection failure because the adapter module is absent.
+- [x] Implement the adapter, wire lazy compatibility dependencies in the composition root, and remove the three nested legacy tool functions.
+- [x] Run service, adapter, focused integration, live-preview fallback, protocol-contract, and tool-surface tests.
+- [x] Commit with `refactor(schematic): delegate rendering registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -61,21 +61,34 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_rendering_architecture.py`
 
-- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
-- [ ] Run the architecture test; expect failure because policy entries are absent.
-- [ ] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
-- [ ] Compare exact full-server metadata for all three tools against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard rendering boundaries`.
+- [x] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
+- [x] Run the architecture test; expect failure because policy entries are absent.
+- [x] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
+- [x] Compare exact full-server metadata for all three tools against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard rendering boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-24-schematic-rendering-service.md`
 
-- [ ] Run focused service/adapter coverage and require at least 83%.
-- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
-- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
-- [ ] Commit with `docs(architecture): record rendering evidence`.
+- [x] Run focused service/adapter coverage and require at least 83%.
+- [x] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
+- [x] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
+- [x] Commit with `docs(architecture): record rendering evidence`.
+
+## Verification Evidence
+
+- TDD red/green evidence was observed for the absent rendering service, absent adapter, and missing architecture-policy entries before implementation.
+- Direct service and adapter suite: 13 tests passed; architecture suite: 3 tests passed; focused integration, fallback, protocol-contract, and tool-surface suite: 15 tests passed.
+- Focused coverage: 193 statements, 98% total (`rendering.py` 165 statements at 99%; `schematic_rendering.py` 28 statements at 96%), exceeding the 83% requirement.
+- Exact full-server metadata matches `main` for all three tools: names, descriptions, input schemas, output schemas, annotations, MCP metadata, and headless/KiCad-running metadata.
+- Committed tool-surface snapshot passed unchanged.
+- Main schematic `register()` span decreased from 1,657 lines on `main` to 1,368 lines; the new adapter `register()` is 93 lines.
+- Full selected unit gate passed: 1,749 tests collected, 5 skipped, no failures.
+- Focused schematic PNG render, visual diff, live-preview debounce/child-sheet/bounds, renderer-fallback, protocol-contract, and snapshot tests passed.
+- Formatting, Ruff, mypy, scoped Pyright, architecture, metadata, generated references, parity, profile, tool-contract, compatibility, runtime-policy, strict MkDocs, latency benchmark, Bandit, dependency audit, GitHub Actions policy, zizmor, actionlint workflow checks, package build, and package metadata checks all passed.
+- The repository bootstrap reproduced the known `actionlint-py` wheel-install `EPERM` on the exec-agent filesystem. Verification used the locked environment with `uv sync --all-extras --frozen --no-install-package actionlint-py` and the exact cached actionlint binary; no source or lockfile changes were required.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/specs/2026-07-24-schematic-rendering-service-design.md
+++ b/docs/superpowers/specs/2026-07-24-schematic-rendering-service-design.md
@@ -1,0 +1,103 @@
+# Schematic Rendering Service Design
+
+## Context
+
+Issue #434 is incrementally reducing `src/kicad_mcp/tools/schematic.py` into a small FastMCP composition root. The remaining `sch_live_preview`, `sch_render_png`, and `sch_render_visual_diff` registrations still contain validation, preview-state orchestration, render selection, mutation-snapshot verification, artifact path handling, and response construction inside the registry function.
+
+This tranche extracts those three rendering capabilities while preserving the existing rendering helpers and compatibility seams.
+
+## Goals
+
+- Make live-preview, PNG rendering, and visual-diff orchestration directly unit-testable without constructing FastMCP.
+- Preserve exact public names, signatures, descriptions, schemas, annotations, image/text response behavior, metadata, validation messages, state transitions, debounce behavior, file selection, and error handling.
+- Keep the new adapter `register()` function at or below 300 lines.
+- Keep the service independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Preserve existing integration-test monkeypatch seams for schematic SVG export and SVG-to-PNG conversion.
+
+## Non-goals
+
+- No renderer, CairoSVG, Pillow, KiCad CLI, or image-diff algorithm changes.
+- No live-preview contract or state-file format changes.
+- No new output formats, arguments, or runtime dependencies.
+- No mutation snapshot or schematic target resolution changes.
+
+## Architecture
+
+### Before
+
+```text
+FastMCP register()
+  ├─ sch_live_preview
+  │   ├─ validate and resolve target
+  │   ├─ read/write debounce state
+  │   ├─ detect changed files
+  │   ├─ optionally reload and render
+  │   └─ construct MCP text/image response
+  ├─ sch_render_png
+  │   ├─ validate and resolve target
+  │   ├─ inspect renderable content
+  │   ├─ render artifact
+  │   └─ construct MCP image response
+  └─ sch_render_visual_diff
+      ├─ validate mutation snapshot
+      ├─ render before/after/diff artifacts
+      └─ construct MCP image response
+```
+
+### After
+
+```text
+FastMCP composition root
+  ├─ lazy compatibility dependency wrappers
+  └─ thin schematic_rendering adapter
+       └─ SchematicRenderingService (FastMCP-free)
+            ├─ live_preview()
+            ├─ render_png()
+            └─ render_visual_diff()
+```
+
+Create `SchematicRenderingService` in `src/kicad_mcp/schematic/rendering.py`. It receives explicit callables for target resolution, parsing, renderability checks, safe output paths, artifact rendering, visual-diff loading/rendering, preview file/signature/state operations, payload normalization, reload, and the clock. It returns a small `SchematicRenderingResponse` data object containing text, optional metadata, and an optional image path.
+
+Create `src/kicad_mcp/tools/schematic_rendering.py` as the thin FastMCP adapter. It preserves each public signature and docstring, applies `headless_compatible`, delegates to the service, and converts the internal response through the existing `text_tool_result` and `image_tool_result` helpers.
+
+Keep rendering helper functions in `src/kicad_mcp/tools/schematic.py` for this tranche. The composition root injects lazy lambdas rather than captured helper objects so existing post-registration monkeypatch seams continue to work in integration tests.
+
+## Service Interface
+
+```python
+@dataclass(frozen=True)
+class SchematicRenderingResponse:
+    text: str | None = None
+    metadata: dict[str, Any] | None = None
+    image_path: Path | None = None
+
+@dataclass(frozen=True)
+class SchematicRenderingService:
+    # Explicit injected dependencies omitted here for brevity.
+
+    def live_preview(...) -> SchematicRenderingResponse: ...
+    def render_png(...) -> SchematicRenderingResponse: ...
+    def render_visual_diff(...) -> SchematicRenderingResponse: ...
+```
+
+A structural `SchematicTargetLike` protocol exposes only `path` and `description`, avoiding imports from the registry module.
+
+## Behavior Preservation
+
+- Preserve debounce range `0..60000` and DPI range `72..600` with exact messages.
+- Preserve initialization, no-change, pending-debounce, changed, rendered, reloaded, forced, empty-sheet, and failed-render statuses.
+- Preserve live-preview state keys, timestamps, changed-file ordering, child-sheet render selection, reload messaging, and image-return conditions.
+- Preserve safe output-name validation and exact render/visual-diff error messages.
+- Preserve mutation snapshot absence, missing-before, stale-after hash, changed object/ref/net metadata, artifact directory layout, and image metadata.
+- Preserve `image_tool_result` for successful artifacts and `text_tool_result` for all non-image outcomes.
+- Preserve exact tool metadata and committed tool-surface snapshot.
+
+## Testing
+
+Direct service tests cover validation, PNG empty/success/failure paths, visual-diff snapshot states and success, live-preview initialization/no-change/debounce/forced/render failure/render success/reload behavior, state writes, and image response selection.
+
+Adapter tests cover exact names, descriptions, schemas, annotations, delegation, and response conversion. Existing integration tests remain authoritative for real server wiring and compatibility monkeypatch seams. Architecture tests enforce service purity, adapter isolation, and the 300-line registration limit.
+
+## Expected Result
+
+The main schematic `register()` function loses roughly 340 lines. The three rendering tools become independently testable while their observable MCP contract and existing rendering implementation remain unchanged.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -48,6 +48,7 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "layout_inspection.py",
+    "kicad_mcp.schematic.rendering": SRC_ROOT / "kicad_mcp" / "schematic" / "rendering.py",
     "kicad_mcp.schematic.semantic_ir": SRC_ROOT / "kicad_mcp" / "schematic" / "semantic_ir.py",
     "kicad_mcp.schematic.symbol_mutation": SRC_ROOT
     / "kicad_mcp"
@@ -106,6 +107,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_layout_inspection.py",
+    "kicad_mcp.tools.schematic_rendering": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_rendering.py",
     "kicad_mcp.tools.schematic_semantic_ir": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -133,6 +138,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.hierarchy_authoring",
     "kicad_mcp.schematic.inspection",
     "kicad_mcp.schematic.layout_inspection",
+    "kicad_mcp.schematic.rendering",
     "kicad_mcp.schematic.semantic_ir",
     "kicad_mcp.schematic.symbol_mutation",
     "kicad_mcp.schematic.template_catalog",
@@ -160,6 +166,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_rendering": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_semantic_ir": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_symbol_mutation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_template_catalog": ("kicad_mcp.tools.schematic",),
@@ -175,6 +182,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
     "kicad_mcp.tools.schematic_layout_inspection": 300,
+    "kicad_mcp.tools.schematic_rendering": 300,
     "kicad_mcp.tools.schematic_semantic_ir": 300,
     "kicad_mcp.tools.schematic_symbol_mutation": 300,
     "kicad_mcp.tools.schematic_template_catalog": 300,

--- a/src/kicad_mcp/schematic/rendering.py
+++ b/src/kicad_mcp/schematic/rendering.py
@@ -1,0 +1,391 @@
+"""FastMCP-independent schematic rendering orchestration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+
+class SchematicTargetLike(Protocol):
+    @property
+    def path(self) -> Path: ...
+
+    @property
+    def description(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class SchematicRenderingResponse:
+    """Internal rendering result converted to MCP content by the thin adapter."""
+
+    text: str | None = None
+    metadata: dict[str, Any] | None = None
+    image_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class SchematicRenderingService:
+    """Coordinate schematic preview, PNG render, and visual-diff behavior."""
+
+    resolve_target: Callable[[str | None, str | None], SchematicTargetLike]
+    parse_schematic: Callable[[Path], dict[str, Any]]
+    has_renderable_content: Callable[[dict[str, Any]], bool]
+    safe_output_path: Callable[[str | None, str], Path]
+    render_png_artifact: Callable[[Path, Path, int, bool, bool], tuple[Path, dict[str, object]]]
+    load_visual_diff: Callable[[Path], dict[str, Any] | None]
+    render_png_visual_diff: Callable[[Path, Path, Path], dict[str, object]]
+    preview_files: Callable[[Path, bool], list[Path]]
+    preview_signature: Callable[[list[Path]], dict[str, Any]]
+    preview_state_filename: Callable[[Path, bool], str]
+    preview_state_read: Callable[[str], dict[str, Any] | None]
+    preview_state_write: Callable[[str, dict[str, Any]], None]
+    preview_changed_files: Callable[[dict[str, Any] | None, dict[str, Any]], list[str]]
+    preview_render_path: Callable[[Path, list[Path], list[str]], Path]
+    preview_payload: Callable[..., dict[str, Any]]
+    reload_schematic: Callable[[], str]
+    now_ns: Callable[[], int]
+
+    @staticmethod
+    def _text(message: str) -> SchematicRenderingResponse:
+        return SchematicRenderingResponse(text=message)
+
+    @staticmethod
+    def _json(metadata: dict[str, Any]) -> SchematicRenderingResponse:
+        return SchematicRenderingResponse(
+            text=json.dumps(metadata, indent=2),
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _image(path: Path, metadata: dict[str, Any]) -> SchematicRenderingResponse:
+        return SchematicRenderingResponse(metadata=metadata, image_path=path)
+
+    def render_png(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        crop_to_content: bool = True,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> SchematicRenderingResponse:
+        """Render a schematic sheet to a PNG response."""
+        if dpi < 72 or dpi > 600:
+            return self._text("dpi must be between 72 and 600.")
+
+        target = self.resolve_target(sheet, sheet_file)
+        data = self.parse_schematic(target.path)
+        if not self.has_renderable_content(data):
+            metadata: dict[str, Any] = {
+                "status": "empty_sheet",
+                "sheet_path": str(target.path),
+                "message": "No schematic content was available to render.",
+            }
+            return self._json(metadata)
+
+        try:
+            png_file = self.safe_output_path(
+                output_file,
+                f"{target.path.stem}.png",
+            )
+        except ValueError as exc:
+            return self._text(f"Invalid output path: {exc}")
+        try:
+            svg_file, image_metadata = self.render_png_artifact(
+                target.path,
+                png_file,
+                dpi,
+                crop_to_content,
+                include_title_block,
+            )
+        except RuntimeError as exc:
+            return self._text(f"Schematic PNG render failed: {exc}")
+        metadata = {
+            "status": "ok",
+            "png_path": str(png_file),
+            "svg_path": str(svg_file),
+            "sheet_path": str(target.path),
+            "dpi": dpi,
+            "include_title_block": include_title_block,
+            **image_metadata,
+        }
+        return self._image(png_file, metadata)
+
+    def render_visual_diff(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> SchematicRenderingResponse:
+        """Render the exact visual delta from the latest mutation snapshot."""
+        if dpi < 72 or dpi > 600:
+            return self._text("dpi must be between 72 and 600.")
+
+        target = self.resolve_target(sheet, sheet_file)
+        state = self.load_visual_diff(target.path)
+        if state is None:
+            metadata: dict[str, Any] = {
+                "status": "no_recorded_mutation",
+                "sheet_path": str(target.path),
+                "message": "No mutation snapshot is available for this schematic.",
+            }
+            return self._json(metadata)
+
+        before_snapshot = Path(str(state.get("before_snapshot", "")))
+        if not before_snapshot.is_file():
+            metadata = {
+                "status": "missing_before_snapshot",
+                "sheet_path": str(target.path),
+                "before_snapshot": str(before_snapshot),
+            }
+            return self._json(metadata)
+
+        current_content = target.path.read_text(encoding="utf-8")
+        current_sha256 = hashlib.sha256(current_content.encode("utf-8")).hexdigest()
+        if current_sha256 != state.get("after_sha256"):
+            metadata = {
+                "status": "stale_mutation_snapshot",
+                "sheet_path": str(target.path),
+                "recorded_after_sha256": state.get("after_sha256"),
+                "current_sha256": current_sha256,
+                "message": "The schematic changed outside the recorded mutation.",
+            }
+            return self._json(metadata)
+
+        try:
+            diff_file = self.safe_output_path(
+                output_file,
+                f"{target.path.stem}-visual-diff.png",
+            )
+        except ValueError as exc:
+            return self._text(f"Invalid output path: {exc}")
+
+        artifact_dir = diff_file.parent / "_visual-diff"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        before_png = artifact_dir / f"{diff_file.stem}-before.png"
+        after_png = artifact_dir / f"{diff_file.stem}-after.png"
+        try:
+            before_svg, before_metadata = self.render_png_artifact(
+                before_snapshot,
+                before_png,
+                dpi,
+                False,
+                include_title_block,
+            )
+            after_svg, after_metadata = self.render_png_artifact(
+                target.path,
+                after_png,
+                dpi,
+                False,
+                include_title_block,
+            )
+            diff_metadata = self.render_png_visual_diff(
+                before_png,
+                after_png,
+                diff_file,
+            )
+        except RuntimeError as exc:
+            return self._text(f"Schematic visual diff failed: {exc}")
+
+        metadata2: dict[str, Any] = {
+            "status": "ok",
+            "diff_path": str(diff_file),
+            "before_png_path": str(before_png),
+            "after_png_path": str(after_png),
+            "before_svg_path": str(before_svg),
+            "after_svg_path": str(after_svg),
+            "sheet_path": str(target.path),
+            "dpi": dpi,
+            "include_title_block": include_title_block,
+            "before_render": before_metadata,
+            "after_render": after_metadata,
+            "changed_objects": state.get("changed_objects", []),
+            "changed_refs": state.get("changed_refs", []),
+            "changed_nets": state.get("changed_nets", []),
+            **diff_metadata,
+        }
+        return self._image(diff_file, metadata2)
+
+    def live_preview(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        include_child_sheets: bool = True,
+        debounce_ms: int = 750,
+        render: bool = True,
+        reload: bool = False,
+        force: bool = False,
+        crop_to_content: bool = True,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> SchematicRenderingResponse:
+        """Poll and optionally refresh a safe live schematic preview."""
+        if debounce_ms < 0 or debounce_ms > 60_000:
+            return self._text("debounce_ms must be between 0 and 60000.")
+        if dpi < 72 or dpi > 600:
+            return self._text("dpi must be between 72 and 600.")
+
+        target = self.resolve_target(sheet, sheet_file)
+        files = self.preview_files(target.path, include_child_sheets)
+        signature = self.preview_signature(files)
+        state_name = self.preview_state_filename(target.path, include_child_sheets)
+        existing_state = self.preview_state_read(state_name)
+        now_ns = self.now_ns()
+        debounce_ns = debounce_ms * 1_000_000
+
+        state: dict[str, Any]
+        if existing_state is None:
+            state = {
+                "last_signature": signature,
+                "pending_signature": None,
+                "pending_observed_at_ns": None,
+                "updated_at_ns": now_ns,
+            }
+            self.preview_state_write(state_name, state)
+            if not force:
+                payload = self.preview_payload(
+                    status="initialized",
+                    target=target,
+                    files=files,
+                    signature=signature,
+                    message=(
+                        "Live preview baseline recorded. Call again after a schematic "
+                        "change, or use force=True to render immediately."
+                    ),
+                )
+                return self._json(payload)
+        else:
+            state = existing_state
+
+        last_signature = cast(dict[str, Any] | None, state.get("last_signature"))
+        pending_signature = cast(dict[str, Any] | None, state.get("pending_signature"))
+        changed_files = self.preview_changed_files(last_signature, signature)
+
+        if not force and signature == last_signature:
+            state["pending_signature"] = None
+            state["pending_observed_at_ns"] = None
+            state["updated_at_ns"] = now_ns
+            self.preview_state_write(state_name, state)
+            payload = self.preview_payload(
+                status="no_change",
+                target=target,
+                files=files,
+                signature=signature,
+                message="No schematic file changes detected since the last live-preview refresh.",
+            )
+            return self._json(payload)
+
+        if not force:
+            if pending_signature != signature:
+                state["pending_signature"] = signature
+                state["pending_observed_at_ns"] = now_ns
+                state["updated_at_ns"] = now_ns
+                self.preview_state_write(state_name, state)
+                payload = self.preview_payload(
+                    status="pending_debounce",
+                    target=target,
+                    files=files,
+                    signature=signature,
+                    changed_files=changed_files,
+                    message="Change detected; waiting for debounce window before preview refresh.",
+                )
+                return self._json(payload)
+            observed_at = int(state.get("pending_observed_at_ns") or now_ns)
+            if now_ns - observed_at < debounce_ns:
+                payload = self.preview_payload(
+                    status="pending_debounce",
+                    target=target,
+                    files=files,
+                    signature=signature,
+                    changed_files=changed_files,
+                    message="Change is still inside the debounce window.",
+                )
+                return self._json(payload)
+
+        reload_result = self.reload_schematic() if reload else None
+        render_metadata: dict[str, Any] | None = None
+        output_path: Path | None = None
+        if render:
+            render_path = self.preview_render_path(
+                target.path,
+                files,
+                changed_files,
+            )
+            data = self.parse_schematic(render_path)
+            if self.has_renderable_content(data):
+                try:
+                    default_name = f"live-preview-{render_path.stem}.png"
+                    output_path = self.safe_output_path(output_file, default_name)
+                    svg_file, image_metadata = self.render_png_artifact(
+                        render_path,
+                        output_path,
+                        dpi,
+                        crop_to_content,
+                        include_title_block,
+                    )
+                    render_metadata = {
+                        "status": "ok",
+                        "sheet_path": str(render_path),
+                        "png_path": str(output_path),
+                        "svg_path": str(svg_file),
+                        "dpi": dpi,
+                        "include_title_block": include_title_block,
+                        **image_metadata,
+                    }
+                except (OSError, RuntimeError, ValueError) as exc:
+                    render_metadata = {
+                        "status": "failed",
+                        "sheet_path": str(render_path),
+                        "message": str(exc),
+                    }
+            else:
+                render_metadata = {
+                    "status": "empty_sheet",
+                    "sheet_path": str(render_path),
+                    "message": "No schematic content was available to render.",
+                }
+
+        state["last_signature"] = signature
+        state["pending_signature"] = None
+        state["pending_observed_at_ns"] = None
+        state["last_changed_files"] = changed_files
+        state["last_render"] = render_metadata
+        state["last_reload_result"] = reload_result
+        state["updated_at_ns"] = now_ns
+        self.preview_state_write(state_name, state)
+
+        status = "forced_rendered" if force else "changed"
+        if render_metadata and render_metadata.get("status") == "ok":
+            status = "forced_rendered" if force else "changed_rendered"
+        elif reload_result:
+            status = "forced_reloaded" if force else "changed_reloaded"
+        payload = self.preview_payload(
+            status=status,
+            target=target,
+            files=files,
+            signature=signature,
+            changed_files=changed_files,
+            reload_result=reload_result,
+            render_metadata=render_metadata,
+            message=(
+                "A best-effort KiCad GUI reload was requested by opt-in reload=True; "
+                "schematic disk reload in the open GUI document is not confirmed."
+                if reload
+                else "Preview refreshed without forcing a KiCad GUI reload."
+            ),
+        )
+        if (
+            output_path is not None
+            and output_path.exists()
+            and render_metadata
+            and render_metadata.get("status") == "ok"
+        ):
+            return self._image(output_path, payload)
+        return self._json(payload)

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -19,13 +19,11 @@ from typing import Any, Literal, Protocol, TextIO, TypedDict, cast
 
 import structlog
 from mcp.server.fastmcp import FastMCP
-from mcp.types import CallToolResult
 
 from ..config import get_config
 from ..connection import KiCadConnectionError, get_kicad
 from ..discovery import is_numbered_duplicate_kicad_file
 from ..errors import SchematicWriteUnsafeError
-from ..mcp_media import image_tool_result, text_tool_result
 from ..models.schematic import (
     AddLabelInput,
     AddSymbolInput,
@@ -49,6 +47,7 @@ from ..schematic.hierarchy_authoring import (
 )
 from ..schematic.inspection import SchematicInspectionService
 from ..schematic.layout_inspection import SchematicLayoutInspectionService
+from ..schematic.rendering import SchematicRenderingService
 from ..schematic.semantic_ir import (
     CircuitLike,
     FindingLike,
@@ -78,6 +77,7 @@ from . import (
     schematic_hierarchy_authoring,
     schematic_inspection,
     schematic_layout_inspection,
+    schematic_rendering,
     schematic_semantic_ir,
     schematic_symbol_mutation,
     schematic_template_catalog,
@@ -5579,6 +5579,67 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
+    rendering_service = SchematicRenderingService(
+        resolve_target=lambda sheet, sheet_file: _resolve_schematic_target(
+            sheet=sheet,
+            sheet_file=sheet_file,
+        ),
+        parse_schematic=lambda path: parse_schematic_file(path),
+        has_renderable_content=lambda data: _schematic_has_renderable_content(data),
+        safe_output_path=lambda raw_name, default_name: _safe_render_output_path(
+            raw_name,
+            default_name=default_name,
+        ),
+        render_png_artifact=lambda schematic_file, output_path, dpi, crop, title: (
+            _render_schematic_png_artifact(
+                schematic_file,
+                output_path,
+                dpi=dpi,
+                crop_to_content=crop,
+                include_title_block=title,
+            )
+        ),
+        load_visual_diff=lambda path: _load_schematic_visual_diff(path),
+        render_png_visual_diff=lambda before, after, output: _render_png_visual_diff(
+            before,
+            after,
+            output,
+        ),
+        preview_files=lambda root, include_children: _schematic_live_preview_files(
+            root,
+            include_children,
+        ),
+        preview_signature=lambda paths: _schematic_live_preview_signature(paths),
+        preview_state_filename=lambda path, include_children: (
+            _schematic_live_preview_state_filename(path, include_children)
+        ),
+        preview_state_read=lambda filename: _schematic_live_preview_state_read(filename),
+        preview_state_write=lambda filename, state: _schematic_live_preview_state_write(
+            filename,
+            state,
+        ),
+        preview_changed_files=lambda before, after: _schematic_live_preview_changed_files(
+            before,
+            after,
+        ),
+        preview_render_path=lambda target_path, watched_files, changed_files: (
+            _schematic_live_preview_render_path(
+                target_path=target_path,
+                watched_files=watched_files,
+                changed_files=changed_files,
+            )
+        ),
+        preview_payload=lambda **kwargs: _schematic_live_preview_payload(**kwargs),
+        reload_schematic=lambda: _reload_schematic(),
+        now_ns=lambda: time.time_ns(),
+    )
+    schematic_rendering.register(
+        mcp,
+        schematic_rendering.SchematicRenderingDependencies(
+            service=rendering_service,
+        ),
+    )
+
     topology_service = SchematicTopologyService(
         load_schematic=_load_kicad_schematic,
         with_diagnostics=_with_schematic_diagnostics,
@@ -6581,356 +6642,6 @@ def register(mcp: FastMCP) -> None:
     # -----------------------------------------------------------------------
     # Spatial awareness tools (v2.1.0)
     # -----------------------------------------------------------------------
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_live_preview(
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-        include_child_sheets: bool = True,
-        debounce_ms: int = 750,
-        render: bool = True,
-        reload: bool = False,
-        force: bool = False,
-        crop_to_content: bool = True,
-        dpi: int = 200,
-        include_title_block: bool = True,
-        output_file: str | None = None,
-    ) -> CallToolResult:
-        """Poll a safe live schematic preview state and refresh rendered output on changes.
-
-        This is an opt-in polling watcher for agents and companion-plugin flows. It
-        records the current schematic file signature, debounces rapid writes, then
-        refreshes a PNG preview when the watched files are stable. KiCad GUI reload
-        is deliberately opt-in via ``reload=True`` because the tool cannot reliably
-        prove that the user has no unsaved GUI edits.
-        """
-        if debounce_ms < 0 or debounce_ms > 60_000:
-            return text_tool_result("debounce_ms must be between 0 and 60000.")
-        if dpi < 72 or dpi > 600:
-            return text_tool_result("dpi must be between 72 and 600.")
-
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        files = _schematic_live_preview_files(target.path, include_child_sheets)
-        signature = _schematic_live_preview_signature(files)
-        state_name = _schematic_live_preview_state_filename(target.path, include_child_sheets)
-        state = _schematic_live_preview_state_read(state_name)
-        now_ns = time.time_ns()
-        debounce_ns = debounce_ms * 1_000_000
-
-        if state is None:
-            state = {
-                "last_signature": signature,
-                "pending_signature": None,
-                "pending_observed_at_ns": None,
-                "updated_at_ns": now_ns,
-            }
-            _schematic_live_preview_state_write(state_name, state)
-            if not force:
-                payload = _schematic_live_preview_payload(
-                    status="initialized",
-                    target=target,
-                    files=files,
-                    signature=signature,
-                    message=(
-                        "Live preview baseline recorded. Call again after a schematic "
-                        "change, or use force=True to render immediately."
-                    ),
-                )
-                return text_tool_result(json.dumps(payload, indent=2), metadata=payload)
-
-        last_signature = cast(dict[str, Any] | None, state.get("last_signature"))
-        pending_signature = cast(dict[str, Any] | None, state.get("pending_signature"))
-        changed_files = _schematic_live_preview_changed_files(last_signature, signature)
-
-        if not force and signature == last_signature:
-            state["pending_signature"] = None
-            state["pending_observed_at_ns"] = None
-            state["updated_at_ns"] = now_ns
-            _schematic_live_preview_state_write(state_name, state)
-            payload = _schematic_live_preview_payload(
-                status="no_change",
-                target=target,
-                files=files,
-                signature=signature,
-                message="No schematic file changes detected since the last live-preview refresh.",
-            )
-            return text_tool_result(json.dumps(payload, indent=2), metadata=payload)
-
-        if not force:
-            if pending_signature != signature:
-                state["pending_signature"] = signature
-                state["pending_observed_at_ns"] = now_ns
-                state["updated_at_ns"] = now_ns
-                _schematic_live_preview_state_write(state_name, state)
-                payload = _schematic_live_preview_payload(
-                    status="pending_debounce",
-                    target=target,
-                    files=files,
-                    signature=signature,
-                    changed_files=changed_files,
-                    message="Change detected; waiting for debounce window before preview refresh.",
-                )
-                return text_tool_result(json.dumps(payload, indent=2), metadata=payload)
-            observed_at = int(state.get("pending_observed_at_ns") or now_ns)
-            if now_ns - observed_at < debounce_ns:
-                payload = _schematic_live_preview_payload(
-                    status="pending_debounce",
-                    target=target,
-                    files=files,
-                    signature=signature,
-                    changed_files=changed_files,
-                    message="Change is still inside the debounce window.",
-                )
-                return text_tool_result(json.dumps(payload, indent=2), metadata=payload)
-
-        reload_result = _reload_schematic() if reload else None
-        render_metadata: dict[str, Any] | None = None
-        output_path: Path | None = None
-        if render:
-            render_path = _schematic_live_preview_render_path(
-                target_path=target.path,
-                watched_files=files,
-                changed_files=changed_files,
-            )
-            data = parse_schematic_file(render_path)
-            if _schematic_has_renderable_content(data):
-                try:
-                    default_name = f"live-preview-{render_path.stem}.png"
-                    output_path = _safe_render_output_path(output_file, default_name=default_name)
-                    svg_file, image_metadata = _render_schematic_png_artifact(
-                        render_path,
-                        output_path,
-                        dpi=dpi,
-                        crop_to_content=crop_to_content,
-                        include_title_block=include_title_block,
-                    )
-                    render_metadata = {
-                        "status": "ok",
-                        "sheet_path": str(render_path),
-                        "png_path": str(output_path),
-                        "svg_path": str(svg_file),
-                        "dpi": dpi,
-                        "include_title_block": include_title_block,
-                        **image_metadata,
-                    }
-                except (OSError, RuntimeError, ValueError) as exc:
-                    render_metadata = {
-                        "status": "failed",
-                        "sheet_path": str(render_path),
-                        "message": str(exc),
-                    }
-            else:
-                render_metadata = {
-                    "status": "empty_sheet",
-                    "sheet_path": str(render_path),
-                    "message": "No schematic content was available to render.",
-                }
-
-        state["last_signature"] = signature
-        state["pending_signature"] = None
-        state["pending_observed_at_ns"] = None
-        state["last_changed_files"] = changed_files
-        state["last_render"] = render_metadata
-        state["last_reload_result"] = reload_result
-        state["updated_at_ns"] = now_ns
-        _schematic_live_preview_state_write(state_name, state)
-
-        status = "forced_rendered" if force else "changed"
-        if render_metadata and render_metadata.get("status") == "ok":
-            status = "forced_rendered" if force else "changed_rendered"
-        elif reload_result:
-            status = "forced_reloaded" if force else "changed_reloaded"
-        payload = _schematic_live_preview_payload(
-            status=status,
-            target=target,
-            files=files,
-            signature=signature,
-            changed_files=changed_files,
-            reload_result=reload_result,
-            render_metadata=render_metadata,
-            message=(
-                "A best-effort KiCad GUI reload was requested by opt-in reload=True; "
-                "schematic disk reload in the open GUI document is not confirmed."
-                if reload
-                else "Preview refreshed without forcing a KiCad GUI reload."
-            ),
-        )
-        if (
-            output_path is not None
-            and output_path.exists()
-            and render_metadata
-            and render_metadata.get("status") == "ok"
-        ):
-            return image_tool_result(output_path, payload)
-        return text_tool_result(json.dumps(payload, indent=2), metadata=payload)
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_render_png(
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-        crop_to_content: bool = True,
-        dpi: int = 200,
-        include_title_block: bool = True,
-        output_file: str | None = None,
-    ) -> CallToolResult:
-        """Render a schematic sheet to PNG for visual self-checks.
-
-        Uses headless ``kicad-cli sch export svg`` followed by SVG-to-PNG
-        conversion. Empty sheets return ``status=empty_sheet`` instead of a
-        misleading blank image.
-        """
-        if dpi < 72 or dpi > 600:
-            return text_tool_result("dpi must be between 72 and 600.")
-
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        data = parse_schematic_file(target.path)
-        if not _schematic_has_renderable_content(data):
-            metadata: dict[str, Any] = {
-                "status": "empty_sheet",
-                "sheet_path": str(target.path),
-                "message": "No schematic content was available to render.",
-            }
-            return text_tool_result(
-                json.dumps(metadata, indent=2),
-                metadata=metadata,
-            )
-
-        try:
-            png_file = _safe_render_output_path(output_file, default_name=f"{target.path.stem}.png")
-        except ValueError as exc:
-            return text_tool_result(f"Invalid output path: {exc}")
-        try:
-            svg_file, image_metadata = _render_schematic_png_artifact(
-                target.path,
-                png_file,
-                dpi=dpi,
-                crop_to_content=crop_to_content,
-                include_title_block=include_title_block,
-            )
-        except RuntimeError as exc:
-            return text_tool_result(f"Schematic PNG render failed: {exc}")
-        metadata = {
-            "status": "ok",
-            "png_path": str(png_file),
-            "svg_path": str(svg_file),
-            "sheet_path": str(target.path),
-            "dpi": dpi,
-            "include_title_block": include_title_block,
-            **image_metadata,
-        }
-        return image_tool_result(
-            png_file,
-            metadata,
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_render_visual_diff(
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-        dpi: int = 200,
-        include_title_block: bool = True,
-        output_file: str | None = None,
-    ) -> CallToolResult:
-        """Render the exact visual delta produced by the last schematic mutation.
-
-        The red pixels are the aligned before/after image difference. Metadata lists
-        every changed symbol, label/net, wire, bus, junction, or document object.
-        """
-        if dpi < 72 or dpi > 600:
-            return text_tool_result("dpi must be between 72 and 600.")
-
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        state = _load_schematic_visual_diff(target.path)
-        if state is None:
-            metadata: dict[str, Any] = {
-                "status": "no_recorded_mutation",
-                "sheet_path": str(target.path),
-                "message": "No mutation snapshot is available for this schematic.",
-            }
-            return text_tool_result(
-                json.dumps(metadata, indent=2),
-                metadata=metadata,
-            )
-
-        before_snapshot = Path(str(state.get("before_snapshot", "")))
-        if not before_snapshot.is_file():
-            metadata = {
-                "status": "missing_before_snapshot",
-                "sheet_path": str(target.path),
-                "before_snapshot": str(before_snapshot),
-            }
-            return text_tool_result(
-                json.dumps(metadata, indent=2),
-                metadata=metadata,
-            )
-
-        current_content = target.path.read_text(encoding="utf-8")
-        current_sha256 = hashlib.sha256(current_content.encode("utf-8")).hexdigest()
-        if current_sha256 != state.get("after_sha256"):
-            metadata = {
-                "status": "stale_mutation_snapshot",
-                "sheet_path": str(target.path),
-                "recorded_after_sha256": state.get("after_sha256"),
-                "current_sha256": current_sha256,
-                "message": "The schematic changed outside the recorded mutation.",
-            }
-            return text_tool_result(
-                json.dumps(metadata, indent=2),
-                metadata=metadata,
-            )
-
-        try:
-            diff_file = _safe_render_output_path(
-                output_file,
-                default_name=f"{target.path.stem}-visual-diff.png",
-            )
-        except ValueError as exc:
-            return text_tool_result(f"Invalid output path: {exc}")
-
-        artifact_dir = diff_file.parent / "_visual-diff"
-        artifact_dir.mkdir(parents=True, exist_ok=True)
-        before_png = artifact_dir / f"{diff_file.stem}-before.png"
-        after_png = artifact_dir / f"{diff_file.stem}-after.png"
-        try:
-            before_svg, before_metadata = _render_schematic_png_artifact(
-                before_snapshot,
-                before_png,
-                dpi=dpi,
-                crop_to_content=False,
-                include_title_block=include_title_block,
-            )
-            after_svg, after_metadata = _render_schematic_png_artifact(
-                target.path,
-                after_png,
-                dpi=dpi,
-                crop_to_content=False,
-                include_title_block=include_title_block,
-            )
-            diff_metadata = _render_png_visual_diff(before_png, after_png, diff_file)
-        except RuntimeError as exc:
-            return text_tool_result(f"Schematic visual diff failed: {exc}")
-
-        metadata2: dict[str, Any] = {
-            "status": "ok",
-            "diff_path": str(diff_file),
-            "before_png_path": str(before_png),
-            "after_png_path": str(after_png),
-            "before_svg_path": str(before_svg),
-            "after_svg_path": str(after_svg),
-            "sheet_path": str(target.path),
-            "dpi": dpi,
-            "include_title_block": include_title_block,
-            "before_render": before_metadata,
-            "after_render": after_metadata,
-            "changed_objects": state.get("changed_objects", []),
-            "changed_refs": state.get("changed_refs", []),
-            "changed_nets": state.get("changed_nets", []),
-            **diff_metadata,
-        }
-        return image_tool_result(diff_file, metadata2)
 
     @mcp.tool()
     @headless_compatible

--- a/src/kicad_mcp/tools/schematic_rendering.py
+++ b/src/kicad_mcp/tools/schematic_rendering.py
@@ -1,0 +1,122 @@
+"""Thin FastMCP adapter for schematic rendering and live preview."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult
+
+from ..mcp_media import image_tool_result, text_tool_result
+from ..schematic.rendering import SchematicRenderingResponse, SchematicRenderingService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicRenderingDependencies:
+    """Rendering service injected by the schematic composition root."""
+
+    service: SchematicRenderingService
+
+
+def _tool_result(response: SchematicRenderingResponse) -> CallToolResult:
+    if response.image_path is not None:
+        return image_tool_result(response.image_path, response.metadata or {})
+    return text_tool_result(response.text or "", metadata=response.metadata)
+
+
+def register(mcp: FastMCP, dependencies: SchematicRenderingDependencies) -> None:
+    """Register schematic rendering and live-preview tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_live_preview(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        include_child_sheets: bool = True,
+        debounce_ms: int = 750,
+        render: bool = True,
+        reload: bool = False,
+        force: bool = False,
+        crop_to_content: bool = True,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> CallToolResult:
+        """Poll a safe live schematic preview state and refresh rendered output on changes.
+
+        This is an opt-in polling watcher for agents and companion-plugin flows. It
+        records the current schematic file signature, debounces rapid writes, then
+        refreshes a PNG preview when the watched files are stable. KiCad GUI reload
+        is deliberately opt-in via ``reload=True`` because the tool cannot reliably
+        prove that the user has no unsaved GUI edits.
+        """
+        return _tool_result(
+            service.live_preview(
+                sheet=sheet,
+                sheet_file=sheet_file,
+                include_child_sheets=include_child_sheets,
+                debounce_ms=debounce_ms,
+                render=render,
+                reload=reload,
+                force=force,
+                crop_to_content=crop_to_content,
+                dpi=dpi,
+                include_title_block=include_title_block,
+                output_file=output_file,
+            )
+        )
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_render_png(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        crop_to_content: bool = True,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> CallToolResult:
+        """Render a schematic sheet to PNG for visual self-checks.
+
+        Uses headless ``kicad-cli sch export svg`` followed by SVG-to-PNG
+        conversion. Empty sheets return ``status=empty_sheet`` instead of a
+        misleading blank image.
+        """
+        return _tool_result(
+            service.render_png(
+                sheet=sheet,
+                sheet_file=sheet_file,
+                crop_to_content=crop_to_content,
+                dpi=dpi,
+                include_title_block=include_title_block,
+                output_file=output_file,
+            )
+        )
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_render_visual_diff(
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> CallToolResult:
+        """Render the exact visual delta produced by the last schematic mutation.
+
+        The red pixels are the aligned before/after image difference. Metadata lists
+        every changed symbol, label/net, wire, bus, junction, or document object.
+        """
+        return _tool_result(
+            service.render_visual_diff(
+                sheet=sheet,
+                sheet_file=sheet_file,
+                dpi=dpi,
+                include_title_block=include_title_block,
+                output_file=output_file,
+            )
+        )

--- a/tests/unit/test_schematic_rendering_architecture.py
+++ b/tests/unit/test_schematic_rendering_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_rendering_modules() -> None:
+    assert "kicad_mcp.schematic.rendering" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.rendering" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_rendering" in boundaries.DOMAIN_MODULES
+
+
+def test_rendering_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_rendering.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES["kicad_mcp.tools.schematic_rendering"] == (
+        "kicad_mcp.tools.schematic",
+    )
+
+
+def test_rendering_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_rendering.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_rendering"] == 300

--- a/tests/unit/test_schematic_rendering_registration.py
+++ b/tests/unit/test_schematic_rendering_registration.py
@@ -1,0 +1,266 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ImageContent, TextContent
+
+from kicad_mcp.schematic.rendering import SchematicRenderingResponse
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_rendering import (
+    SchematicRenderingDependencies,
+    register,
+)
+
+
+class FakeRenderingService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.responses: dict[str, SchematicRenderingResponse] = {
+            "live_preview": SchematicRenderingResponse(text="live"),
+            "render_png": SchematicRenderingResponse(text="png"),
+            "render_visual_diff": SchematicRenderingResponse(text="diff"),
+        }
+
+    def live_preview(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        include_child_sheets: bool = True,
+        debounce_ms: int = 750,
+        render: bool = True,
+        reload: bool = False,
+        force: bool = False,
+        crop_to_content: bool = True,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> SchematicRenderingResponse:
+        self.calls.append(
+            (
+                "live_preview",
+                {
+                    "sheet": sheet,
+                    "sheet_file": sheet_file,
+                    "include_child_sheets": include_child_sheets,
+                    "debounce_ms": debounce_ms,
+                    "render": render,
+                    "reload": reload,
+                    "force": force,
+                    "crop_to_content": crop_to_content,
+                    "dpi": dpi,
+                    "include_title_block": include_title_block,
+                    "output_file": output_file,
+                },
+            )
+        )
+        return self.responses["live_preview"]
+
+    def render_png(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        crop_to_content: bool = True,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> SchematicRenderingResponse:
+        self.calls.append(
+            (
+                "render_png",
+                {
+                    "sheet": sheet,
+                    "sheet_file": sheet_file,
+                    "crop_to_content": crop_to_content,
+                    "dpi": dpi,
+                    "include_title_block": include_title_block,
+                    "output_file": output_file,
+                },
+            )
+        )
+        return self.responses["render_png"]
+
+    def render_visual_diff(
+        self,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+        dpi: int = 200,
+        include_title_block: bool = True,
+        output_file: str | None = None,
+    ) -> SchematicRenderingResponse:
+        self.calls.append(
+            (
+                "render_visual_diff",
+                {
+                    "sheet": sheet,
+                    "sheet_file": sheet_file,
+                    "dpi": dpi,
+                    "include_title_block": include_title_block,
+                    "output_file": output_file,
+                },
+            )
+        )
+        return self.responses["render_visual_diff"]
+
+
+def _registered() -> tuple[FastMCP, FakeRenderingService]:
+    server = FastMCP("schematic-rendering-test")
+    service = FakeRenderingService()
+    register(server, SchematicRenderingDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_live_preview",
+        "sch_render_png",
+        "sch_render_visual_diff",
+    }
+    assert tools["sch_live_preview"].description == (
+        "Poll a safe live schematic preview state and refresh rendered output on changes.\n\n"
+        "This is an opt-in polling watcher for agents and companion-plugin flows. It\n"
+        "records the current schematic file signature, debounces rapid writes, then\n"
+        "refreshes a PNG preview when the watched files are stable. KiCad GUI reload\n"
+        "is deliberately opt-in via ``reload=True`` because the tool cannot reliably\n"
+        "prove that the user has no unsaved GUI edits.\n"
+    )
+    assert tools["sch_render_png"].description == (
+        "Render a schematic sheet to PNG for visual self-checks.\n\n"
+        "Uses headless ``kicad-cli sch export svg`` followed by SVG-to-PNG\n"
+        "conversion. Empty sheets return ``status=empty_sheet`` instead of a\n"
+        "misleading blank image.\n"
+    )
+    assert tools["sch_render_visual_diff"].description == (
+        "Render the exact visual delta produced by the last schematic mutation.\n\n"
+        "The red pixels are the aligned before/after image difference. Metadata lists\n"
+        "every changed symbol, label/net, wire, bus, junction, or document object.\n"
+    )
+
+    live_properties = tools["sch_live_preview"].parameters["properties"]
+    assert set(live_properties) == {
+        "sheet",
+        "sheet_file",
+        "include_child_sheets",
+        "debounce_ms",
+        "render",
+        "reload",
+        "force",
+        "crop_to_content",
+        "dpi",
+        "include_title_block",
+        "output_file",
+    }
+    assert live_properties["debounce_ms"]["default"] == 750
+    assert live_properties["dpi"]["default"] == 200
+    assert tools["sch_live_preview"].parameters["title"] == "sch_live_previewArguments"
+
+    png_properties = tools["sch_render_png"].parameters["properties"]
+    assert set(png_properties) == {
+        "sheet",
+        "sheet_file",
+        "crop_to_content",
+        "dpi",
+        "include_title_block",
+        "output_file",
+    }
+    assert tools["sch_render_png"].parameters["title"] == "sch_render_pngArguments"
+
+    diff_properties = tools["sch_render_visual_diff"].parameters["properties"]
+    assert set(diff_properties) == {
+        "sheet",
+        "sheet_file",
+        "dpi",
+        "include_title_block",
+        "output_file",
+    }
+    assert tools["sch_render_visual_diff"].parameters["title"] == "sch_render_visual_diffArguments"
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+
+    for tool in server._tool_manager.list_tools():
+        metadata = get_tool_metadata(tool.name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+        assert metadata.requires_kicad_running is False
+        assert tool.annotations is None
+
+
+def test_registration_delegates_exact_arguments_and_text_response() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    result = tools["sch_live_preview"].fn(
+        sheet="Power",
+        sheet_file=None,
+        include_child_sheets=False,
+        debounce_ms=12,
+        render=False,
+        reload=True,
+        force=True,
+        crop_to_content=False,
+        dpi=144,
+        include_title_block=False,
+        output_file="live.png",
+    )
+
+    assert service.calls == [
+        (
+            "live_preview",
+            {
+                "sheet": "Power",
+                "sheet_file": None,
+                "include_child_sheets": False,
+                "debounce_ms": 12,
+                "render": False,
+                "reload": True,
+                "force": True,
+                "crop_to_content": False,
+                "dpi": 144,
+                "include_title_block": False,
+                "output_file": "live.png",
+            },
+        )
+    ]
+    assert len(result.content) == 1
+    text = result.content[0]
+    assert isinstance(text, TextContent)
+    assert text.text == "live"
+    assert result.structuredContent is None
+
+
+def test_registration_converts_image_response(tmp_path: Path) -> None:
+    server, service = _registered()
+    image = tmp_path / "render.png"
+    image.write_bytes(b"png")
+    service.responses["render_png"] = SchematicRenderingResponse(
+        metadata={"status": "ok", "png_path": str(image)},
+        image_path=image,
+    )
+    tool = {item.name: item for item in server._tool_manager.list_tools()}["sch_render_png"]
+
+    result = tool.fn()
+
+    assert service.calls == [
+        (
+            "render_png",
+            {
+                "sheet": None,
+                "sheet_file": None,
+                "crop_to_content": True,
+                "dpi": 200,
+                "include_title_block": True,
+                "output_file": None,
+            },
+        )
+    ]
+    assert result.structuredContent == {"status": "ok", "png_path": str(image)}
+    assert any(isinstance(item, TextContent) for item in result.content)
+    assert any(isinstance(item, ImageContent) for item in result.content)

--- a/tests/unit/test_schematic_rendering_service.py
+++ b/tests/unit/test_schematic_rendering_service.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kicad_mcp.schematic.rendering import SchematicRenderingService
+
+
+@dataclass(frozen=True)
+class FakeTarget:
+    path: Path
+    description: str = "root"
+
+
+class RenderingHarness:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.schematic = tmp_path / "demo.kicad_sch"
+        self.schematic.write_text("content", encoding="utf-8")
+        self.target = FakeTarget(self.schematic)
+        self.renderable = True
+        self.visual_state: dict[str, Any] | None = None
+        self.preview_state: dict[str, Any] | None = None
+        self.signature: dict[str, Any] = {"files": [{"path": str(self.schematic), "sha256": "a"}]}
+        self.changed_files: list[str] = [str(self.schematic)]
+        self.render_error: Exception | None = None
+        self.diff_error: Exception | None = None
+        self.safe_output_error: ValueError | None = None
+        self.now = 10_000_000_000
+        self.reload_result = "reloaded"
+        self.writes: list[tuple[str, dict[str, Any]]] = []
+        self.render_calls: list[tuple[Path, Path, int, bool, bool]] = []
+        self.diff_calls: list[tuple[Path, Path, Path]] = []
+
+    def service(self) -> SchematicRenderingService:
+        return SchematicRenderingService(
+            resolve_target=lambda sheet, sheet_file: self.target,
+            parse_schematic=lambda path: {"symbols": [1]} if self.renderable else {},
+            has_renderable_content=lambda data: bool(data.get("symbols")),
+            safe_output_path=self.safe_output_path,
+            render_png_artifact=self.render_png_artifact,
+            load_visual_diff=lambda path: self.visual_state,
+            render_png_visual_diff=self.render_png_visual_diff,
+            preview_files=lambda root, include_children: [root],
+            preview_signature=lambda paths: self.signature,
+            preview_state_filename=lambda path, include_children: "preview.json",
+            preview_state_read=lambda filename: self.preview_state,
+            preview_state_write=self.preview_state_write,
+            preview_changed_files=lambda before, after: self.changed_files,
+            preview_render_path=lambda target_path, watched_files, changed_files: target_path,
+            preview_payload=self.preview_payload,
+            reload_schematic=lambda: self.reload_result,
+            now_ns=lambda: self.now,
+        )
+
+    def safe_output_path(self, raw_name: str | None, default_name: str) -> Path:
+        if self.safe_output_error is not None:
+            raise self.safe_output_error
+        return self.tmp_path / (raw_name or default_name)
+
+    def render_png_artifact(
+        self,
+        schematic: Path,
+        output: Path,
+        dpi: int,
+        crop_to_content: bool,
+        include_title_block: bool,
+    ) -> tuple[Path, dict[str, object]]:
+        self.render_calls.append((schematic, output, dpi, crop_to_content, include_title_block))
+        if self.render_error is not None:
+            raise self.render_error
+        output.write_bytes(b"png")
+        svg = output.with_suffix(".svg")
+        svg.write_text("<svg/>", encoding="utf-8")
+        return svg, {"width_px": 32, "height_px": 16, "cropped": crop_to_content}
+
+    def render_png_visual_diff(self, before: Path, after: Path, output: Path) -> dict[str, object]:
+        self.diff_calls.append((before, after, output))
+        if self.diff_error is not None:
+            raise self.diff_error
+        output.write_bytes(b"diff")
+        return {"changed_pixels": 3, "changed_bbox_px": [1, 2, 3, 4]}
+
+    def preview_state_write(self, filename: str, state: dict[str, Any]) -> None:
+        self.preview_state = dict(state)
+        self.writes.append((filename, dict(state)))
+
+    def preview_payload(
+        self,
+        *,
+        status: str,
+        target: FakeTarget,
+        files: list[Path],
+        signature: dict[str, Any],
+        changed_files: list[str] | None = None,
+        message: str | None = None,
+        reload_result: str | None = None,
+        render_metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload = {
+            "status": status,
+            "target": target.description,
+            "target_path": str(target.path),
+            "watch_files": [str(path) for path in files],
+            "signature": signature,
+            "changed_files": changed_files or [],
+        }
+        if message:
+            payload["message"] = message
+        if reload_result:
+            payload["reload_result"] = reload_result
+        if render_metadata:
+            payload["render"] = render_metadata
+        return payload
+
+
+def _json(response_text: str | None) -> dict[str, Any]:
+    assert response_text is not None
+    return json.loads(response_text)
+
+
+def test_render_png_validates_dpi_and_handles_empty_sheet(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    service = harness.service()
+
+    invalid = service.render_png(dpi=71)
+    assert invalid.text == "dpi must be between 72 and 600."
+    assert invalid.metadata is None
+
+    harness.renderable = False
+    empty = service.render_png()
+    assert (
+        _json(empty.text)
+        == empty.metadata
+        == {
+            "status": "empty_sheet",
+            "sheet_path": str(harness.schematic),
+            "message": "No schematic content was available to render.",
+        }
+    )
+
+
+def test_render_png_preserves_output_errors_and_success_metadata(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    service = harness.service()
+
+    harness.safe_output_error = ValueError("unsafe")
+    assert service.render_png(output_file="bad.png").text == "Invalid output path: unsafe"
+
+    harness.safe_output_error = None
+    harness.render_error = RuntimeError("cli failed")
+    assert service.render_png().text == "Schematic PNG render failed: cli failed"
+
+    harness.render_error = None
+    response = service.render_png(
+        dpi=150,
+        crop_to_content=False,
+        include_title_block=False,
+        output_file="render.png",
+    )
+    assert response.image_path == tmp_path / "render.png"
+    assert response.metadata == {
+        "status": "ok",
+        "png_path": str(tmp_path / "render.png"),
+        "svg_path": str(tmp_path / "render.svg"),
+        "sheet_path": str(harness.schematic),
+        "dpi": 150,
+        "include_title_block": False,
+        "width_px": 32,
+        "height_px": 16,
+        "cropped": False,
+    }
+
+
+def test_visual_diff_handles_missing_and_stale_snapshots(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    service = harness.service()
+
+    missing = service.render_visual_diff()
+    assert _json(missing.text)["status"] == "no_recorded_mutation"
+
+    before = tmp_path / "before.kicad_sch"
+    harness.visual_state = {"before_snapshot": str(before), "after_sha256": "x"}
+    assert _json(service.render_visual_diff().text)["status"] == "missing_before_snapshot"
+
+    before.write_text("before", encoding="utf-8")
+    stale = _json(service.render_visual_diff().text)
+    assert stale["status"] == "stale_mutation_snapshot"
+    assert stale["current_sha256"] == hashlib.sha256(b"content").hexdigest()
+
+
+def test_visual_diff_renders_exact_artifacts_and_metadata(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    before = tmp_path / "before.kicad_sch"
+    before.write_text("before", encoding="utf-8")
+    harness.visual_state = {
+        "before_snapshot": str(before),
+        "after_sha256": hashlib.sha256(b"content").hexdigest(),
+        "changed_objects": [{"kind": "label"}],
+        "changed_refs": ["R1"],
+        "changed_nets": ["READY"],
+    }
+    service = harness.service()
+
+    harness.safe_output_error = ValueError("unsafe")
+    assert service.render_visual_diff().text == "Invalid output path: unsafe"
+
+    harness.safe_output_error = None
+    harness.render_error = RuntimeError("export failed")
+    assert service.render_visual_diff().text == "Schematic visual diff failed: export failed"
+
+    harness.render_error = None
+    response = service.render_visual_diff(
+        dpi=144, include_title_block=False, output_file="delta.png"
+    )
+    assert response.image_path == tmp_path / "delta.png"
+    assert response.metadata is not None
+    assert response.metadata["status"] == "ok"
+    assert response.metadata["changed_pixels"] == 3
+    assert response.metadata["changed_refs"] == ["R1"]
+    assert response.metadata["changed_nets"] == ["READY"]
+    assert response.metadata["before_render"]["cropped"] is False  # type: ignore[index]
+    assert response.metadata["after_render"]["cropped"] is False  # type: ignore[index]
+
+
+def test_live_preview_validates_arguments_and_initializes_state(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    service = harness.service()
+
+    assert service.live_preview(debounce_ms=-1).text == ("debounce_ms must be between 0 and 60000.")
+    assert service.live_preview(dpi=601).text == "dpi must be between 72 and 600."
+
+    response = service.live_preview(render=False)
+    payload = _json(response.text)
+    assert payload["status"] == "initialized"
+    assert harness.preview_state == {
+        "last_signature": harness.signature,
+        "pending_signature": None,
+        "pending_observed_at_ns": None,
+        "updated_at_ns": harness.now,
+    }
+
+
+def test_live_preview_handles_no_change_and_debounce(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    service = harness.service()
+
+    harness.preview_state = {
+        "last_signature": harness.signature,
+        "pending_signature": {"files": []},
+        "pending_observed_at_ns": 1,
+    }
+    no_change = _json(service.live_preview(render=False).text)
+    assert no_change["status"] == "no_change"
+    assert harness.preview_state["pending_signature"] is None
+
+    old_signature = {"files": [{"path": str(harness.schematic), "sha256": "old"}]}
+    harness.preview_state = {
+        "last_signature": old_signature,
+        "pending_signature": None,
+        "pending_observed_at_ns": None,
+    }
+    pending = _json(service.live_preview(render=False, debounce_ms=1000).text)
+    assert pending["status"] == "pending_debounce"
+    assert harness.preview_state["pending_signature"] == harness.signature
+
+    harness.preview_state = {
+        "last_signature": old_signature,
+        "pending_signature": harness.signature,
+        "pending_observed_at_ns": harness.now - 500_000_000,
+    }
+    inside = _json(service.live_preview(render=False, debounce_ms=1000).text)
+    assert inside["status"] == "pending_debounce"
+    assert inside["message"] == "Change is still inside the debounce window."
+
+
+def test_live_preview_refreshes_render_and_reload_state(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    old_signature = {"files": [{"path": str(harness.schematic), "sha256": "old"}]}
+    harness.preview_state = {
+        "last_signature": old_signature,
+        "pending_signature": harness.signature,
+        "pending_observed_at_ns": 0,
+    }
+    service = harness.service()
+
+    response = service.live_preview(
+        debounce_ms=0,
+        render=True,
+        reload=True,
+        dpi=150,
+        include_title_block=False,
+        output_file="live.png",
+    )
+    assert response.image_path == tmp_path / "live.png"
+    assert response.metadata is not None
+    assert response.metadata["status"] == "changed_rendered"
+    assert response.metadata["reload_result"] == "reloaded"
+    assert response.metadata["render"]["status"] == "ok"  # type: ignore[index]
+    assert harness.preview_state["last_signature"] == harness.signature
+    assert harness.preview_state["last_render"]["status"] == "ok"
+
+
+def test_live_preview_reports_failed_and_empty_render_without_image(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    harness.preview_state = {
+        "last_signature": {"files": []},
+        "pending_signature": harness.signature,
+        "pending_observed_at_ns": 0,
+    }
+    harness.render_error = RuntimeError("renderer unavailable")
+    failed = harness.service().live_preview(debounce_ms=0, render=True)
+    assert failed.image_path is None
+    assert _json(failed.text)["render"]["status"] == "failed"
+
+    harness.preview_state = {
+        "last_signature": {"files": []},
+        "pending_signature": harness.signature,
+        "pending_observed_at_ns": 0,
+    }
+    harness.render_error = None
+    harness.renderable = False
+    empty = harness.service().live_preview(debounce_ms=0, render=True)
+    assert empty.image_path is None
+    assert _json(empty.text)["render"]["status"] == "empty_sheet"
+
+
+def test_live_preview_force_renders_on_first_call(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    response = harness.service().live_preview(force=True, render=True)
+
+    assert response.image_path is not None
+    assert response.metadata is not None
+    assert response.metadata["status"] == "forced_rendered"


### PR DESCRIPTION
## Summary

- extract `sch_live_preview`, `sch_render_png`, and `sch_render_visual_diff` orchestration into a FastMCP-independent `SchematicRenderingService`
- register the three public tools through a thin adapter while preserving legacy renderer monkeypatch seams
- add direct service, adapter, integration, fallback, metadata, and architecture-boundary coverage
- document exact contract and repository-gate evidence

## Architecture impact

- `src/kicad_mcp/tools/schematic.py` remains the composition root
- its `register()` span decreases from 1,657 to 1,368 lines
- the new adapter `register()` is 93 lines
- the service has no FastMCP or schematic-registry dependency

## Contract preservation

Exact full-server metadata matches `main` for all three tools: names, descriptions, input/output schemas, annotations, MCP metadata, and headless/KiCad-running metadata. The committed tool-surface snapshot is unchanged.

## Verification

- 1,749 selected unit tests collected; full unit gate passed with 5 skips and no failures
- focused rendering service/adapter coverage: 193 statements, 98%
- focused PNG render, visual diff, live-preview debounce/child-sheet/bounds, renderer-fallback, protocol-contract, and tool-surface tests passed
- Ruff format/check, mypy, scoped Pyright, architecture checks, generated metadata/docs, strict MkDocs, latency benchmark, Bandit, dependency audit, GitHub Actions policy, zizmor, actionlint, package build, and package metadata checks passed

Closes part of #434.