### PR TITLE
refactor(schematic): extract circuit compilation service

### DIFF
--- a/docs/superpowers/plans/2026-07-24-schematic-circuit-compilation-service.md
+++ b/docs/superpowers/plans/2026-07-24-schematic-circuit-compilation-service.md
@@ -24,12 +24,12 @@
 - Create: `src/kicad_mcp/schematic/circuit_compilation.py`
 - Create: `tests/unit/test_schematic_circuit_compilation_service.py`
 
-- [ ] Write direct tests for analysis delegation, empty builds, unresolved warnings/errors, paper preservation/growth, library deduplication, generated elements, transaction flags, reload ordering, and result notes.
-- [ ] Run the service test; expect collection failure because the module is absent.
-- [ ] Implement `PreparedCircuitInputs` and the minimal injected service while preserving legacy behavior byte-for-byte.
-- [ ] Re-run service tests; expect all pass.
-- [ ] Run Ruff, mypy, and scoped Pyright.
-- [ ] Commit with `refactor(schematic): extract circuit compilation service`.
+- [x] Write direct tests for analysis delegation, empty builds, unresolved warnings/errors, paper preservation/growth, library deduplication, generated elements, transaction flags, reload ordering, and result notes.
+- [x] Run the service test; expect collection failure because the module is absent.
+- [x] Implement `PreparedCircuitInputs` and the minimal injected service while preserving legacy behavior byte-for-byte.
+- [x] Re-run service tests; expect all pass.
+- [x] Run Ruff, mypy, and scoped Pyright.
+- [x] Commit with `refactor(schematic): extract circuit compilation service`.
 
 ### Task 2: Add the thin adapter and composition wiring
 
@@ -38,11 +38,11 @@
 - Create: `tests/unit/test_schematic_circuit_compilation_registration.py`
 - Modify: `src/kicad_mcp/tools/schematic.py`
 
-- [ ] Write adapter tests for exact names, descriptions, schemas, annotations, and delegation.
-- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
-- [ ] Implement the adapter, wire lazy compatibility dependencies in the composition root, and remove the two nested legacy functions.
-- [ ] Run service, adapter, focused integration, authoring-surface, and tool-surface tests.
-- [ ] Commit with `refactor(schematic): delegate circuit compilation registration`.
+- [x] Write adapter tests for exact names, descriptions, schemas, annotations, and delegation.
+- [x] Run the adapter test; expect collection failure because the adapter module is absent.
+- [x] Implement the adapter, wire lazy compatibility dependencies in the composition root, and remove the two nested legacy functions.
+- [x] Run service, adapter, focused integration, authoring-surface, and tool-surface tests.
+- [x] Commit with `refactor(schematic): delegate circuit compilation registration`.
 
 ### Task 3: Enforce architecture and public-contract stability
 
@@ -50,21 +50,32 @@
 - Modify: `scripts/check_architecture_boundaries.py`
 - Create: `tests/unit/test_schematic_circuit_compilation_architecture.py`
 
-- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
-- [ ] Run the architecture test; expect failure because policy entries are absent.
-- [ ] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
-- [ ] Compare exact full-server metadata for both tools against `main` and run the committed tool-surface snapshot.
-- [ ] Commit with `test(architecture): guard circuit compilation boundaries`.
+- [x] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
+- [x] Run the architecture test; expect failure because policy entries are absent.
+- [x] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
+- [x] Compare exact full-server metadata for both tools against `main` and run the committed tool-surface snapshot.
+- [x] Commit with `test(architecture): guard circuit compilation boundaries`.
 
 ### Task 4: Record evidence and run repository gates
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-24-schematic-circuit-compilation-service.md`
 
-- [ ] Run focused service/adapter coverage and require at least 83%.
-- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
-- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
-- [ ] Commit with `docs(architecture): record circuit compilation evidence`.
+- [x] Run focused service/adapter coverage and require at least 83%.
+- [x] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
+- [x] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
+- [x] Commit with `docs(architecture): record circuit compilation evidence`.
+
+## Verification Evidence
+
+- TDD red/green evidence was observed for the absent service, absent adapter, and missing architecture-policy entries before implementation.
+- Direct service, adapter, and architecture suites passed; focused schematic integration and committed tool-surface tests passed unchanged.
+- Focused coverage is 100%: 126 statements (`circuit_compilation.py` 110 and `schematic_circuit_compilation.py` 16), with no missed lines.
+- Exact full-server metadata matches `main` for both tools, including names, descriptions, input/output schemas, annotations, MCP metadata, and compatibility metadata.
+- The monolithic schematic `register()` span decreased from 1,368 lines on `main` to 1,110 lines; the new adapter `register()` is 85 lines.
+- Full selected unit gate passed: 1,765 tests selected from 1,768 collected, 5 skipped, no failures.
+- Formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated references, parity, profile, tool-contract, compatibility, runtime-policy, strict MkDocs, latency benchmark, Bandit, dependency audit, GitHub Actions policy, zizmor, actionlint workflow checks, package build, and package metadata checks all passed.
+- The repository bootstrap reproduced the known `actionlint-py` wheel-install `EPERM` on the exec-agent filesystem. Verification used the locked environment with `uv sync --all-extras --frozen --no-install-package actionlint-py` and the exact cached actionlint binary; no source or lockfile changes were required.
 
 ### Task 5: Open, review, and merge the pull request
 

--- a/docs/superpowers/plans/2026-07-24-schematic-circuit-compilation-service.md
+++ b/docs/superpowers/plans/2026-07-24-schematic-circuit-compilation-service.md
@@ -1,0 +1,75 @@
+# Schematic Circuit Compilation Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `sch_analyze_net_compilation` and `sch_build_circuit` from the monolithic schematic FastMCP registry into a directly testable service and thin adapter without changing public contracts or generated schematic behavior.
+
+**Architecture:** Add one FastMCP-free circuit-compilation service with a prepared-input data object and explicit injected dependencies, plus one thin registration adapter. Keep `src/kicad_mcp/tools/schematic.py` as the composition root and inject lazy wrappers around current helpers to preserve monkeypatch compatibility.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic models, pytest, Ruff, mypy, Pyright, existing schematic netlist and architecture tooling.
+
+## Global Constraints
+
+- Preserve exact public names, signatures, descriptions, schemas, annotations, validation/error text, warning events, generated schematic text, transaction flags, reload ordering, and result notes.
+- Do not change routing, auto-layout, validation, symbol lookup, paper handling, or serialization algorithms.
+- Keep the adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Keep the committed tool-surface snapshot unchanged.
+
+---
+
+### Task 1: Add the FastMCP-free circuit compilation service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/circuit_compilation.py`
+- Create: `tests/unit/test_schematic_circuit_compilation_service.py`
+
+- [ ] Write direct tests for analysis delegation, empty builds, unresolved warnings/errors, paper preservation/growth, library deduplication, generated elements, transaction flags, reload ordering, and result notes.
+- [ ] Run the service test; expect collection failure because the module is absent.
+- [ ] Implement `PreparedCircuitInputs` and the minimal injected service while preserving legacy behavior byte-for-byte.
+- [ ] Re-run service tests; expect all pass.
+- [ ] Run Ruff, mypy, and scoped Pyright.
+- [ ] Commit with `refactor(schematic): extract circuit compilation service`.
+
+### Task 2: Add the thin adapter and composition wiring
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_circuit_compilation.py`
+- Create: `tests/unit/test_schematic_circuit_compilation_registration.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+
+- [ ] Write adapter tests for exact names, descriptions, schemas, annotations, and delegation.
+- [ ] Run the adapter test; expect collection failure because the adapter module is absent.
+- [ ] Implement the adapter, wire lazy compatibility dependencies in the composition root, and remove the two nested legacy functions.
+- [ ] Run service, adapter, focused integration, authoring-surface, and tool-surface tests.
+- [ ] Commit with `refactor(schematic): delegate circuit compilation registration`.
+
+### Task 3: Enforce architecture and public-contract stability
+
+**Files:**
+- Modify: `scripts/check_architecture_boundaries.py`
+- Create: `tests/unit/test_schematic_circuit_compilation_architecture.py`
+
+- [ ] Write failing architecture tests requiring the service and adapter to be tracked, forbidding monolith imports, and enforcing the 300-line limit.
+- [ ] Run the architecture test; expect failure because policy entries are absent.
+- [ ] Add the new modules to the architecture checker and rerun focused architecture plus the checker.
+- [ ] Compare exact full-server metadata for both tools against `main` and run the committed tool-surface snapshot.
+- [ ] Commit with `test(architecture): guard circuit compilation boundaries`.
+
+### Task 4: Record evidence and run repository gates
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-24-schematic-circuit-compilation-service.md`
+
+- [ ] Run focused service/adapter coverage and require at least 83%.
+- [ ] Run formatting, Ruff, mypy, scoped Pyright, architecture, metadata/generated-doc checks, tool-surface snapshot, strict docs, latency, security, workflow, package, focused integration, and full unit gates.
+- [ ] Record exact metadata equality, focused/full test counts, coverage, register spans, and gate outcomes.
+- [ ] Commit with `docs(architecture): record circuit compilation evidence`.
+
+### Task 5: Open, review, and merge the pull request
+
+- [ ] Push and open a professional English PR referencing #434.
+- [ ] Inspect CI, bot comments, reviews, and review threads.
+- [ ] Address every actionable finding and rerun affected checks.
+- [ ] Merge only after required checks pass and the merge state is clean.
+- [ ] Update `main` and remove the worktree and local/remote topic branch.

--- a/docs/superpowers/specs/2026-07-24-schematic-circuit-compilation-service-design.md
+++ b/docs/superpowers/specs/2026-07-24-schematic-circuit-compilation-service-design.md
@@ -1,0 +1,47 @@
+# Schematic Circuit Compilation Service Design
+
+## Context
+
+Issue #434 is incrementally reducing `src/kicad_mcp/tools/schematic.py` into a small FastMCP composition root. `sch_analyze_net_compilation` and `sch_build_circuit` still combine public registration, netlist compilation orchestration, whole-document generation, symbol-library loading, paper-size preservation, transactional writes, warnings, and result rendering inside the registry.
+
+This tranche extracts only those two circuit-compilation tools.
+
+## Goals
+
+- Make net-compilation analysis and whole-schematic generation directly unit-testable without FastMCP.
+- Preserve exact public names, signatures, descriptions, schemas, annotations, validation errors, generated schematic text, warning events, transactional behavior, and result notes.
+- Preserve existing monkeypatch seams by injecting lazy composition-root wrappers around current helpers.
+- Keep the adapter `register()` function at or below 300 lines.
+- Keep domain code independent of FastMCP and `kicad_mcp.tools.schematic`.
+
+## Non-goals
+
+- No net-routing, auto-layout, validation, symbol-resolution, or serialization algorithm changes.
+- No public input/output changes.
+- No changes to transaction safety or approval behavior.
+- No new runtime dependencies.
+
+## Architecture
+
+Create `PreparedCircuitInputs` and `SchematicCircuitCompilationService` in `src/kicad_mcp/schematic/circuit_compilation.py`. The service receives explicit callables for input preparation, report rendering, active-file/project resolution, paper declarations, symbol-library loading, primitive block generation, connectivity normalization, validation, transactional writing, reload, and warning emission.
+
+Create `src/kicad_mcp/tools/schematic_circuit_compilation.py` as the thin FastMCP adapter. It preserves both public signatures and docstrings and delegates directly to the service.
+
+Keep `src/kicad_mcp/tools/schematic.py` as the composition root. Lazy wrappers continue resolving current module globals at call time so existing tests and integrations that monkeypatch helper functions after registration keep working.
+
+## Behavior Preservation
+
+- `sch_analyze_net_compilation` invokes the same preparation helper and report renderer with the same routing-mode and explicit-wire calculations.
+- `sch_build_circuit` preserves the active paper declaration, including custom User dimensions, and only promotes named paper sizes when auto-layout grows the sheet.
+- Unresolved-net warning fields and the complete no-routable-terminal error text remain unchanged.
+- Regular and power symbol library definitions remain deduplicated in encounter order.
+- Symbol, power, wire, and label blocks retain the same snapping and argument behavior.
+- Generated KiCad document structure, connectivity normalization, validation, transaction flags, reload ordering, and result notes remain byte-for-byte compatible.
+
+## Testing
+
+Direct service tests cover analysis delegation, unresolved-net errors and warnings, empty builds, paper preservation/growth, library deduplication, generated document structure, terminal/routed notes, and partial unresolved warnings. Adapter tests pin exact metadata and delegation. Existing integration and tool-surface tests remain the compatibility oracle.
+
+## Expected Result
+
+The main schematic `register()` function loses approximately 290 lines. Circuit compilation becomes independently testable while its public MCP contract and generated schematic behavior remain unchanged.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -31,6 +31,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "basic_authoring.py",
+    "kicad_mcp.schematic.circuit_compilation": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "circuit_compilation.py",
     "kicad_mcp.schematic.destructive_edit": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -71,6 +75,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_basic_authoring.py",
+    "kicad_mcp.tools.schematic_circuit_compilation": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_circuit_compilation.py",
     "kicad_mcp.tools.schematic_destructive_edit": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -133,6 +141,7 @@ PURE_HELPERS = {
     "kicad_mcp.models.visual_qa",
     "kicad_mcp.schematic.back_annotation",
     "kicad_mcp.schematic.basic_authoring",
+    "kicad_mcp.schematic.circuit_compilation",
     "kicad_mcp.schematic.destructive_edit",
     "kicad_mcp.schematic.document_settings",
     "kicad_mcp.schematic.hierarchy_authoring",
@@ -161,6 +170,7 @@ FORBIDDEN_PURE_IMPORT_PREFIXES = (
 ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_back_annotation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_basic_authoring": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_circuit_compilation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_document_settings": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
@@ -177,6 +187,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
 REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_back_annotation": 300,
     "kicad_mcp.tools.schematic_basic_authoring": 300,
+    "kicad_mcp.tools.schematic_circuit_compilation": 300,
     "kicad_mcp.tools.schematic_destructive_edit": 300,
     "kicad_mcp.tools.schematic_document_settings": 300,
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,

--- a/src/kicad_mcp/schematic/circuit_compilation.py
+++ b/src/kicad_mcp/schematic/circuit_compilation.py
@@ -1,0 +1,353 @@
+"""FastMCP-independent schematic circuit compilation services."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..models.schematic import AddLabelInput, AddSymbolInput, AddWireInput, PowerSymbolInput
+
+
+@dataclass(frozen=True)
+class PreparedCircuitInputs:
+    """Validated and generated inputs produced by the legacy compilation planner."""
+
+    symbols: list[AddSymbolInput]
+    powers: list[PowerSymbolInput]
+    labels: list[AddLabelInput]
+    wires: list[AddWireInput]
+    nets: list[dict[str, Any]]
+    generated_wires: list[dict[str, float | bool]]
+    unresolved_nets: list[dict[str, Any]]
+    resolution_stats: dict[str, int]
+    chosen_paper: str
+
+
+class PrepareInputs(Protocol):
+    def __call__(
+        self,
+        *,
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+        paper: str = "A4",
+    ) -> PreparedCircuitInputs: ...
+
+
+class RenderReport(Protocol):
+    def __call__(
+        self,
+        *,
+        symbols: list[AddSymbolInput],
+        powers: list[PowerSymbolInput],
+        labels: list[AddLabelInput],
+        explicit_wires: int,
+        nets: list[dict[str, Any]],
+        generated_wires: list[dict[str, float | bool]],
+        unresolved_nets: list[dict[str, Any]],
+        resolution_stats: dict[str, int],
+        auto_layout: bool,
+        terminalized: bool = True,
+    ) -> str: ...
+
+
+class PlaceSymbolBlock(Protocol):
+    def __call__(
+        self,
+        *,
+        lib_id: str,
+        x: float,
+        y: float,
+        reference: str,
+        value: str,
+        footprint: str = "",
+        rotation: int = 0,
+        unit: int = 1,
+        project_name: str,
+        root_uuid: str,
+    ) -> str: ...
+
+
+class LabelBlock(Protocol):
+    def __call__(
+        self,
+        name: str,
+        x: float,
+        y: float,
+        rotation: int,
+        *,
+        global_label: bool,
+        shape: str | None,
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class SchematicCircuitCompilationService:
+    """Analyze net compilation and generate complete schematic documents."""
+
+    active_schematic_file: Callable[[], Path]
+    project_name: Callable[[], str]
+    read_sheet_paper: Callable[[Path], str]
+    read_sheet_paper_declaration: Callable[[Path], str]
+    prepare_inputs: PrepareInputs
+    render_report: RenderReport
+    paper_sizes: Mapping[str, object]
+    new_uuid: Callable[[], str]
+    load_lib_symbol: Callable[[str, str], str | None]
+    snap_point: Callable[[float, float, bool], tuple[float, float]]
+    place_symbol_block: PlaceSymbolBlock
+    wire_block: Callable[[float, float, float, float], str]
+    snap_line: Callable[[float, float, float, float, bool], tuple[float, float, float, float]]
+    label_block: LabelBlock
+    normalize_connectivity: Callable[[str], str]
+    validate_schematic_text: Callable[[str], None]
+    transactional_write: Callable[[str, Path, bool], None]
+    reload_schematic: Callable[[], str]
+    warn_unresolved: Callable[[dict[str, Any]], None]
+
+    def analyze(
+        self,
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+    ) -> str:
+        """Preview how structured inputs resolve to terminals or routed wires."""
+        prepared = self.prepare_inputs(
+            symbols=symbols,
+            wires=wires,
+            labels=labels,
+            power_symbols=power_symbols,
+            nets=nets,
+            snap_to_grid=snap_to_grid,
+            auto_layout=auto_layout,
+            unsafe_routed_wires=unsafe_routed_wires,
+        )
+        return self.render_report(
+            symbols=prepared.symbols,
+            powers=prepared.powers,
+            labels=prepared.labels,
+            explicit_wires=len(prepared.wires) - len(prepared.generated_wires),
+            nets=prepared.nets,
+            generated_wires=prepared.generated_wires,
+            unresolved_nets=prepared.unresolved_nets,
+            resolution_stats=prepared.resolution_stats,
+            auto_layout=auto_layout,
+            terminalized=not unsafe_routed_wires,
+        )
+
+    def build(
+        self,
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+    ) -> str:
+        """Build and replace the active schematic from structured circuit inputs."""
+        schematic_file = self.active_schematic_file()
+        start_paper = self.read_sheet_paper(schematic_file)
+        prepared = self.prepare_inputs(
+            symbols=symbols,
+            wires=wires,
+            labels=labels,
+            power_symbols=power_symbols,
+            nets=nets,
+            snap_to_grid=snap_to_grid,
+            auto_layout=auto_layout,
+            unsafe_routed_wires=unsafe_routed_wires,
+            paper=start_paper,
+        )
+        if prepared.unresolved_nets:
+            self.warn_unresolved(
+                {
+                    "generated_wire_count": len(prepared.generated_wires),
+                    "unresolved_net_count": len(prepared.unresolved_nets),
+                    "unresolved_nets": prepared.unresolved_nets[:10],
+                }
+            )
+        if prepared.nets and not prepared.generated_wires and not prepared.wires:
+            examples = "; ".join(
+                (
+                    f"{item['name']} "
+                    f"(resolved {item['resolved_count']}/{item['endpoint_count']}, "
+                    f"missing: {', '.join(item['unresolved_endpoints']) or 'all'})"
+                )
+                for item in prepared.unresolved_nets[:5]
+            )
+            raise ValueError(
+                "Netlist-aware auto-layout could not generate any safe terminal stubs. "
+                "The provided nets did not resolve to collision-safe pin endpoints. "
+                "Use `sch_analyze_net_compilation()` to inspect unresolved nets, or "
+                "provide explicit reference+pin endpoints / explicit wires. "
+                f"Examples: {examples or 'no endpoints were routable'}. "
+                f"Alias matches: {prepared.resolution_stats['pin_alias_resolutions']}."
+            )
+
+        paper_declaration = self.read_sheet_paper_declaration(schematic_file)
+        if (
+            auto_layout
+            and prepared.chosen_paper != start_paper
+            and prepared.chosen_paper in self.paper_sizes
+        ):
+            paper_declaration = f'(paper "{prepared.chosen_paper}")'
+        root_uuid = self.new_uuid()
+        project_name = self.project_name()
+        library_definitions: set[str] = set()
+        library_content: list[str] = []
+        elements: list[str] = []
+
+        for symbol in prepared.symbols:
+            key = f"{symbol.library}:{symbol.symbol_name}"
+            if key not in library_definitions:
+                library_definition = self.load_lib_symbol(symbol.library, symbol.symbol_name)
+                if library_definition is not None:
+                    library_content.append(library_definition)
+                library_definitions.add(key)
+
+        for power in prepared.powers:
+            key = f"power:{power.name}"
+            if key not in library_definitions:
+                library_definition = self.load_lib_symbol("power", power.name)
+                if library_definition is not None:
+                    library_content.append(library_definition)
+                library_definitions.add(key)
+
+        for symbol in prepared.symbols:
+            symbol_x, symbol_y = self.snap_point(
+                symbol.x_mm,
+                symbol.y_mm,
+                snap_to_grid and symbol.snap_to_grid,
+            )
+            elements.append(
+                self.place_symbol_block(
+                    lib_id=f"{symbol.library}:{symbol.symbol_name}",
+                    x=symbol_x,
+                    y=symbol_y,
+                    reference=symbol.reference,
+                    value=symbol.value,
+                    footprint=symbol.footprint,
+                    rotation=symbol.rotation,
+                    unit=symbol.unit,
+                    project_name=project_name,
+                    root_uuid=root_uuid,
+                )
+            )
+
+        for index, power in enumerate(prepared.powers, start=1):
+            power_x, power_y = self.snap_point(
+                power.x_mm,
+                power.y_mm,
+                snap_to_grid and power.snap_to_grid,
+            )
+            elements.append(
+                self.place_symbol_block(
+                    lib_id=f"power:{power.name}",
+                    x=power_x,
+                    y=power_y,
+                    reference=f"#PWR{index:03d}",
+                    value=power.name,
+                    rotation=power.rotation,
+                    project_name=project_name,
+                    root_uuid=root_uuid,
+                )
+            )
+
+        for wire in prepared.wires:
+            elements.append(
+                self.wire_block(
+                    *self.snap_line(
+                        wire.x1_mm,
+                        wire.y1_mm,
+                        wire.x2_mm,
+                        wire.y2_mm,
+                        snap_to_grid and wire.snap_to_grid,
+                    )
+                )
+            )
+
+        for label in prepared.labels:
+            label_x, label_y = self.snap_point(
+                label.x_mm,
+                label.y_mm,
+                snap_to_grid and label.snap_to_grid,
+            )
+            elements.append(
+                self.label_block(
+                    label.name,
+                    label_x,
+                    label_y,
+                    label.rotation,
+                    global_label=label.global_label,
+                    shape=label.shape,
+                )
+            )
+
+        library_section = "\t(lib_symbols\n"
+        for library_definition in library_content:
+            library_section += (
+                "\n".join("\t" + line for line in library_definition.splitlines()) + "\n"
+            )
+        library_section += "\t)"
+        content = (
+            "(kicad_sch\n"
+            "\t(version 20250316)\n"
+            '\t(generator "kicad-mcp-pro")\n'
+            f'\t(uuid "{root_uuid}")\n'
+            f"\t{paper_declaration}\n"
+            f"{library_section}\n"
+            + "\n".join(elements)
+            + (
+                "\n\t(sheet_instances\n"
+                '\t\t(path "/"\n'
+                '\t\t\t(page "1")\n'
+                "\t\t)\n"
+                "\t)\n"
+                "\t(embedded_fonts no)\n"
+                ")\n"
+            )
+        )
+        content = self.normalize_connectivity(content)
+        self.validate_schematic_text(content)
+        self.transactional_write(content, schematic_file, True)
+        result = self.reload_schematic()
+        notes: list[str] = []
+        if auto_layout:
+            notes.append("Applied auto-layout to schematic symbols.")
+        if prepared.nets:
+            if unsafe_routed_wires:
+                notes.append(
+                    f"Generated {len(prepared.generated_wires)} routed wire segment(s) in "
+                    "unsafe routed mode — these can short by crossing geometry; "
+                    "prefer the default terminal strategy."
+                )
+            else:
+                notes.append(
+                    f"Generated {len(prepared.generated_wires)} collision-safe terminal "
+                    "stub(s); nets connect by name."
+                )
+            if prepared.unresolved_nets:
+                names = ", ".join(str(item["name"]) for item in prepared.unresolved_nets[:8])
+                more = " …" if len(prepared.unresolved_nets) > 8 else ""
+                notes.append(
+                    f"WARNING: {len(prepared.unresolved_nets)} net(s) could not be "
+                    f"terminalized safely and were left unconnected: {names}{more}. "
+                    "Use sch_analyze_net_compilation() for per-endpoint details."
+                )
+        if notes:
+            return result + "\n" + "\n".join(notes)
+        return result

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -38,6 +38,10 @@ from ..models.visual_qa import run_visual_qa as _run_visual_qa
 from ..path_safety import resolve_under
 from ..schematic.back_annotation import SchematicBackAnnotationService
 from ..schematic.basic_authoring import SchematicBasicAuthoringService
+from ..schematic.circuit_compilation import (
+    PreparedCircuitInputs,
+    SchematicCircuitCompilationService,
+)
 from ..schematic.destructive_edit import SchematicDestructiveEditService
 from ..schematic.document_settings import SchematicDocumentSettingsService
 from ..schematic.hierarchy_authoring import (
@@ -72,6 +76,7 @@ from ..utils.sexpr import (
 from . import (
     schematic_back_annotation,
     schematic_basic_authoring,
+    schematic_circuit_compilation,
     schematic_destructive_edit,
     schematic_document_settings,
     schematic_hierarchy_authoring,
@@ -5483,6 +5488,55 @@ def _lint_semantic_ir(circuit: CircuitLike) -> Iterable[FindingLike]:
     return cast(Iterable[FindingLike], lint_circuit(cast(IRCircuit, circuit)))
 
 
+def _prepare_circuit_compilation_inputs(
+    *,
+    symbols: list[dict[str, Any]] | None = None,
+    wires: list[dict[str, Any]] | None = None,
+    labels: list[dict[str, Any]] | None = None,
+    power_symbols: list[dict[str, Any]] | None = None,
+    nets: list[dict[str, Any]] | None = None,
+    snap_to_grid: bool = True,
+    auto_layout: bool = False,
+    unsafe_routed_wires: bool = False,
+    paper: str = "A4",
+) -> PreparedCircuitInputs:
+    prepared = _prepare_build_circuit_inputs(
+        symbols=symbols,
+        wires=wires,
+        labels=labels,
+        power_symbols=power_symbols,
+        nets=nets,
+        snap_to_grid=snap_to_grid,
+        auto_layout=auto_layout,
+        unsafe_routed_wires=unsafe_routed_wires,
+        paper=paper,
+    )
+    return PreparedCircuitInputs(
+        symbols=prepared[0],
+        powers=prepared[1],
+        labels=prepared[2],
+        wires=prepared[3],
+        nets=prepared[4],
+        generated_wires=prepared[5],
+        unresolved_nets=prepared[6],
+        resolution_stats=prepared[7],
+        chosen_paper=prepared[8],
+    )
+
+
+def _write_compiled_schematic(content: str, path: Path, allow_node_loss: bool) -> None:
+    transactional_write(
+        lambda _current: content,
+        path,
+        allow_node_loss=allow_node_loss,
+    )
+
+
+def _active_project_name() -> str:
+    config = get_config()
+    return config.project_file.stem if config.project_file is not None else "KiCadMCP"
+
+
 def register(mcp: FastMCP) -> None:
     """Register schematic tools."""
     inspection_service = SchematicInspectionService(
@@ -5576,6 +5630,39 @@ def register(mcp: FastMCP) -> None:
         mcp,
         schematic_semantic_ir.SchematicSemanticIRDependencies(
             service=semantic_ir_service,
+        ),
+    )
+
+    circuit_compilation_service = SchematicCircuitCompilationService(
+        active_schematic_file=lambda: _get_schematic_file(),
+        project_name=_active_project_name,
+        read_sheet_paper=lambda path: _read_sheet_paper(path),
+        read_sheet_paper_declaration=lambda path: _read_sheet_paper_declaration(path),
+        prepare_inputs=_prepare_circuit_compilation_inputs,
+        render_report=lambda **kwargs: _render_net_compilation_report(**kwargs),
+        paper_sizes=PAPER_SIZES_MM,
+        new_uuid=lambda: new_uuid(),
+        load_lib_symbol=lambda library, symbol_name: load_lib_symbol(library, symbol_name),
+        snap_point=lambda x, y, enabled: _snap_point(x, y, enabled),
+        place_symbol_block=lambda **kwargs: place_symbol_block(**kwargs),
+        wire_block=lambda x1, y1, x2, y2: wire_block(x1, y1, x2, y2),
+        snap_line=lambda x1, y1, x2, y2, enabled: _snap_line(x1, y1, x2, y2, enabled),
+        label_block=lambda name, x, y, rotation, **kwargs: label_block(
+            name, x, y, rotation, **kwargs
+        ),
+        normalize_connectivity=lambda content: _normalize_schematic_wire_connectivity(content),
+        validate_schematic_text=lambda content: _validate_schematic_text(content),
+        transactional_write=_write_compiled_schematic,
+        reload_schematic=lambda: _reload_schematic(),
+        warn_unresolved=lambda payload: logger.warning(
+            "schematic_netlist_routing_incomplete",
+            **payload,
+        ),
+    )
+    schematic_circuit_compilation.register(
+        mcp,
+        schematic_circuit_compilation.SchematicCircuitCompilationDependencies(
+            service=circuit_compilation_service,
         ),
     )
 
@@ -5988,298 +6075,7 @@ def register(mcp: FastMCP) -> None:
         return f"{detail}\n{result}\n{snap_note}" if snap_note else f"{detail}\n{result}"
 
     @mcp.tool()
-    def sch_analyze_net_compilation(
-        symbols: list[dict[str, Any]] | None = None,
-        wires: list[dict[str, Any]] | None = None,
-        labels: list[dict[str, Any]] | None = None,
-        power_symbols: list[dict[str, Any]] | None = None,
-        nets: list[dict[str, Any]] | None = None,
-        snap_to_grid: bool = True,
-        auto_layout: bool = False,
-        unsafe_routed_wires: bool = False,
-    ) -> str:
-        """Preview how netlist-aware schematic compilation will resolve endpoints and wires.
-
-        Mirrors ``sch_build_circuit``: by default nets resolve to collision-safe
-        terminal stubs; pass ``unsafe_routed_wires=True`` to preview routed Manhattan
-        wire segments instead.
-        """
-        (
-            validated_symbols,
-            validated_powers,
-            validated_labels,
-            validated_wires,
-            raw_nets,
-            generated_wires,
-            unresolved_nets,
-            resolution_stats,
-            _chosen_paper,
-        ) = _prepare_build_circuit_inputs(
-            symbols=symbols,
-            wires=wires,
-            labels=labels,
-            power_symbols=power_symbols,
-            nets=nets,
-            snap_to_grid=snap_to_grid,
-            auto_layout=auto_layout,
-            unsafe_routed_wires=unsafe_routed_wires,
-        )
-        return _render_net_compilation_report(
-            symbols=validated_symbols,
-            powers=validated_powers,
-            labels=validated_labels,
-            explicit_wires=len(validated_wires) - len(generated_wires),
-            nets=raw_nets,
-            generated_wires=generated_wires,
-            unresolved_nets=unresolved_nets,
-            resolution_stats=resolution_stats,
-            auto_layout=auto_layout,
-            terminalized=not unsafe_routed_wires,
-        )
-
     @mcp.tool()
-    def sch_build_circuit(
-        symbols: list[dict[str, Any]] | None = None,
-        wires: list[dict[str, Any]] | None = None,
-        labels: list[dict[str, Any]] | None = None,
-        power_symbols: list[dict[str, Any]] | None = None,
-        nets: list[dict[str, Any]] | None = None,
-        snap_to_grid: bool = True,
-        auto_layout: bool = False,
-        unsafe_routed_wires: bool = False,
-    ) -> str:
-        """Build (overwrite) the active schematic from structured symbol, wire, and label inputs.
-
-        IMPORTANT: This tool **replaces** the entire schematic content.  Any symbols
-        already placed in the schematic will be lost.  To add symbols to an existing
-        schematic without erasing it use ``sch_add_symbol`` / ``sch_add_wire`` /
-        ``sch_add_label`` instead.
-
-        Coordinates are snapped to the 1.27 mm / 50 mil grid by default.  When no coordinates
-        are provided for a symbol, set ``auto_layout=True`` so the placement engine
-        assigns non-overlapping positions automatically.
-
-        When ``nets`` are provided, the builder is connection-aware. By default it
-        uses the **collision-safe** strategy: each pin endpoint gets a short stub plus
-        a same-named terminal (a global label for signal nets, a power symbol for
-        power nets), so nets connect *by name* and can never short by crossing wire
-        geometry.  Nets that cannot resolve to a routable pin endpoint raise a clear
-        error (or are surfaced as warnings) instead of silently producing a
-        disconnected schematic.
-
-        Set ``unsafe_routed_wires=True`` only if you explicitly want routed Manhattan
-        wire segments between pins.  That star-routing can cross unrelated pins or
-        labels and KiCad will merge them by geometry, so it can introduce silent
-        shorts on non-trivial netlists — prefer the default terminal strategy.
-
-        Recommended workflow:
-          1. Call ``sch_find_free_placement(count=N)`` to obtain safe coordinates.
-          2. Pass those coordinates in the ``symbols`` list.
-          3. OR set ``auto_layout=True`` and omit coordinates entirely.
-        """
-        start_paper = _read_sheet_paper(_get_schematic_file())
-        (
-            validated_symbols,
-            validated_powers,
-            validated_labels,
-            validated_wires,
-            raw_nets,
-            generated_wires,
-            unresolved_nets,
-            resolution_stats,
-            chosen_paper,
-        ) = _prepare_build_circuit_inputs(
-            symbols=symbols,
-            wires=wires,
-            labels=labels,
-            power_symbols=power_symbols,
-            nets=nets,
-            snap_to_grid=snap_to_grid,
-            auto_layout=auto_layout,
-            unsafe_routed_wires=unsafe_routed_wires,
-            paper=start_paper,
-        )
-        if unresolved_nets:
-            logger.warning(
-                "schematic_netlist_routing_incomplete",
-                generated_wire_count=len(generated_wires),
-                unresolved_net_count=len(unresolved_nets),
-                unresolved_nets=unresolved_nets[:10],
-            )
-        if raw_nets and not generated_wires and not validated_wires:
-            examples = "; ".join(
-                (
-                    f"{item['name']} "
-                    f"(resolved {item['resolved_count']}/{item['endpoint_count']}, "
-                    f"missing: {', '.join(item['unresolved_endpoints']) or 'all'})"
-                )
-                for item in unresolved_nets[:5]
-            )
-            raise ValueError(
-                "Netlist-aware auto-layout could not generate any safe terminal stubs. "
-                "The provided nets did not resolve to collision-safe pin endpoints. "
-                "Use `sch_analyze_net_compilation()` to inspect unresolved nets, or "
-                "provide explicit reference+pin endpoints / explicit wires. "
-                f"Examples: {examples or 'no endpoints were routable'}. "
-                f"Alias matches: {resolution_stats['pin_alias_resolutions']}."
-            )
-
-        sch_file = _get_schematic_file()
-        paper_declaration = _read_sheet_paper_declaration(sch_file)
-        # If auto-layout had to grow the sheet to keep every symbol on-page, write
-        # the larger size rather than the (now too small) original declaration.
-        if auto_layout and chosen_paper != start_paper and chosen_paper in PAPER_SIZES_MM:
-            paper_declaration = f'(paper "{chosen_paper}")'
-        root_uuid = new_uuid()
-        cfg = get_config()
-        project_name = cfg.project_file.stem if cfg.project_file is not None else "KiCadMCP"
-        lib_defs_added: set[str] = set()
-        lib_symbols_content: list[str] = []
-        elements: list[str] = []
-
-        # Load lib_symbols for regular symbols
-        for sym in validated_symbols:
-            key = f"{sym.library}:{sym.symbol_name}"
-            if key not in lib_defs_added:
-                lib_def = load_lib_symbol(sym.library, sym.symbol_name)
-                if lib_def is not None:
-                    lib_symbols_content.append(lib_def)
-                lib_defs_added.add(key)
-
-        # Load lib_symbols for power symbols
-        for pwr in validated_powers:
-            key = f"power:{pwr.name}"
-            if key not in lib_defs_added:
-                lib_def = load_lib_symbol("power", pwr.name)
-                if lib_def is not None:
-                    lib_symbols_content.append(lib_def)
-                lib_defs_added.add(key)
-
-        for sym in validated_symbols:
-            symbol_x, symbol_y = _snap_point(
-                sym.x_mm,
-                sym.y_mm,
-                snap_to_grid and sym.snap_to_grid,
-            )
-            elements.append(
-                place_symbol_block(
-                    lib_id=f"{sym.library}:{sym.symbol_name}",
-                    x=symbol_x,
-                    y=symbol_y,
-                    reference=sym.reference,
-                    value=sym.value,
-                    footprint=sym.footprint,
-                    rotation=sym.rotation,
-                    unit=sym.unit,
-                    project_name=project_name,
-                    root_uuid=root_uuid,
-                )
-            )
-
-        for index, pwr in enumerate(validated_powers, start=1):
-            power_x, power_y = _snap_point(
-                pwr.x_mm,
-                pwr.y_mm,
-                snap_to_grid and pwr.snap_to_grid,
-            )
-            elements.append(
-                place_symbol_block(
-                    lib_id=f"power:{pwr.name}",
-                    x=power_x,
-                    y=power_y,
-                    reference=f"#PWR{index:03d}",
-                    value=pwr.name,
-                    rotation=pwr.rotation,
-                    project_name=project_name,
-                    root_uuid=root_uuid,
-                )
-            )
-
-        for wire in validated_wires:
-            elements.append(
-                wire_block(
-                    *_snap_line(
-                        wire.x1_mm,
-                        wire.y1_mm,
-                        wire.x2_mm,
-                        wire.y2_mm,
-                        snap_to_grid and wire.snap_to_grid,
-                    )
-                )
-            )
-
-        for lbl in validated_labels:
-            label_x, label_y = _snap_point(
-                lbl.x_mm,
-                lbl.y_mm,
-                snap_to_grid and lbl.snap_to_grid,
-            )
-            elements.append(
-                label_block(
-                    lbl.name,
-                    label_x,
-                    label_y,
-                    lbl.rotation,
-                    global_label=lbl.global_label,
-                    shape=lbl.shape,
-                )
-            )
-
-        lib_section = "\t(lib_symbols\n"
-        for lib_symbol in lib_symbols_content:
-            lib_section += "\n".join("\t" + line for line in lib_symbol.splitlines()) + "\n"
-        lib_section += "\t)"
-        content = (
-            "(kicad_sch\n"
-            "\t(version 20250316)\n"
-            '\t(generator "kicad-mcp-pro")\n'
-            f'\t(uuid "{root_uuid}")\n'
-            f"\t{paper_declaration}\n"
-            f"{lib_section}\n"
-            + "\n".join(elements)
-            + (
-                "\n\t(sheet_instances\n"
-                '\t\t(path "/"\n'
-                '\t\t\t(page "1")\n'
-                "\t\t)\n"
-                "\t)\n"
-                "\t(embedded_fonts no)\n"
-                ")\n"
-            )
-        )
-        content = _normalize_schematic_wire_connectivity(content)
-        _validate_schematic_text(content)
-        transactional_write(lambda _current: content, sch_file, allow_node_loss=True)
-        result = _reload_schematic()
-        notes: list[str] = []
-        if auto_layout:
-            notes.append("Applied auto-layout to schematic symbols.")
-        if raw_nets:
-            if unsafe_routed_wires:
-                notes.append(
-                    f"Generated {len(generated_wires)} routed wire segment(s) in "
-                    "unsafe routed mode — these can short by crossing geometry; "
-                    "prefer the default terminal strategy."
-                )
-            else:
-                notes.append(
-                    f"Generated {len(generated_wires)} collision-safe terminal "
-                    "stub(s); nets connect by name."
-                )
-            # Never drop a connection silently: if some nets did not resolve to a
-            # routable endpoint, surface them in the result, not just the server log.
-            if unresolved_nets:
-                names = ", ".join(str(item["name"]) for item in unresolved_nets[:8])
-                more = " …" if len(unresolved_nets) > 8 else ""
-                notes.append(
-                    f"WARNING: {len(unresolved_nets)} net(s) could not be "
-                    f"terminalized safely and were left unconnected: {names}{more}. "
-                    "Use sch_analyze_net_compilation() for per-endpoint details."
-                )
-        if notes:
-            return result + "\n" + "\n".join(notes)
-        return result
-
     @mcp.tool()
     def sch_annotate(start_number: int = 1, order: str = "alpha") -> str:
         """Renumber schematic references sequentially."""

--- a/src/kicad_mcp/tools/schematic_circuit_compilation.py
+++ b/src/kicad_mcp/tools/schematic_circuit_compilation.py
@@ -1,0 +1,106 @@
+"""Thin FastMCP adapter for schematic circuit compilation."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.circuit_compilation import SchematicCircuitCompilationService
+
+
+@dataclass(frozen=True)
+class SchematicCircuitCompilationDependencies:
+    """Circuit-compilation service injected by the schematic composition root."""
+
+    service: SchematicCircuitCompilationService
+
+
+def register(
+    mcp: FastMCP,
+    dependencies: SchematicCircuitCompilationDependencies,
+) -> None:
+    """Register schematic circuit-compilation tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    def sch_analyze_net_compilation(
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+    ) -> str:
+        """Preview how netlist-aware schematic compilation will resolve endpoints and wires.
+
+        Mirrors ``sch_build_circuit``: by default nets resolve to collision-safe
+        terminal stubs; pass ``unsafe_routed_wires=True`` to preview routed Manhattan
+        wire segments instead.
+        """
+        return service.analyze(
+            symbols=symbols,
+            wires=wires,
+            labels=labels,
+            power_symbols=power_symbols,
+            nets=nets,
+            snap_to_grid=snap_to_grid,
+            auto_layout=auto_layout,
+            unsafe_routed_wires=unsafe_routed_wires,
+        )
+
+    @mcp.tool()
+    def sch_build_circuit(
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+    ) -> str:
+        """Build (overwrite) the active schematic from structured symbol, wire, and label inputs.
+
+        IMPORTANT: This tool **replaces** the entire schematic content.  Any symbols
+        already placed in the schematic will be lost.  To add symbols to an existing
+        schematic without erasing it use ``sch_add_symbol`` / ``sch_add_wire`` /
+        ``sch_add_label`` instead.
+
+        Coordinates are snapped to the 1.27 mm / 50 mil grid by default.  When no coordinates
+        are provided for a symbol, set ``auto_layout=True`` so the placement engine
+        assigns non-overlapping positions automatically.
+
+        When ``nets`` are provided, the builder is connection-aware. By default it
+        uses the **collision-safe** strategy: each pin endpoint gets a short stub plus
+        a same-named terminal (a global label for signal nets, a power symbol for
+        power nets), so nets connect *by name* and can never short by crossing wire
+        geometry.  Nets that cannot resolve to a routable pin endpoint raise a clear
+        error (or are surfaced as warnings) instead of silently producing a
+        disconnected schematic.
+
+        Set ``unsafe_routed_wires=True`` only if you explicitly want routed Manhattan
+        wire segments between pins.  That star-routing can cross unrelated pins or
+        labels and KiCad will merge them by geometry, so it can introduce silent
+        shorts on non-trivial netlists — prefer the default terminal strategy.
+
+        Recommended workflow:
+          1. Call ``sch_find_free_placement(count=N)`` to obtain safe coordinates.
+          2. Pass those coordinates in the ``symbols`` list.
+          3. OR set ``auto_layout=True`` and omit coordinates entirely.
+        """
+        return service.build(
+            symbols=symbols,
+            wires=wires,
+            labels=labels,
+            power_symbols=power_symbols,
+            nets=nets,
+            snap_to_grid=snap_to_grid,
+            auto_layout=auto_layout,
+            unsafe_routed_wires=unsafe_routed_wires,
+        )

--- a/tests/unit/test_schematic_circuit_compilation_architecture.py
+++ b/tests/unit/test_schematic_circuit_compilation_architecture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_circuit_compilation_modules() -> None:
+    assert "kicad_mcp.schematic.circuit_compilation" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.circuit_compilation" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_circuit_compilation" in boundaries.DOMAIN_MODULES
+
+
+def test_circuit_compilation_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_circuit_compilation.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_circuit_compilation"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_circuit_compilation_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_circuit_compilation.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_circuit_compilation"] == 300

--- a/tests/unit/test_schematic_circuit_compilation_registration.py
+++ b/tests/unit/test_schematic_circuit_compilation_registration.py
@@ -1,0 +1,165 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_circuit_compilation import (
+    SchematicCircuitCompilationDependencies,
+    register,
+)
+
+
+class FakeCircuitCompilationService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def analyze(
+        self,
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+    ) -> str:
+        self.calls.append(
+            (
+                "analyze",
+                {
+                    "symbols": symbols,
+                    "wires": wires,
+                    "labels": labels,
+                    "power_symbols": power_symbols,
+                    "nets": nets,
+                    "snap_to_grid": snap_to_grid,
+                    "auto_layout": auto_layout,
+                    "unsafe_routed_wires": unsafe_routed_wires,
+                },
+            )
+        )
+        return "analysis"
+
+    def build(
+        self,
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+    ) -> str:
+        self.calls.append(
+            (
+                "build",
+                {
+                    "symbols": symbols,
+                    "wires": wires,
+                    "labels": labels,
+                    "power_symbols": power_symbols,
+                    "nets": nets,
+                    "snap_to_grid": snap_to_grid,
+                    "auto_layout": auto_layout,
+                    "unsafe_routed_wires": unsafe_routed_wires,
+                },
+            )
+        )
+        return "built"
+
+
+def _registered() -> tuple[FastMCP, FakeCircuitCompilationService]:
+    server = FastMCP("schematic-circuit-compilation-test")
+    service = FakeCircuitCompilationService()
+    register(server, SchematicCircuitCompilationDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {"sch_analyze_net_compilation", "sch_build_circuit"}
+    assert tools["sch_analyze_net_compilation"].description == (
+        "Preview how netlist-aware schematic compilation will resolve endpoints and wires.\n\n"
+        "Mirrors ``sch_build_circuit``: by default nets resolve to collision-safe\n"
+        "terminal stubs; pass ``unsafe_routed_wires=True`` to preview routed Manhattan\n"
+        "wire segments instead.\n"
+    )
+    assert tools["sch_build_circuit"].description == (
+        "Build (overwrite) the active schematic from structured symbol, wire, and label inputs.\n\n"
+        "IMPORTANT: This tool **replaces** the entire schematic content.  Any symbols\n"
+        "already placed in the schematic will be lost.  To add symbols to an existing\n"
+        "schematic without erasing it use ``sch_add_symbol`` / ``sch_add_wire`` /\n"
+        "``sch_add_label`` instead.\n\n"
+        "Coordinates are snapped to the 1.27 mm / 50 mil grid by default.  When no coordinates\n"
+        "are provided for a symbol, set ``auto_layout=True`` so the placement engine\n"
+        "assigns non-overlapping positions automatically.\n\n"
+        "When ``nets`` are provided, the builder is connection-aware. By default it\n"
+        "uses the **collision-safe** strategy: each pin endpoint gets a short stub plus\n"
+        "a same-named terminal (a global label for signal nets, a power symbol for\n"
+        "power nets), so nets connect *by name* and can never short by crossing wire\n"
+        "geometry.  Nets that cannot resolve to a routable pin endpoint raise a clear\n"
+        "error (or are surfaced as warnings) instead of silently producing a\n"
+        "disconnected schematic.\n\n"
+        "Set ``unsafe_routed_wires=True`` only if you explicitly want routed Manhattan\n"
+        "wire segments between pins.  That star-routing can cross unrelated pins or\n"
+        "labels and KiCad will merge them by geometry, so it can introduce silent\n"
+        "shorts on non-trivial netlists — prefer the default terminal strategy.\n\n"
+        "Recommended workflow:\n"
+        "  1. Call ``sch_find_free_placement(count=N)`` to obtain safe coordinates.\n"
+        "  2. Pass those coordinates in the ``symbols`` list.\n"
+        "  3. OR set ``auto_layout=True`` and omit coordinates entirely.\n"
+    )
+
+    for name, tool in tools.items():
+        properties = tool.parameters["properties"]
+        assert set(properties) == {
+            "symbols",
+            "wires",
+            "labels",
+            "power_symbols",
+            "nets",
+            "snap_to_grid",
+            "auto_layout",
+            "unsafe_routed_wires",
+        }
+        assert properties["symbols"]["default"] is None
+        assert properties["snap_to_grid"]["default"] is True
+        assert properties["auto_layout"]["default"] is False
+        assert properties["unsafe_routed_wires"]["default"] is False
+        assert tool.parameters["title"] == f"{name}Arguments"
+        assert tool.fn_metadata.output_schema["title"] == f"{name}Output"
+
+
+def test_registration_preserves_default_annotations_and_metadata() -> None:
+    server, _service = _registered()
+
+    for tool in server._tool_manager.list_tools():
+        assert tool.annotations is None
+        assert get_tool_metadata(tool.name) is None
+
+
+def test_registration_delegates_exact_arguments() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+    kwargs = {
+        "symbols": [{"reference": "R1"}],
+        "wires": [{"x1_mm": 0}],
+        "labels": [{"name": "NET"}],
+        "power_symbols": [{"name": "GND"}],
+        "nets": [{"name": "NET"}],
+        "snap_to_grid": False,
+        "auto_layout": True,
+        "unsafe_routed_wires": True,
+    }
+
+    assert tools["sch_analyze_net_compilation"].fn(**kwargs) == "analysis"
+    assert tools["sch_build_circuit"].fn(**kwargs) == "built"
+    assert service.calls == [("analyze", kwargs), ("build", kwargs)]

--- a/tests/unit/test_schematic_circuit_compilation_service.py
+++ b/tests/unit/test_schematic_circuit_compilation_service.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kicad_mcp.models.schematic import (
+    AddLabelInput,
+    AddSymbolInput,
+    AddWireInput,
+    PowerSymbolInput,
+)
+from kicad_mcp.schematic.circuit_compilation import (
+    PreparedCircuitInputs,
+    SchematicCircuitCompilationService,
+)
+
+
+class CompilationHarness:
+    def __init__(self, tmp_path: Path) -> None:
+        self.schematic = tmp_path / "demo.kicad_sch"
+        self.schematic.write_text('(kicad_sch\n\t(paper "A4")\n)\n', encoding="utf-8")
+        self.start_paper = "A4"
+        self.paper_declaration = '(paper "A4")'
+        self.prepared = PreparedCircuitInputs(
+            symbols=[],
+            powers=[],
+            labels=[],
+            wires=[],
+            nets=[],
+            generated_wires=[],
+            unresolved_nets=[],
+            resolution_stats={
+                "resolved_endpoints": 0,
+                "unresolved_endpoints": 0,
+                "pin_alias_resolutions": 0,
+                "symbol_center_resolutions": 0,
+            },
+            chosen_paper="A4",
+        )
+        self.prepare_calls: list[dict[str, Any]] = []
+        self.report_calls: list[dict[str, Any]] = []
+        self.library_calls: list[tuple[str, str]] = []
+        self.warn_calls: list[dict[str, Any]] = []
+        self.transaction_calls: list[tuple[Path, bool, str]] = []
+        self.events: list[str] = []
+
+    def service(self) -> SchematicCircuitCompilationService:
+        return SchematicCircuitCompilationService(
+            active_schematic_file=lambda: self.schematic,
+            project_name=lambda: "demo-project",
+            read_sheet_paper=lambda path: self.start_paper,
+            read_sheet_paper_declaration=lambda path: self.paper_declaration,
+            prepare_inputs=self.prepare_inputs,
+            render_report=self.render_report,
+            paper_sizes={"A4": object(), "A3": object()},
+            new_uuid=lambda: "root-uuid",
+            load_lib_symbol=self.load_lib_symbol,
+            snap_point=lambda x, y, enabled: (x, y),
+            place_symbol_block=self.place_symbol_block,
+            wire_block=lambda x1, y1, x2, y2: f"WIRE:{x1},{y1}->{x2},{y2}",
+            snap_line=lambda x1, y1, x2, y2, enabled: (x1, y1, x2, y2),
+            label_block=self.label_block,
+            normalize_connectivity=self.normalize_connectivity,
+            validate_schematic_text=self.validate_schematic_text,
+            transactional_write=self.transactional_write,
+            reload_schematic=self.reload_schematic,
+            warn_unresolved=self.warn_unresolved,
+        )
+
+    def prepare_inputs(
+        self,
+        *,
+        symbols: list[dict[str, Any]] | None = None,
+        wires: list[dict[str, Any]] | None = None,
+        labels: list[dict[str, Any]] | None = None,
+        power_symbols: list[dict[str, Any]] | None = None,
+        nets: list[dict[str, Any]] | None = None,
+        snap_to_grid: bool = True,
+        auto_layout: bool = False,
+        unsafe_routed_wires: bool = False,
+        paper: str = "A4",
+    ) -> PreparedCircuitInputs:
+        self.prepare_calls.append(
+            {
+                "symbols": symbols,
+                "wires": wires,
+                "labels": labels,
+                "power_symbols": power_symbols,
+                "nets": nets,
+                "snap_to_grid": snap_to_grid,
+                "auto_layout": auto_layout,
+                "unsafe_routed_wires": unsafe_routed_wires,
+                "paper": paper,
+            }
+        )
+        return self.prepared
+
+    def render_report(
+        self,
+        *,
+        symbols: list[AddSymbolInput],
+        powers: list[PowerSymbolInput],
+        labels: list[AddLabelInput],
+        explicit_wires: int,
+        nets: list[dict[str, Any]],
+        generated_wires: list[dict[str, float | bool]],
+        unresolved_nets: list[dict[str, Any]],
+        resolution_stats: dict[str, int],
+        auto_layout: bool,
+        terminalized: bool = True,
+    ) -> str:
+        self.report_calls.append(
+            {
+                "symbols": symbols,
+                "powers": powers,
+                "labels": labels,
+                "explicit_wires": explicit_wires,
+                "nets": nets,
+                "generated_wires": generated_wires,
+                "unresolved_nets": unresolved_nets,
+                "resolution_stats": resolution_stats,
+                "auto_layout": auto_layout,
+                "terminalized": terminalized,
+            }
+        )
+        return "analysis"
+
+    def load_lib_symbol(self, library: str, symbol_name: str) -> str | None:
+        self.library_calls.append((library, symbol_name))
+        return f'(symbol "{library}:{symbol_name}")'
+
+    def place_symbol_block(
+        self,
+        *,
+        lib_id: str,
+        x: float,
+        y: float,
+        reference: str,
+        value: str,
+        footprint: str = "",
+        rotation: int = 0,
+        unit: int = 1,
+        project_name: str,
+        root_uuid: str,
+    ) -> str:
+        values = {
+            "lib_id": lib_id,
+            "x": x,
+            "y": y,
+            "reference": reference,
+            "value": value,
+            "footprint": footprint,
+            "rotation": rotation,
+            "unit": unit,
+            "project_name": project_name,
+            "root_uuid": root_uuid,
+        }
+        return "SYMBOL:" + ",".join(f"{key}={value}" for key, value in sorted(values.items()))
+
+    def label_block(
+        self,
+        name: str,
+        x: float,
+        y: float,
+        rotation: int,
+        *,
+        global_label: bool,
+        shape: str | None,
+    ) -> str:
+        return f"LABEL:{name},{x},{y},{rotation},{global_label},{shape}"
+
+    def normalize_connectivity(self, content: str) -> str:
+        self.events.append("normalize")
+        return content + ";normalized"
+
+    def validate_schematic_text(self, content: str) -> None:
+        self.events.append("validate")
+        assert content.endswith(";normalized")
+
+    def transactional_write(self, content: str, path: Path, allow_node_loss: bool) -> None:
+        self.events.append("write")
+        self.transaction_calls.append((path, allow_node_loss, content))
+        path.write_text(content, encoding="utf-8")
+
+    def reload_schematic(self) -> str:
+        self.events.append("reload")
+        return "reloaded"
+
+    def warn_unresolved(self, payload: dict[str, Any]) -> None:
+        self.warn_calls.append(dict(payload))
+
+
+def _symbol(reference: str = "R1") -> AddSymbolInput:
+    return AddSymbolInput(
+        library="Device",
+        symbol_name="R",
+        x_mm=10.0,
+        y_mm=20.0,
+        reference=reference,
+        value="10k",
+        footprint="Resistor_SMD:R_0805",
+    )
+
+
+def _power(name: str = "GND") -> PowerSymbolInput:
+    return PowerSymbolInput(name=name, x_mm=5.0, y_mm=6.0)
+
+
+def test_analyze_delegates_preparation_and_report_arguments(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    harness.prepared = PreparedCircuitInputs(
+        symbols=[_symbol()],
+        powers=[_power()],
+        labels=[AddLabelInput(name="NET", x_mm=1.0, y_mm=2.0)],
+        wires=[
+            AddWireInput(x1_mm=0.0, y1_mm=0.0, x2_mm=1.0, y2_mm=1.0),
+            AddWireInput(x1_mm=1.0, y1_mm=1.0, x2_mm=2.0, y2_mm=2.0),
+        ],
+        nets=[{"name": "NET"}],
+        generated_wires=[{"x1_mm": 1.0, "y1_mm": 1.0, "x2_mm": 2.0, "y2_mm": 2.0}],
+        unresolved_nets=[],
+        resolution_stats={
+            "resolved_endpoints": 2,
+            "unresolved_endpoints": 0,
+            "pin_alias_resolutions": 1,
+            "symbol_center_resolutions": 0,
+        },
+        chosen_paper="A4",
+    )
+
+    result = harness.service().analyze(
+        symbols=[{"reference": "R1"}],
+        nets=[{"name": "NET"}],
+        auto_layout=True,
+        unsafe_routed_wires=True,
+    )
+
+    assert result == "analysis"
+    assert harness.prepare_calls == [
+        {
+            "symbols": [{"reference": "R1"}],
+            "wires": None,
+            "labels": None,
+            "power_symbols": None,
+            "nets": [{"name": "NET"}],
+            "snap_to_grid": True,
+            "auto_layout": True,
+            "unsafe_routed_wires": True,
+            "paper": "A4",
+        }
+    ]
+    assert harness.report_calls[0]["explicit_wires"] == 1
+    assert harness.report_calls[0]["terminalized"] is False
+    assert harness.report_calls[0]["auto_layout"] is True
+
+
+def test_build_raises_when_no_net_endpoint_can_be_generated(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    unresolved = {
+        "name": "BROKEN",
+        "endpoint_count": 2,
+        "resolved_count": 0,
+        "unresolved_endpoints": ["U9.1", "U10.2"],
+    }
+    harness.prepared = PreparedCircuitInputs(
+        symbols=[],
+        powers=[],
+        labels=[],
+        wires=[],
+        nets=[{"name": "BROKEN"}],
+        generated_wires=[],
+        unresolved_nets=[unresolved],
+        resolution_stats={
+            "resolved_endpoints": 0,
+            "unresolved_endpoints": 2,
+            "pin_alias_resolutions": 3,
+            "symbol_center_resolutions": 0,
+        },
+        chosen_paper="A4",
+    )
+
+    with pytest.raises(ValueError, match="could not generate any safe terminal stubs") as exc:
+        harness.service().build(nets=[{"name": "BROKEN"}])
+
+    assert "BROKEN (resolved 0/2, missing: U9.1, U10.2)" in str(exc.value)
+    assert "Alias matches: 3" in str(exc.value)
+    assert harness.warn_calls == [
+        {
+            "generated_wire_count": 0,
+            "unresolved_net_count": 1,
+            "unresolved_nets": [unresolved],
+        }
+    ]
+    assert harness.transaction_calls == []
+
+
+def test_build_empty_preserves_paper_and_transaction_order(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    harness.paper_declaration = '(paper "User" 298.45 217.3224)'
+
+    result = harness.service().build()
+
+    assert result == "reloaded"
+    assert harness.events == ["normalize", "validate", "write", "reload"]
+    path, allow_node_loss, content = harness.transaction_calls[0]
+    assert path == harness.schematic
+    assert allow_node_loss is True
+    assert '\t(paper "User" 298.45 217.3224)' in content
+    assert '\t(uuid "root-uuid")' in content
+    assert '\t(generator "kicad-mcp-pro")' in content
+
+
+def test_build_promotes_named_paper_when_auto_layout_grows(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    harness.prepared = PreparedCircuitInputs(
+        symbols=[],
+        powers=[],
+        labels=[],
+        wires=[],
+        nets=[],
+        generated_wires=[],
+        unresolved_nets=[],
+        resolution_stats={
+            "resolved_endpoints": 0,
+            "unresolved_endpoints": 0,
+            "pin_alias_resolutions": 0,
+            "symbol_center_resolutions": 0,
+        },
+        chosen_paper="A3",
+    )
+
+    result = harness.service().build(auto_layout=True)
+
+    assert '\t(paper "A3")' in harness.transaction_calls[0][2]
+    assert result == "reloaded\nApplied auto-layout to schematic symbols."
+
+
+def test_build_deduplicates_libraries_and_generates_all_element_types(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    harness.prepared = PreparedCircuitInputs(
+        symbols=[_symbol("R1"), _symbol("R2")],
+        powers=[_power("GND"), _power("GND")],
+        labels=[
+            AddLabelInput(
+                name="NET_A",
+                x_mm=3.0,
+                y_mm=4.0,
+                rotation=90,
+                global_label=True,
+                shape="input",
+            )
+        ],
+        wires=[AddWireInput(x1_mm=1.0, y1_mm=2.0, x2_mm=3.0, y2_mm=4.0)],
+        nets=[],
+        generated_wires=[],
+        unresolved_nets=[],
+        resolution_stats={
+            "resolved_endpoints": 0,
+            "unresolved_endpoints": 0,
+            "pin_alias_resolutions": 0,
+            "symbol_center_resolutions": 0,
+        },
+        chosen_paper="A4",
+    )
+
+    harness.service().build(snap_to_grid=False)
+
+    assert harness.library_calls == [("Device", "R"), ("power", "GND")]
+    content = harness.transaction_calls[0][2]
+    assert content.count('(symbol "Device:R")') == 1
+    assert content.count('(symbol "power:GND")') == 1
+    assert "reference=R1" in content and "reference=R2" in content
+    assert "reference=#PWR001" in content and "reference=#PWR002" in content
+    assert "WIRE:1.0,2.0->3.0,4.0" in content
+    assert "LABEL:NET_A,3.0,4.0,90,True,input" in content
+    assert "project_name=demo-project" in content
+
+
+def test_build_reports_terminalized_and_partial_unresolved_notes(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    harness.prepared = PreparedCircuitInputs(
+        symbols=[],
+        powers=[],
+        labels=[],
+        wires=[AddWireInput(x1_mm=0.0, y1_mm=0.0, x2_mm=1.0, y2_mm=1.0)],
+        nets=[{"name": "GOOD"}, {"name": "BROKEN"}],
+        generated_wires=[{"x1_mm": 0.0, "y1_mm": 0.0, "x2_mm": 1.0, "y2_mm": 1.0}],
+        unresolved_nets=[
+            {
+                "name": "BROKEN",
+                "endpoint_count": 2,
+                "resolved_count": 1,
+                "unresolved_endpoints": ["U9.1"],
+            }
+        ],
+        resolution_stats={
+            "resolved_endpoints": 3,
+            "unresolved_endpoints": 1,
+            "pin_alias_resolutions": 0,
+            "symbol_center_resolutions": 0,
+        },
+        chosen_paper="A4",
+    )
+
+    result = harness.service().build(nets=[{"name": "GOOD"}, {"name": "BROKEN"}])
+
+    assert "Generated 1 collision-safe terminal stub(s); nets connect by name." in result
+    assert "WARNING: 1 net(s) could not be terminalized safely" in result
+    assert "BROKEN" in result
+    assert harness.warn_calls[0]["unresolved_net_count"] == 1
+
+
+def test_build_reports_unsafe_routed_wire_note(tmp_path: Path) -> None:
+    harness = CompilationHarness(tmp_path)
+    harness.prepared = PreparedCircuitInputs(
+        symbols=[],
+        powers=[],
+        labels=[],
+        wires=[AddWireInput(x1_mm=0.0, y1_mm=0.0, x2_mm=1.0, y2_mm=1.0)],
+        nets=[{"name": "NET"}],
+        generated_wires=[{"x1_mm": 0.0, "y1_mm": 0.0, "x2_mm": 1.0, "y2_mm": 1.0}],
+        unresolved_nets=[],
+        resolution_stats={
+            "resolved_endpoints": 2,
+            "unresolved_endpoints": 0,
+            "pin_alias_resolutions": 0,
+            "symbol_center_resolutions": 0,
+        },
+        chosen_paper="A4",
+    )
+
+    result = harness.service().build(
+        nets=[{"name": "NET"}],
+        unsafe_routed_wires=True,
+    )
+
+    assert "Generated 1 routed wire segment(s) in unsafe routed mode" in result
+    assert "prefer the default terminal strategy" in result


### PR DESCRIPTION
## Summary

- extract `sch_analyze_net_compilation` and `sch_build_circuit` orchestration into a FastMCP-independent schematic domain service
- add a thin MCP registration adapter while preserving exact public schemas, descriptions, annotations, metadata, errors, transaction behavior, and generated schematic output
- add direct service, adapter, architecture-boundary, integration, and exact metadata regression coverage
- reduce the monolithic schematic `register()` span from 1,368 lines to 1,110 lines

## Verification

- 1,765 selected unit tests passed; 5 skipped; no failures
- focused service and adapter coverage: 126/126 statements, 100%
- exact full-server metadata matches `main` for both tools
- committed tool-surface snapshot unchanged
- Ruff, mypy, Pyright, architecture, generated metadata/docs, parity, strict docs, performance, security, workflow, package, and focused integration gates passed

Refs #434
