### PR TITLE
test(schematic): complete rendering edge-path coverage

### DIFF
--- a/docs/superpowers/plans/2026-07-24-schematic-rendering-service.md
+++ b/docs/superpowers/plans/2026-07-24-schematic-rendering-service.md
@@ -80,12 +80,12 @@
 ## Verification Evidence
 
 - TDD red/green evidence was observed for the absent rendering service, absent adapter, and missing architecture-policy entries before implementation.
-- Direct service and adapter suite: 13 tests passed; architecture suite: 3 tests passed; focused integration, fallback, protocol-contract, and tool-surface suite: 15 tests passed.
-- Focused coverage: 193 statements, 98% total (`rendering.py` 165 statements at 99%; `schematic_rendering.py` 28 statements at 96%), exceeding the 83% requirement.
+- Direct service and adapter suite: 16 tests passed; architecture suite: 3 tests passed; focused integration, fallback, protocol-contract, and tool-surface suite: 15 tests passed.
+- Focused coverage: 193 statements, 100% total (`rendering.py` 165/165; `schematic_rendering.py` 28/28), exceeding the 83% requirement.
 - Exact full-server metadata matches `main` for all three tools: names, descriptions, input schemas, output schemas, annotations, MCP metadata, and headless/KiCad-running metadata.
 - Committed tool-surface snapshot passed unchanged.
 - Main schematic `register()` span decreased from 1,657 lines on `main` to 1,368 lines; the new adapter `register()` is 93 lines.
-- Full selected unit gate passed: 1,749 tests collected, 5 skipped, no failures.
+- Full selected unit gate passed before the review-coverage additions: 1,749 tests collected, 5 skipped, no failures. The pre-push gate then passed again with the three added coverage tests.
 - Focused schematic PNG render, visual diff, live-preview debounce/child-sheet/bounds, renderer-fallback, protocol-contract, and snapshot tests passed.
 - Formatting, Ruff, mypy, scoped Pyright, architecture, metadata, generated references, parity, profile, tool-contract, compatibility, runtime-policy, strict MkDocs, latency benchmark, Bandit, dependency audit, GitHub Actions policy, zizmor, actionlint workflow checks, package build, and package metadata checks all passed.
 - The repository bootstrap reproduced the known `actionlint-py` wheel-install `EPERM` on the exec-agent filesystem. Verification used the locked environment with `uv sync --all-extras --frozen --no-install-package actionlint-py` and the exact cached actionlint binary; no source or lockfile changes were required.

--- a/tests/unit/test_schematic_rendering_registration.py
+++ b/tests/unit/test_schematic_rendering_registration.py
@@ -264,3 +264,33 @@ def test_registration_converts_image_response(tmp_path: Path) -> None:
     assert result.structuredContent == {"status": "ok", "png_path": str(image)}
     assert any(isinstance(item, TextContent) for item in result.content)
     assert any(isinstance(item, ImageContent) for item in result.content)
+
+
+def test_registration_delegates_visual_diff_response() -> None:
+    server, service = _registered()
+    tool = {item.name: item for item in server._tool_manager.list_tools()}["sch_render_visual_diff"]
+
+    result = tool.fn(
+        sheet="Power",
+        sheet_file=None,
+        dpi=144,
+        include_title_block=False,
+        output_file="delta.png",
+    )
+
+    assert service.calls == [
+        (
+            "render_visual_diff",
+            {
+                "sheet": "Power",
+                "sheet_file": None,
+                "dpi": 144,
+                "include_title_block": False,
+                "output_file": "delta.png",
+            },
+        )
+    ]
+    assert len(result.content) == 1
+    text = result.content[0]
+    assert isinstance(text, TextContent)
+    assert text.text == "diff"

--- a/tests/unit/test_schematic_rendering_service.py
+++ b/tests/unit/test_schematic_rendering_service.py
@@ -335,3 +335,30 @@ def test_live_preview_force_renders_on_first_call(tmp_path: Path) -> None:
     assert response.image_path is not None
     assert response.metadata is not None
     assert response.metadata["status"] == "forced_rendered"
+
+
+def test_visual_diff_validates_dpi(tmp_path: Path) -> None:
+    response = RenderingHarness(tmp_path).service().render_visual_diff(dpi=601)
+
+    assert response.text == "dpi must be between 72 and 600."
+    assert response.metadata is None
+
+
+def test_live_preview_reports_reload_only_status(tmp_path: Path) -> None:
+    harness = RenderingHarness(tmp_path)
+    harness.preview_state = {
+        "last_signature": {"files": []},
+        "pending_signature": harness.signature,
+        "pending_observed_at_ns": 0,
+    }
+
+    response = harness.service().live_preview(
+        debounce_ms=0,
+        render=False,
+        reload=True,
+    )
+
+    assert response.image_path is None
+    assert response.metadata is not None
+    assert response.metadata["status"] == "changed_reloaded"
+    assert response.metadata["reload_result"] == "reloaded"


### PR DESCRIPTION
## Summary

- add direct coverage for visual-diff DPI validation
- cover the reload-only live-preview status transition
- cover the visual-diff adapter delegation path
- update recorded evidence to reflect 100% focused rendering coverage

## Verification

- focused rendering service/adapter suite: 16 tests passed
- 193/193 focused statements covered (100%)
- pre-push full unit gate passed before publication

Follow-up to #456 and part of #434.