### PR TITLE
refactor(schematic): extract layout automation service

### DIFF
--- a/docs/superpowers/plans/2026-07-26-schematic-layout-automation-service.md
+++ b/docs/superpowers/plans/2026-07-26-schematic-layout-automation-service.md
@@ -1,0 +1,84 @@
+# Schematic Layout Automation Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract four schematic layout/readability tools into a FastMCP-independent service and thin adapter without changing the public MCP contract.
+
+**Architecture:** `SchematicLayoutAutomationService` owns existing workflows through injected collaborators. `schematic_layout_automation.register()` preserves public signatures and decorators. `tools.schematic.register()` only composes dependencies and delegates registration.
+
+**Tech Stack:** Python 3.13, FastMCP, pytest, Ruff, mypy, repository architecture and metadata checks.
+
+## Global Constraints
+
+- Preserve public tool names, schemas, descriptions, annotations, metadata, response text, transaction behavior, and reload behavior.
+- Keep the service independent of FastMCP and `kicad_mcp.tools.schematic`.
+- Keep the adapter free of domain/file mutation logic.
+- Use the project-pinned uv 0.10.8 executable.
+- Make no unrelated refactors or feature changes.
+
+---
+
+### Task 1: Lock the architecture and adapter contract with failing tests
+
+**Files:**
+- Create: `tests/unit/test_schematic_layout_automation_architecture.py`
+- Create: `tests/unit/test_schematic_layout_automation_registration.py`
+
+**Interfaces:**
+- Consumes: current four tool signatures and metadata from `tools.schematic`.
+- Produces: required module names `schematic.layout_automation` and `tools.schematic_layout_automation`, plus `register(mcp, dependencies)`.
+
+- [ ] Add an AST architecture test that requires a service module with no FastMCP/registry import and requires delegation from `tools.schematic`.
+- [ ] Add a registration test that imports the new adapter, records registered functions, and asserts exact names, signatures, headless metadata, and service delegation.
+- [ ] Run the two tests and verify collection/import fails because the new modules do not exist.
+- [ ] Commit the red tests.
+
+### Task 2: Implement the FastMCP-independent service test-first
+
+**Files:**
+- Create: `tests/unit/test_schematic_layout_automation_service.py`
+- Create: `src/kicad_mcp/schematic/layout_automation.py`
+
+**Interfaces:**
+- Produces: `SchematicLayoutAutomationService.auto_place_symbols()`, `.autoplace_fields()`, `.fix_readability()`, and `.auto_place_functional()` returning `str`.
+- Consumes: injected active-file, parser, loader, placement, transaction, QA, design-intent, geometry, warning, and constant collaborators.
+
+- [ ] Write service tests for empty schematics, load/save failure, obstacle-aware placement, dry-run field placement, transactional field placement, readability stop/apply paths, anchors, missing references, zones, and overflow reporting.
+- [ ] Run focused service tests and verify they fail because the service is absent.
+- [ ] Implement typed protocols and the smallest service implementation copied behavior-for-behavior from the composition root.
+- [ ] Run service tests until green.
+- [ ] Run Ruff and mypy on the new service and test file.
+- [ ] Commit the service and tests.
+
+### Task 3: Add the thin adapter and delegate from the composition root
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_layout_automation.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+- Modify: `scripts/check_architecture_boundaries.py`
+
+**Interfaces:**
+- Produces: `SchematicLayoutAutomationDependencies(service=...)` and `register(mcp, dependencies)`.
+- Consumes: `SchematicLayoutAutomationService` from Task 2.
+
+- [ ] Implement the adapter with exact signatures, decorators, and docstrings, delegating one-to-one to the service.
+- [ ] Compose the service in `tools.schematic.register()` using existing helpers/constants.
+- [ ] Remove only the four original nested tool implementations.
+- [ ] Extend architecture policy for the service and adapter boundary.
+- [ ] Run registration and architecture tests until green.
+- [ ] Commit adapter/delegation changes.
+
+### Task 4: Prove contract preservation and repository health
+
+**Files:**
+- Modify only generated files if repository checks require intentional regeneration; otherwise no files.
+
+**Interfaces:**
+- Consumes: completed service and adapter.
+- Produces: verification evidence suitable for the PR and issue #434.
+
+- [ ] Run existing focused integration tests for the four tools.
+- [ ] Run tool-surface, generated metadata/documentation, architecture, and adapter contract checks.
+- [ ] Run full unit tests, Ruff format/check, mypy, and focused coverage.
+- [ ] Run `git diff --check` and inspect the final diff for unrelated changes.
+- [ ] Push the branch and open a PR referencing #434 without closing it.

--- a/docs/superpowers/specs/2026-07-26-schematic-layout-automation-service-design.md
+++ b/docs/superpowers/specs/2026-07-26-schematic-layout-automation-service-design.md
@@ -1,0 +1,59 @@
+# Schematic Layout Automation Service Design
+
+## Context
+
+Issue #434 requires `src/kicad_mcp/tools/schematic.py` to become a composition root whose domain behavior is independently testable without constructing FastMCP. The remaining `register()` span is 1,110 lines. Four cohesive layout/readability tools account for roughly 440 lines:
+
+- `sch_auto_place_symbols`
+- `sch_autoplace_fields`
+- `sch_fix_readability`
+- `sch_auto_place_functional`
+
+The repository already uses a stable extraction pattern: a FastMCP-independent service under `src/kicad_mcp/schematic/`, a thin adapter under `src/kicad_mcp/tools/`, dependency construction in the original composition root, direct service tests, registration-contract tests, and architecture-boundary checks.
+
+## Goals
+
+- Extract the four layout/readability workflows into a FastMCP-independent service.
+- Preserve exact public tool names, descriptions, argument schemas, output schemas, annotations, metadata, messages, write behavior, reload behavior, and error behavior.
+- Preserve legacy monkeypatch seams in `tools.schematic` by injecting the existing helper functions and constants from the composition root.
+- Reduce the `schematic.register()` span without introducing unrelated refactoring.
+- Add direct tests that exercise layout decisions without registering a FastMCP server.
+
+## Architecture
+
+Create `SchematicLayoutAutomationService` in `src/kicad_mcp/schematic/layout_automation.py`. The service owns the four workflows and receives file access, parser/loader functions, geometry helpers, transaction functions, visual-QA helpers, design-intent loading, logging, and layout constants through typed constructor fields. It must not import FastMCP or `tools.schematic`.
+
+Create `src/kicad_mcp/tools/schematic_layout_automation.py` as the thin MCP adapter. It defines the same four nested tool functions with unchanged signatures, decorators, and docstrings, then delegates directly to the service.
+
+`src/kicad_mcp/tools/schematic.py` remains the composition root. It builds the service from the existing private helpers and constants, registers the adapter, and no longer contains the four tool implementations.
+
+## Data and control flow
+
+1. FastMCP validates the public adapter arguments exactly as before.
+2. The adapter calls the matching service method with those arguments.
+3. The service performs the existing deterministic layout/readability workflow through injected collaborators.
+4. The service returns the same text response as the current implementation.
+5. Existing transaction, format-preservation, reload, diagnostics, and warning paths remain unchanged because the same composition-root helpers are injected.
+
+## Error handling
+
+- Schematic load/save failures retain the current user-facing messages.
+- Load/save failures retain structured warning calls where the current implementation emits them.
+- Empty and no-match conditions retain current diagnostic messages.
+- Readability loops retain the current minimum-pass behavior, stop conditions, unresolved-code reporting, and conditional reload.
+- No new exception swallowing or policy changes are introduced.
+
+## Testing
+
+- Service tests cover successful and failure paths for all four methods with deterministic fakes.
+- Registration tests compare tool signatures/descriptions and verify delegation without executing domain logic.
+- Architecture tests prove the service has no FastMCP or registry dependency and prove the composition root delegates the four tools.
+- Existing integration tests for symbol placement, field placement, readability repair, functional placement, tool-surface snapshots, and metadata remain green.
+- Ruff, mypy, architecture checks, generated metadata checks, and focused coverage must pass before push.
+
+## Scope exclusions
+
+- No new placement strategies.
+- No changes to functional-zone classification or spacing policy.
+- No changes to transaction, approval, checkpoint, or reload semantics.
+- No extraction of pin-label, jumper, annotation, reload, routing, or missing-junction tools in this change.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -48,6 +48,10 @@ DOMAIN_MODULES = {
     / "schematic"
     / "hierarchy_authoring.py",
     "kicad_mcp.schematic.inspection": SRC_ROOT / "kicad_mcp" / "schematic" / "inspection.py",
+    "kicad_mcp.schematic.layout_automation": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "layout_automation.py",
     "kicad_mcp.schematic.layout_inspection": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -111,6 +115,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_inspection.py",
+    "kicad_mcp.tools.schematic_layout_automation": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_layout_automation.py",
     "kicad_mcp.tools.schematic_layout_inspection": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -146,6 +154,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.document_settings",
     "kicad_mcp.schematic.hierarchy_authoring",
     "kicad_mcp.schematic.inspection",
+    "kicad_mcp.schematic.layout_automation",
     "kicad_mcp.schematic.layout_inspection",
     "kicad_mcp.schematic.rendering",
     "kicad_mcp.schematic.semantic_ir",
@@ -175,6 +184,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_document_settings": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_inspection": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_layout_automation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_layout_inspection": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_rendering": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_semantic_ir": ("kicad_mcp.tools.schematic",),
@@ -192,6 +202,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_document_settings": 300,
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,
     "kicad_mcp.tools.schematic_inspection": 300,
+    "kicad_mcp.tools.schematic_layout_automation": 300,
     "kicad_mcp.tools.schematic_layout_inspection": 300,
     "kicad_mcp.tools.schematic_rendering": 300,
     "kicad_mcp.tools.schematic_semantic_ir": 300,

--- a/src/kicad_mcp/schematic/layout_automation.py
+++ b/src/kicad_mcp/schematic/layout_automation.py
@@ -6,7 +6,7 @@ import math
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, cast
 
 from ..models.schematic import AutoPlaceSymbolsInput
 
@@ -35,11 +35,13 @@ class SchematicLike(Protocol):
 class FunctionalDesignIntentLike(Protocol):
     """Design-intent setting consumed by functional placement."""
 
-    functional_spacing_mm: float
+    @property
+    def functional_spacing_mm(self) -> float: ...
 
 
 FieldMutator = Callable[[str], str]
 ParsedSchematic = dict[str, Any]
+LayoutStrategy = Literal["cluster", "linear", "star", "grid"]
 
 
 @dataclass(frozen=True)
@@ -86,7 +88,10 @@ class SchematicLayoutAutomationService:
         strategy: str = "cluster",
     ) -> str:
         """Place references with the existing deterministic layout strategies."""
-        payload = AutoPlaceSymbolsInput(symbol_list=symbol_list or [], strategy=strategy)
+        payload = AutoPlaceSymbolsInput(
+            symbol_list=symbol_list or [],
+            strategy=cast(LayoutStrategy, strategy),
+        )
         sch_file = self.active_schematic_file()
         try:
             schematic = self.load_schematic(sch_file)
@@ -231,7 +236,14 @@ class SchematicLayoutAutomationService:
             report = self.run_visual_qa(sch_file.read_text(encoding="utf-8", errors="ignore"))
             status = str(report["status"])
             findings = report["findings"]
-            codes = {str(f["code"]) for f in findings} if isinstance(findings, list) else set()
+            codes: set[str] = set()
+            if isinstance(findings, list):
+                for finding in cast(list[object], findings):
+                    if not isinstance(finding, dict):
+                        continue
+                    code = cast(dict[str, object], finding).get("code")
+                    if code is not None:
+                        codes.add(str(code))
             if initial_status is None:
                 initial_status = status
             final_status = status

--- a/src/kicad_mcp/schematic/layout_automation.py
+++ b/src/kicad_mcp/schematic/layout_automation.py
@@ -1,0 +1,470 @@
+"""FastMCP-independent schematic layout and readability automation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..models.schematic import AutoPlaceSymbolsInput
+
+
+class ComponentLike(Protocol):
+    """Placed component surface required by the layout service."""
+
+    def move(self, x: float, y: float) -> None: ...
+
+
+class ComponentCollectionLike(Protocol):
+    """Component lookup surface required by the layout service."""
+
+    def get(self, reference: str) -> ComponentLike | None: ...
+
+
+class SchematicLike(Protocol):
+    """Loaded schematic surface required by the layout service."""
+
+    @property
+    def components(self) -> ComponentCollectionLike: ...
+
+    def save(self, path: Path, *, preserve_format: bool) -> None: ...
+
+
+class FunctionalDesignIntentLike(Protocol):
+    """Design-intent setting consumed by functional placement."""
+
+    functional_spacing_mm: float
+
+
+FieldMutator = Callable[[str], str]
+ParsedSchematic = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SchematicLayoutAutomationService:
+    """Coordinate schematic symbol placement and readability repair."""
+
+    active_schematic_file: Callable[[], Path]
+    load_schematic: Callable[[Path], SchematicLike]
+    parse_schematic: Callable[[Path], ParsedSchematic]
+    with_diagnostics: Callable[[str, Path], str]
+    estimate_occupied_cells: Callable[[list[dict[str, Any]]], set[tuple[int, int]]]
+    next_free_cell: Callable[..., tuple[float, float]]
+    snap_point: Callable[[float, float, bool], tuple[float, float]]
+    reload_schematic: Callable[[], str]
+    build_autoplace_fields_mutator: Callable[
+        [Path, list[str] | None], tuple[FieldMutator, list[str], list[str]]
+    ]
+    transactional_write_to_schematic_file: Callable[[Path, FieldMutator], object]
+    run_visual_qa: Callable[[str], Mapping[str, Any]]
+    read_sheet_paper: Callable[[Path], str]
+    paper_ladder: tuple[str, ...]
+    resize_sheet_apply: Callable[[Path, str], bool]
+    schematic_has_connections: Callable[[str], bool]
+    respace_symbols_apply: Callable[[Path], list[str]]
+    autoplace_fields_apply: Callable[[Path], list[str]]
+    load_design_intent: Callable[[], FunctionalDesignIntentLike]
+    normalize_anchor_refs: Callable[[str | list[str] | None], list[str]]
+    sheet_usable_cols: Callable[[str], int]
+    sheet_usable_rows: Callable[[str], int]
+    paper_sizes_mm: Mapping[str, tuple[float, float]]
+    classify_symbol: Callable[..., str]
+    functional_zone_origin: Callable[..., tuple[int, int]]
+    functional_zones: tuple[str, ...]
+    zone_max_cols: int
+    auto_layout_origin_x_mm: float
+    auto_layout_origin_y_mm: float
+    auto_layout_column_spacing_mm: float
+    auto_layout_row_spacing_mm: float
+    warn: Callable[..., object]
+
+    def auto_place_symbols(
+        self,
+        symbol_list: list[str] | None = None,
+        strategy: str = "cluster",
+    ) -> str:
+        """Place references with the existing deterministic layout strategies."""
+        payload = AutoPlaceSymbolsInput(symbol_list=symbol_list or [], strategy=strategy)
+        sch_file = self.active_schematic_file()
+        try:
+            schematic = self.load_schematic(sch_file)
+        except Exception as exc:
+            self.warn(
+                "schematic_auto_place_load_failed",
+                schematic_file=str(sch_file),
+                error=str(exc),
+            )
+            return f"Could not load the active schematic for auto-placement: {exc}"
+
+        sch_data = self.parse_schematic(sch_file)
+        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
+
+        requested = payload.symbol_list or [str(sym["reference"]) for sym in sch_data["symbols"]]
+        if not requested:
+            return self.with_diagnostics(
+                "The active schematic contains no symbols to auto-place.",
+                sch_file,
+            )
+
+        requested_set = set(requested)
+        fixed_syms = [s for s in all_syms if str(s.get("reference", "")) not in requested_set]
+        occupied = self.estimate_occupied_cells(fixed_syms)
+
+        placed = 0
+        missing: list[str] = []
+        radius_mm = self.auto_layout_column_spacing_mm * 2
+        center_x = self.auto_layout_origin_x_mm + self.auto_layout_column_spacing_mm
+        center_y = self.auto_layout_origin_y_mm + self.auto_layout_row_spacing_mm
+
+        for index, reference in enumerate(requested):
+            component = schematic.components.get(reference)
+            if component is None:
+                missing.append(reference)
+                continue
+
+            if payload.strategy == "linear":
+                x, y = self.next_free_cell(
+                    occupied,
+                    start_col=index,
+                    start_row=0,
+                    max_cols=24,
+                )
+            elif payload.strategy == "star":
+                if index == 0:
+                    x = center_x
+                    y = center_y
+                    col = int(
+                        round(
+                            (x - self.auto_layout_origin_x_mm) / self.auto_layout_column_spacing_mm
+                        )
+                    )
+                    row = int(
+                        round((y - self.auto_layout_origin_y_mm) / self.auto_layout_row_spacing_mm)
+                    )
+                    occupied.add((col, row))
+                else:
+                    angle = ((index - 1) / max(len(requested) - 1, 1)) * (2 * math.pi)
+                    raw_x = center_x + (radius_mm * math.cos(angle))
+                    raw_y = center_y + (radius_mm * math.sin(angle))
+                    col = int(
+                        round(
+                            (raw_x - self.auto_layout_origin_x_mm)
+                            / self.auto_layout_column_spacing_mm
+                        )
+                    )
+                    row = int(
+                        round(
+                            (raw_y - self.auto_layout_origin_y_mm) / self.auto_layout_row_spacing_mm
+                        )
+                    )
+                    x, y = self.next_free_cell(occupied, start_col=col, start_row=row)
+            elif payload.strategy == "grid":
+                grid_cols = max(1, math.ceil(math.sqrt(len(requested))))
+                x, y = self.next_free_cell(occupied, max_cols=grid_cols)
+            else:
+                x, y = self.next_free_cell(occupied)
+
+            snapped_x, snapped_y = self.snap_point(x, y, True)
+            component.move(snapped_x, snapped_y)
+            placed += 1
+
+        try:
+            schematic.save(sch_file, preserve_format=True)
+        except Exception as exc:
+            self.warn(
+                "schematic_auto_place_save_failed",
+                schematic_file=str(sch_file),
+                error=str(exc),
+            )
+            return f"Could not save auto-placement changes: {exc}"
+
+        result = self.reload_schematic()
+        missing_suffix = f" Missing: {', '.join(missing)}." if missing else ""
+        return (
+            f"{result}\n"
+            f"Auto-placed {placed} symbol(s) using the {payload.strategy} strategy. "
+            f"Overlap-aware placement respected {len(fixed_syms)} fixed obstacle(s)."
+            f"{missing_suffix}"
+        )
+
+    def autoplace_fields(
+        self,
+        references: list[str] | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        """Reposition visible Reference/Value fields using existing helpers."""
+        sch_file = self.active_schematic_file()
+        mutator, targets, updated = self.build_autoplace_fields_mutator(sch_file, references)
+        if not targets:
+            return self.with_diagnostics(
+                "No matching symbols found to auto-place fields for.", sch_file
+            )
+
+        if dry_run:
+            mutator(sch_file.read_text(encoding="utf-8"))
+            return (
+                f"Dry run: would reposition Reference/Value fields on {len(updated)} "
+                f"symbol(s): {', '.join(updated) if updated else '(none)'}\."
+            ).replace("\\.", ".")
+
+        self.transactional_write_to_schematic_file(sch_file, mutator)
+        result = self.reload_schematic()
+        return (
+            f"{result}\n"
+            f"Auto-placed Reference/Value fields on {len(updated)} symbol(s)"
+            f"{': ' + ', '.join(updated) if updated else ''}."
+        )
+
+    def fix_readability(self, max_passes: int = 3) -> str:
+        """Apply safe readability fixes until clean, stable, or pass-limited."""
+        passes = max(1, max_passes)
+        sch_file = self.active_schematic_file()
+        actions: list[str] = []
+        pass_log: list[str] = []
+        initial_status: str | None = None
+        final_status = "PASS"
+        remaining: set[str] = set()
+
+        for pass_index in range(passes):
+            report = self.run_visual_qa(sch_file.read_text(encoding="utf-8", errors="ignore"))
+            status = str(report["status"])
+            findings = report["findings"]
+            codes = {str(f["code"]) for f in findings} if isinstance(findings, list) else set()
+            if initial_status is None:
+                initial_status = status
+            final_status = status
+            pass_log.append(
+                f"pass {pass_index + 1}: {status} ({', '.join(sorted(codes)) or 'clean'})"
+            )
+            if status == "PASS":
+                break
+
+            changed = False
+            if {"offsheet_symbol", "offsheet_label"} & codes:
+                current_paper = self.read_sheet_paper(sch_file)
+                ladder_index = (
+                    self.paper_ladder.index(current_paper)
+                    if current_paper in self.paper_ladder
+                    else 0
+                )
+                if ladder_index < len(self.paper_ladder) - 1:
+                    target = self.paper_ladder[ladder_index + 1]
+                    if self.resize_sheet_apply(sch_file, target):
+                        actions.append(f"grew sheet to {target}")
+                        changed = True
+            if "symbol_overlap" in codes and not self.schematic_has_connections(
+                sch_file.read_text(encoding="utf-8", errors="ignore")
+            ):
+                respaced = self.respace_symbols_apply(sch_file)
+                if respaced:
+                    actions.append(f"re-spaced {len(respaced)} overlapping symbol(s)")
+                    changed = True
+            if "text_overlap" in codes:
+                moved = self.autoplace_fields_apply(sch_file)
+                if moved:
+                    actions.append(f"auto-placed fields on {len(moved)} symbol(s)")
+                    changed = True
+
+            if not changed:
+                remaining = codes
+                break
+            remaining = codes
+
+        if actions:
+            self.reload_schematic()
+
+        unresolved = sorted(remaining & {"symbol_overlap", "label_overlap", "dense_label_fanout"})
+        summary = [
+            f"Readability fix: {initial_status or 'PASS'} -> {final_status} "
+            f"over {len(pass_log)} pass(es).",
+            *pass_log,
+        ]
+        if actions:
+            summary.append("Applied: " + "; ".join(actions) + ".")
+        else:
+            summary.append("No automatic fixes were applied.")
+        if unresolved:
+            summary.append(
+                "Manual follow-up suggested for: "
+                + ", ".join(unresolved)
+                + " (try sch_auto_place_functional / sch_auto_resize_sheet)."
+            )
+        return "\n".join(summary)
+
+    def auto_place_functional(
+        self,
+        symbol_list: list[str] | None = None,
+        anchor_ref: str | list[str] | None = None,
+    ) -> str:
+        """Place symbols into the existing semantic functional zones."""
+        sch_file = self.active_schematic_file()
+        try:
+            schematic = self.load_schematic(sch_file)
+        except Exception as exc:
+            return f"Could not load the active schematic for functional placement: {exc}"
+
+        sch_data = self.parse_schematic(sch_file)
+        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
+
+        requested: list[str] = symbol_list or [str(s["reference"]) for s in sch_data["symbols"]]
+        if not requested:
+            return self.with_diagnostics(
+                "The active schematic contains no symbols to place.",
+                sch_file,
+            )
+
+        design_intent = self.load_design_intent()
+        functional_spacing_mm = design_intent.functional_spacing_mm
+        anchor_refs = self.normalize_anchor_refs(anchor_ref)
+        anchor_set = set(anchor_refs)
+
+        requested_set = set(requested)
+        paper = self.read_sheet_paper(sch_file)
+        max_cols = self.sheet_usable_cols(paper)
+        max_rows = self.sheet_usable_rows(paper)
+        default_size = self.paper_sizes_mm["A4"]
+        sheet_w, sheet_h = self.paper_sizes_mm.get(paper, default_size)
+
+        fixed_syms = [
+            s
+            for s in all_syms
+            if str(s.get("reference", "")) not in requested_set
+            or str(s.get("reference", "")) in anchor_set
+        ]
+        global_occupied = self.estimate_occupied_cells(fixed_syms)
+
+        zone_occupied: dict[str, set[tuple[int, int]]] = {
+            zone: set() for zone in self.functional_zones
+        }
+
+        sym_meta: dict[str, dict[str, str]] = {}
+        for symbol in sch_data["symbols"]:
+            ref = str(symbol.get("reference", ""))
+            sym_meta[ref] = {
+                "value": str(symbol.get("value", "")),
+                "lib_id": str(symbol.get("lib_id", "")),
+            }
+
+        anchored_preserved = [
+            ref for ref in anchor_refs if ref in requested_set and schematic.components.get(ref)
+        ]
+        for symbol in fixed_syms:
+            reference = str(symbol.get("reference", ""))
+            category = self.classify_symbol(
+                ref=reference,
+                value=sym_meta.get(reference, {}).get("value", ""),
+                lib_id=sym_meta.get(reference, {}).get("lib_id", ""),
+            )
+            x = float(symbol.get("x", symbol.get("x_mm", 0.0)) or 0.0)
+            y = float(symbol.get("y", symbol.get("y_mm", 0.0)) or 0.0)
+            col = int(
+                round((x - self.auto_layout_origin_x_mm) / self.auto_layout_column_spacing_mm)
+            )
+            row = int(round((y - self.auto_layout_origin_y_mm) / self.auto_layout_row_spacing_mm))
+            zone_occupied.setdefault(category, set()).add((col, row))
+
+        placed = 0
+        overflow_count = 0
+        missing: list[str] = []
+        zone_counts: dict[str, int] = {}
+
+        for reference in requested:
+            if reference in anchor_set:
+                continue
+            component = schematic.components.get(reference)
+            if component is None:
+                missing.append(reference)
+                continue
+
+            meta = sym_meta.get(reference, {})
+            category = self.classify_symbol(
+                ref=reference,
+                value=meta.get("value", ""),
+                lib_id=meta.get("lib_id", ""),
+            )
+
+            zone_col, zone_row = self.functional_zone_origin(
+                category,
+                max_cols=max_cols,
+                max_rows=max_rows,
+                spacing_mm=functional_spacing_mm,
+            )
+
+            placed_in_zone = zone_occupied.setdefault(category, set())
+            found = False
+            col = zone_col
+            row = zone_row
+            for sub_row in range(0, max_rows):
+                for sub_col in range(0, self.zone_max_cols):
+                    cand_col = zone_col + sub_col
+                    cand_row = zone_row + sub_row
+                    if cand_col >= max_cols or cand_row >= max_rows:
+                        continue
+                    cell = (cand_col, cand_row)
+                    if cell not in global_occupied and cell not in placed_in_zone:
+                        col, row = cell
+                        found = True
+                        break
+                if found:
+                    break
+
+            if not found:
+                col_f, row_f = self.next_free_cell(global_occupied, paper=paper)
+                col = int(
+                    round(
+                        (col_f - self.auto_layout_origin_x_mm) / self.auto_layout_column_spacing_mm
+                    )
+                )
+                row = int(
+                    round((row_f - self.auto_layout_origin_y_mm) / self.auto_layout_row_spacing_mm)
+                )
+                if col >= max_cols or row >= max_rows:
+                    overflow_count += 1
+
+            x = self.auto_layout_origin_x_mm + col * self.auto_layout_column_spacing_mm
+            y = self.auto_layout_origin_y_mm + row * self.auto_layout_row_spacing_mm
+            snapped_x, snapped_y = self.snap_point(x, y, True)
+
+            component.move(snapped_x, snapped_y)
+            placed += 1
+
+            for dc in (-1, 0, 1):
+                for dr in (-1, 0, 1):
+                    global_occupied.add((col + dc, row + dr))
+            placed_in_zone.add((col, row))
+            zone_counts[category] = zone_counts.get(category, 0) + 1
+
+        try:
+            schematic.save(sch_file, preserve_format=True)
+        except Exception as exc:
+            return f"Could not save functional placement changes: {exc}"
+
+        result = self.reload_schematic()
+        missing_suffix = f" Missing refs: {', '.join(missing)}." if missing else ""
+        anchor_suffix = (
+            f"\nAnchored refs preserved: {', '.join(anchored_preserved)}."
+            if anchored_preserved
+            else ""
+        )
+
+        zone_lines = [f"  {cat}: {count}" for cat, count in sorted(zone_counts.items())]
+        summary = "\n".join(zone_lines) if zone_lines else "  (none)"
+
+        overflow_note = ""
+        if overflow_count:
+            overflow_note = (
+                f"\nWARNING: {overflow_count} symbol(s) could not fit within the "
+                f"'{paper}' sheet ({sheet_w:.0f}x{sheet_h:.0f} mm).  "
+                "Call sch_auto_resize_sheet to switch to a larger format, "
+                "then run sch_auto_place_functional again."
+            )
+
+        return (
+            f"{result}\n"
+            f"Functional auto-placement complete on '{paper}' sheet — "
+            f"{placed} symbol(s) placed in {len(zone_counts)} zone(s):\n{summary}"
+            f"\nFunctional spacing target: {functional_spacing_mm:.2f} mm."
+            f"{anchor_suffix}{missing_suffix}{overflow_note}"
+        )

--- a/src/kicad_mcp/schematic/layout_automation.py
+++ b/src/kicad_mcp/schematic/layout_automation.py
@@ -206,8 +206,8 @@ class SchematicLayoutAutomationService:
             mutator(sch_file.read_text(encoding="utf-8"))
             return (
                 f"Dry run: would reposition Reference/Value fields on {len(updated)} "
-                f"symbol(s): {', '.join(updated) if updated else '(none)'}\."
-            ).replace("\\.", ".")
+                f"symbol(s): {', '.join(updated) if updated else '(none)'}."
+            )
 
         self.transactional_write_to_schematic_file(sch_file, mutator)
         result = self.reload_schematic()

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -29,7 +29,6 @@ from ..models.schematic import (
     AddSymbolInput,
     AddWireInput,
     AnnotateInput,
-    AutoPlaceSymbolsInput,
     PowerSymbolInput,
     RouteWireBetweenPinsInput,
     UpdatePropertiesInput,
@@ -50,6 +49,11 @@ from ..schematic.hierarchy_authoring import (
     SchematicHierarchyAuthoringService,
 )
 from ..schematic.inspection import SchematicInspectionService
+from ..schematic.layout_automation import (
+    FunctionalDesignIntentLike,
+    SchematicLayoutAutomationService,
+    SchematicLike,
+)
 from ..schematic.layout_inspection import SchematicLayoutInspectionService
 from ..schematic.rendering import SchematicRenderingService
 from ..schematic.semantic_ir import (
@@ -81,6 +85,7 @@ from . import (
     schematic_document_settings,
     schematic_hierarchy_authoring,
     schematic_inspection,
+    schematic_layout_automation,
     schematic_layout_inspection,
     schematic_rendering,
     schematic_semantic_ir,
@@ -5537,6 +5542,16 @@ def _active_project_name() -> str:
     return config.project_file.stem if config.project_file is not None else "KiCadMCP"
 
 
+def _load_layout_schematic(path: Path) -> SchematicLike:
+    return cast(SchematicLike, _load_kicad_schematic(path))
+
+
+def _load_layout_design_intent() -> FunctionalDesignIntentLike:
+    from .project import load_design_intent
+
+    return load_design_intent()
+
+
 def register(mcp: FastMCP) -> None:
     """Register schematic tools."""
     inspection_service = SchematicInspectionService(
@@ -6197,453 +6212,42 @@ def register(mcp: FastMCP) -> None:
         result = _reload_schematic()
         return f"{result}\n{summary}"
 
-    @mcp.tool()
-    def sch_auto_place_symbols(
-        symbol_list: list[str] | None = None,
-        strategy: str = "cluster",
-    ) -> str:
-        """Place selected references with a deterministic cluster, linear, star, or grid layout.
-
-        Unlike the legacy behaviour, this version reads all already-placed symbols
-        first and avoids placing new symbols on top of them.  Fixed/already-placed
-        symbols that are not in ``symbol_list`` are treated as immovable obstacles.
-        """
-        payload = AutoPlaceSymbolsInput(symbol_list=symbol_list or [], strategy=strategy)
-        sch_file = _get_schematic_file()
-        try:
-            schematic = _load_kicad_schematic(sch_file)
-        except Exception as exc:
-            logger.warning(
-                "schematic_auto_place_load_failed",
-                schematic_file=str(sch_file),
-                error=str(exc),
-            )
-            return f"Could not load the active schematic for auto-placement: {exc}"
-
-        sch_data = parse_schematic_file(sch_file)
-        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
-
-        requested = payload.symbol_list or [str(sym["reference"]) for sym in sch_data["symbols"]]
-        if not requested:
-            return _with_schematic_diagnostics(
-                "The active schematic contains no symbols to auto-place.",
-                sch_file,
-            )
-
-        requested_set = set(requested)
-
-        # Symbols NOT being moved are fixed obstacles.
-        fixed_syms = [s for s in all_syms if str(s.get("reference", "")) not in requested_set]
-        occupied = _estimate_occupied_cells(fixed_syms)
-
-        placed = 0
-        missing: list[str] = []
-        radius_mm = AUTO_LAYOUT_COLUMN_SPACING_MM * 2
-        center_x = AUTO_LAYOUT_ORIGIN_X_MM + AUTO_LAYOUT_COLUMN_SPACING_MM
-        center_y = AUTO_LAYOUT_ORIGIN_Y_MM + AUTO_LAYOUT_ROW_SPACING_MM
-
-        for index, reference in enumerate(requested):
-            component = schematic.components.get(reference)
-            if component is None:
-                missing.append(reference)
-                continue
-
-            if payload.strategy == "linear":
-                # Find next free cell along a single row
-                x, y = _next_free_cell(
-                    occupied,
-                    start_col=index,
-                    start_row=0,
-                    max_cols=24,
-                )
-            elif payload.strategy == "star":
-                if index == 0:
-                    x = center_x
-                    y = center_y
-                    # Mark centre cell occupied
-                    col = int(round((x - AUTO_LAYOUT_ORIGIN_X_MM) / AUTO_LAYOUT_COLUMN_SPACING_MM))
-                    row = int(round((y - AUTO_LAYOUT_ORIGIN_Y_MM) / AUTO_LAYOUT_ROW_SPACING_MM))
-                    occupied.add((col, row))
-                else:
-                    angle = ((index - 1) / max(len(requested) - 1, 1)) * (2 * math.pi)
-                    raw_x = center_x + (radius_mm * math.cos(angle))
-                    raw_y = center_y + (radius_mm * math.sin(angle))
-                    # Snap to nearest free cell
-                    col = int(
-                        round((raw_x - AUTO_LAYOUT_ORIGIN_X_MM) / AUTO_LAYOUT_COLUMN_SPACING_MM)
-                    )
-                    row = int(round((raw_y - AUTO_LAYOUT_ORIGIN_Y_MM) / AUTO_LAYOUT_ROW_SPACING_MM))
-                    x, y = _next_free_cell(occupied, start_col=col, start_row=row)
-            elif payload.strategy == "grid":
-                # Uniform 2D grid: wrap into a roughly square arrangement so the
-                # references fill rows and columns evenly instead of one long row.
-                grid_cols = max(1, math.ceil(math.sqrt(len(requested))))
-                x, y = _next_free_cell(occupied, max_cols=grid_cols)
-            else:
-                # cluster: row-major grid, skip occupied cells
-                x, y = _next_free_cell(occupied)
-
-            snapped_x, snapped_y = _snap_point(x, y, True)
-            component.move(snapped_x, snapped_y)
-            placed += 1
-
-        try:
-            schematic.save(sch_file, preserve_format=True)
-        except Exception as exc:
-            logger.warning(
-                "schematic_auto_place_save_failed",
-                schematic_file=str(sch_file),
-                error=str(exc),
-            )
-            return f"Could not save auto-placement changes: {exc}"
-
-        result = _reload_schematic()
-        missing_suffix = f" Missing: {', '.join(missing)}." if missing else ""
-        return (
-            f"{result}\n"
-            f"Auto-placed {placed} symbol(s) using the {payload.strategy} strategy. "
-            f"Overlap-aware placement respected {len(fixed_syms)} fixed obstacle(s)."
-            f"{missing_suffix}"
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_autoplace_fields(references: list[str] | None = None, dry_run: bool = False) -> str:
-        """Reposition symbol Reference/Value text onto the clearest body side.
-
-        Mirrors KiCad's ``autoplace_fields``: for each symbol the visible
-        Reference and Value fields are moved to the body side with the most
-        clearance, away from pins and neighbouring symbols, so the rendered sheet
-        stops stacking text on top of other text. Footprint/Datasheet and hidden
-        fields are left untouched. Pass ``references`` to limit the operation to
-        specific designators, or ``dry_run`` to preview the count without writing.
-
-        Run this after ``sch_auto_place_symbols`` (or any bulk placement) and use
-        ``sch_visual_qa`` to confirm the ``text_overlap`` findings clear.
-        """
-        sch_file = _get_schematic_file()
-        mutator, targets, updated = _build_autoplace_fields_mutator(sch_file, references)
-        if not targets:
-            return _with_schematic_diagnostics(
-                "No matching symbols found to auto-place fields for.", sch_file
-            )
-
-        if dry_run:
-            mutator(sch_file.read_text(encoding="utf-8"))
-            return (
-                f"Dry run: would reposition Reference/Value fields on {len(updated)} "
-                f"symbol(s): {', '.join(updated) if updated else '(none)'}."
-            )
-
-        _transactional_write_to_schematic_file(sch_file, mutator)
-        result = _reload_schematic()
-        return (
-            f"{result}\n"
-            f"Auto-placed Reference/Value fields on {len(updated)} symbol(s)"
-            f"{': ' + ', '.join(updated) if updated else ''}."
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_fix_readability(max_passes: int = 3) -> str:
-        """Iteratively fix schematic readability defects until clean or stable.
-
-        Runs the headless ``sch_visual_qa`` checks, then applies the matching
-        fixer and re-checks, looping until the sheet passes, no further progress
-        is made, or ``max_passes`` is reached:
-
-        - **off-sheet** symbols/labels -> grow the sheet one paper size (A4 -> A3 ...)
-        - **text overlap** -> auto-place Reference/Value fields onto clear body sides
-        - **symbol-body overlap** -> re-space the symbols on a body-sized grid, but
-          ONLY when the sheet has no wires, labels or power symbols (moving a
-          connected symbol would break its nets); otherwise it is reported.
-
-        Dense label clusters are reported for manual follow-up (label anchors are
-        electrical attachment points and cannot be moved safely). Returns a
-        per-pass log with the before/after QA status so the closing state is
-        explicit.
-        """
-        passes = max(1, max_passes)
-        sch_file = _get_schematic_file()
-        actions: list[str] = []
-        pass_log: list[str] = []
-        initial_status: str | None = None
-        final_status = "PASS"
-        remaining: set[str] = set()
-
-        for pass_index in range(passes):
-            report = _run_visual_qa(sch_file.read_text(encoding="utf-8", errors="ignore"))
-            status = str(report["status"])
-            findings = report["findings"]
-            codes = {str(f["code"]) for f in findings} if isinstance(findings, list) else set()
-            if initial_status is None:
-                initial_status = status
-            final_status = status
-            pass_log.append(
-                f"pass {pass_index + 1}: {status} ({', '.join(sorted(codes)) or 'clean'})"
-            )
-            if status == "PASS":
-                break
-
-            changed = False
-            if {"offsheet_symbol", "offsheet_label"} & codes:
-                current_paper = _read_sheet_paper(sch_file)
-                ladder_index = (
-                    _PAPER_LADDER.index(current_paper) if current_paper in _PAPER_LADDER else 0
-                )
-                if ladder_index < len(_PAPER_LADDER) - 1:
-                    target = _PAPER_LADDER[ladder_index + 1]
-                    if _resize_sheet_apply(sch_file, target):
-                        actions.append(f"grew sheet to {target}")
-                        changed = True
-            if "symbol_overlap" in codes and not _schematic_has_connections(
-                sch_file.read_text(encoding="utf-8", errors="ignore")
-            ):
-                respaced = _respace_symbols_apply(sch_file)
-                if respaced:
-                    actions.append(f"re-spaced {len(respaced)} overlapping symbol(s)")
-                    changed = True
-            if "text_overlap" in codes:
-                moved = _autoplace_fields_apply(sch_file)
-                if moved:
-                    actions.append(f"auto-placed fields on {len(moved)} symbol(s)")
-                    changed = True
-
-            if not changed:
-                remaining = codes
-                break
-            remaining = codes
-
-        if actions:
-            _reload_schematic()
-
-        unresolved = sorted(remaining & {"symbol_overlap", "label_overlap", "dense_label_fanout"})
-        summary = [
-            f"Readability fix: {initial_status or 'PASS'} -> {final_status} "
-            f"over {len(pass_log)} pass(es).",
-            *pass_log,
-        ]
-        if actions:
-            summary.append("Applied: " + "; ".join(actions) + ".")
-        else:
-            summary.append("No automatic fixes were applied.")
-        if unresolved:
-            summary.append(
-                "Manual follow-up suggested for: "
-                + ", ".join(unresolved)
-                + " (try sch_auto_place_functional / sch_auto_resize_sheet)."
-            )
-        return "\n".join(summary)
-
-    # -----------------------------------------------------------------------
-    # Spatial awareness tools (v2.1.0)
-    # -----------------------------------------------------------------------
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_auto_place_functional(
-        symbol_list: list[str] | None = None,
-        anchor_ref: str | list[str] | None = None,
-    ) -> str:
-        """Place schematic symbols into semantically meaningful zones on the sheet.
-
-        Unlike the basic ``sch_auto_place_symbols`` which uses a plain grid,
-        this tool categorises each symbol by its **function** (MCU, connector,
-        power IC, sensor, passive, protection …) and places it in the
-        corresponding region of the schematic sheet.  The result is a readable,
-        professionally structured schematic with logical signal flow
-        (connectors on the left, processing in the centre, power/decoupling at
-        the bottom).
-
-        Zone layout (column × row, each cell = 25.4 × 17.78 mm)::
-
-            Col →    0-2          3-5          6-8
-            Row 0:   connectors   MCU          UI/LED/SW
-            Row 3:   power IC     sensors/IC   protection
-            Row 5:   power_pass   passives     transistors/filter
-            Row 7:   test points  ---          misc
-
-        The actual sheet size is read from the schematic file.  If the symbol
-        count would overflow the current sheet, a warning is appended
-        recommending ``sch_auto_resize_sheet`` to switch to a larger format
-        (A3, A2, …) before re-running this tool.
-
-        Symbols already placed (not in ``symbol_list``) are treated as fixed
-        obstacles and will not be overwritten.  Within each zone, symbols are
-        arranged in a compact row-major sub-grid.
-
-        Args:
-            symbol_list: Optional list of reference designators to place.  If
-                omitted, all symbols in the schematic are placed.
-            anchor_ref: Optional single reference or list of references to keep
-                fixed while re-placing the remaining symbols around them.
-
-        Returns:
-            A summary showing how many symbols were placed per functional zone,
-            plus an overflow warning if the sheet is too small.
-        """
-        sch_file = _get_schematic_file()
-        try:
-            schematic = _load_kicad_schematic(sch_file)
-        except Exception as exc:
-            return f"Could not load the active schematic for functional placement: {exc}"
-
-        sch_data = parse_schematic_file(sch_file)
-        all_syms = sch_data["symbols"] + sch_data["power_symbols"]
-
-        requested: list[str] = symbol_list or [str(s["reference"]) for s in sch_data["symbols"]]
-        if not requested:
-            return _with_schematic_diagnostics(
-                "The active schematic contains no symbols to place.",
-                sch_file,
-            )
-
-        from .project import load_design_intent
-
-        design_intent = load_design_intent()
-        functional_spacing_mm = design_intent.functional_spacing_mm
-        anchor_refs = _normalize_anchor_refs(anchor_ref)
-        anchor_set = set(anchor_refs)
-
-        requested_set = set(requested)
-        paper = _read_sheet_paper(sch_file)
-        max_cols = _sheet_usable_cols(paper)
-        max_rows = _sheet_usable_rows(paper)
-        sheet_w, sheet_h = PAPER_SIZES_MM.get(paper, PAPER_SIZES_MM["A4"])
-
-        # Fixed obstacles — symbols we are NOT moving
-        fixed_syms = [
-            s
-            for s in all_syms
-            if str(s.get("reference", "")) not in requested_set
-            or str(s.get("reference", "")) in anchor_set
-        ]
-        global_occupied = _estimate_occupied_cells(fixed_syms)
-
-        # Per-zone occupancy
-        zone_occupied: dict[str, set[tuple[int, int]]] = {z: set() for z in _FUNCTIONAL_ZONES}
-
-        # Build symbol metadata lookup
-        sym_meta: dict[str, dict[str, str]] = {}
-        for s in sch_data["symbols"]:
-            ref = str(s.get("reference", ""))
-            sym_meta[ref] = {
-                "value": str(s.get("value", "")),
-                "lib_id": str(s.get("lib_id", "")),
-            }
-
-        anchored_preserved = [
-            ref for ref in anchor_refs if ref in requested_set and schematic.components.get(ref)
-        ]
-        for symbol in fixed_syms:
-            reference = str(symbol.get("reference", ""))
-            category = _classify_symbol(
-                ref=reference,
-                value=sym_meta.get(reference, {}).get("value", ""),
-                lib_id=sym_meta.get(reference, {}).get("lib_id", ""),
-            )
-            x = float(symbol.get("x", symbol.get("x_mm", 0.0)) or 0.0)
-            y = float(symbol.get("y", symbol.get("y_mm", 0.0)) or 0.0)
-            col = int(round((x - AUTO_LAYOUT_ORIGIN_X_MM) / AUTO_LAYOUT_COLUMN_SPACING_MM))
-            row = int(round((y - AUTO_LAYOUT_ORIGIN_Y_MM) / AUTO_LAYOUT_ROW_SPACING_MM))
-            zone_occupied.setdefault(category, set()).add((col, row))
-
-        placed = 0
-        overflow_count = 0
-        missing: list[str] = []
-        zone_counts: dict[str, int] = {}
-
-        for reference in requested:
-            if reference in anchor_set:
-                continue
-            component = schematic.components.get(reference)
-            if component is None:
-                missing.append(reference)
-                continue
-
-            meta = sym_meta.get(reference, {})
-            category = _classify_symbol(
-                ref=reference,
-                value=meta.get("value", ""),
-                lib_id=meta.get("lib_id", ""),
-            )
-
-            zone_col, zone_row = _functional_zone_origin(
-                category,
-                max_cols=max_cols,
-                max_rows=max_rows,
-                spacing_mm=functional_spacing_mm,
-            )
-
-            # Find next free cell within this zone's sub-grid
-            placed_in_zone = zone_occupied[category]
-            found = False
-            for sub_row in range(0, max_rows):
-                for sub_col in range(0, _ZONE_MAX_COLS):
-                    cand_col = zone_col + sub_col
-                    cand_row = zone_row + sub_row
-                    if cand_col >= max_cols or cand_row >= max_rows:
-                        continue
-                    cell = (cand_col, cand_row)
-                    if cell not in global_occupied and cell not in placed_in_zone:
-                        col, row = cell
-                        found = True
-                        break
-                if found:
-                    break
-
-            if not found:
-                # Fall back to any remaining free cell within sheet bounds
-                col_f, row_f = _next_free_cell(global_occupied, paper=paper)
-                col = int(round((col_f - AUTO_LAYOUT_ORIGIN_X_MM) / AUTO_LAYOUT_COLUMN_SPACING_MM))
-                row = int(round((row_f - AUTO_LAYOUT_ORIGIN_Y_MM) / AUTO_LAYOUT_ROW_SPACING_MM))
-                # If still outside sheet bounds, flag overflow
-                if col >= max_cols or row >= max_rows:
-                    overflow_count += 1
-
-            x = AUTO_LAYOUT_ORIGIN_X_MM + col * AUTO_LAYOUT_COLUMN_SPACING_MM
-            y = AUTO_LAYOUT_ORIGIN_Y_MM + row * AUTO_LAYOUT_ROW_SPACING_MM
-            snapped_x, snapped_y = _snap_point(x, y, True)
-
-            component.move(snapped_x, snapped_y)
-            placed += 1
-
-            # Mark this cell occupied globally and within its zone
-            for dc in (-1, 0, 1):
-                for dr in (-1, 0, 1):
-                    global_occupied.add((col + dc, row + dr))
-            zone_occupied[category].add((col, row))
-            zone_counts[category] = zone_counts.get(category, 0) + 1
-
-        try:
-            schematic.save(sch_file, preserve_format=True)
-        except Exception as exc:
-            return f"Could not save functional placement changes: {exc}"
-
-        result = _reload_schematic()
-        missing_suffix = f" Missing refs: {', '.join(missing)}." if missing else ""
-        anchor_suffix = (
-            f"\nAnchored refs preserved: {', '.join(anchored_preserved)}."
-            if anchored_preserved
-            else ""
-        )
-
-        zone_lines = [f"  {cat}: {n}" for cat, n in sorted(zone_counts.items())]
-        summary = "\n".join(zone_lines) if zone_lines else "  (none)"
-
-        overflow_note = ""
-        if overflow_count:
-            overflow_note = (
-                f"\nWARNING: {overflow_count} symbol(s) could not fit within the "
-                f"'{paper}' sheet ({sheet_w:.0f}x{sheet_h:.0f} mm).  "
-                "Call sch_auto_resize_sheet to switch to a larger format, "
-                "then run sch_auto_place_functional again."
-            )
-
-        return (
-            f"{result}\n"
-            f"Functional auto-placement complete on '{paper}' sheet — "
-            f"{placed} symbol(s) placed in {len(zone_counts)} zone(s):\n{summary}"
-            f"\nFunctional spacing target: {functional_spacing_mm:.2f} mm."
-            f"{anchor_suffix}{missing_suffix}{overflow_note}"
-        )
+    layout_automation_service = SchematicLayoutAutomationService(
+        active_schematic_file=_get_schematic_file,
+        load_schematic=_load_layout_schematic,
+        parse_schematic=parse_schematic_file,
+        with_diagnostics=_with_schematic_diagnostics,
+        estimate_occupied_cells=_estimate_occupied_cells,
+        next_free_cell=_next_free_cell,
+        snap_point=_snap_point,
+        reload_schematic=_reload_schematic,
+        build_autoplace_fields_mutator=_build_autoplace_fields_mutator,
+        transactional_write_to_schematic_file=_transactional_write_to_schematic_file,
+        run_visual_qa=_run_visual_qa,
+        read_sheet_paper=_read_sheet_paper,
+        paper_ladder=_PAPER_LADDER,
+        resize_sheet_apply=_resize_sheet_apply,
+        schematic_has_connections=_schematic_has_connections,
+        respace_symbols_apply=_respace_symbols_apply,
+        autoplace_fields_apply=_autoplace_fields_apply,
+        load_design_intent=_load_layout_design_intent,
+        normalize_anchor_refs=_normalize_anchor_refs,
+        sheet_usable_cols=_sheet_usable_cols,
+        sheet_usable_rows=_sheet_usable_rows,
+        paper_sizes_mm=PAPER_SIZES_MM,
+        classify_symbol=_classify_symbol,
+        functional_zone_origin=_functional_zone_origin,
+        functional_zones=tuple(_FUNCTIONAL_ZONES),
+        zone_max_cols=_ZONE_MAX_COLS,
+        auto_layout_origin_x_mm=AUTO_LAYOUT_ORIGIN_X_MM,
+        auto_layout_origin_y_mm=AUTO_LAYOUT_ORIGIN_Y_MM,
+        auto_layout_column_spacing_mm=AUTO_LAYOUT_COLUMN_SPACING_MM,
+        auto_layout_row_spacing_mm=AUTO_LAYOUT_ROW_SPACING_MM,
+        warn=logger.warning,
+    )
+    schematic_layout_automation.register(
+        mcp,
+        schematic_layout_automation.SchematicLayoutAutomationDependencies(
+            service=layout_automation_service,
+        ),
+    )

--- a/src/kicad_mcp/tools/schematic_layout_automation.py
+++ b/src/kicad_mcp/tools/schematic_layout_automation.py
@@ -1,0 +1,121 @@
+"""Thin FastMCP adapter for schematic layout and readability automation."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.layout_automation import SchematicLayoutAutomationService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicLayoutAutomationDependencies:
+    """Layout automation service injected by the schematic composition root."""
+
+    service: SchematicLayoutAutomationService
+
+
+def register(mcp: FastMCP, dependencies: SchematicLayoutAutomationDependencies) -> None:
+    """Register schematic layout and readability automation tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    def sch_auto_place_symbols(
+        symbol_list: list[str] | None = None,
+        strategy: str = "cluster",
+    ) -> str:
+        """Place selected references with a deterministic cluster, linear, star, or grid layout.
+
+        Unlike the legacy behaviour, this version reads all already-placed symbols
+        first and avoids placing new symbols on top of them.  Fixed/already-placed
+        symbols that are not in ``symbol_list`` are treated as immovable obstacles.
+        """
+        return service.auto_place_symbols(symbol_list=symbol_list, strategy=strategy)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_autoplace_fields(references: list[str] | None = None, dry_run: bool = False) -> str:
+        """Reposition symbol Reference/Value text onto the clearest body side.
+
+        Mirrors KiCad's ``autoplace_fields``: for each symbol the visible
+        Reference and Value fields are moved to the body side with the most
+        clearance, away from pins and neighbouring symbols, so the rendered sheet
+        stops stacking text on top of other text. Footprint/Datasheet and hidden
+        fields are left untouched. Pass ``references`` to limit the operation to
+        specific designators, or ``dry_run`` to preview the count without writing.
+
+        Run this after ``sch_auto_place_symbols`` (or any bulk placement) and use
+        ``sch_visual_qa`` to confirm the ``text_overlap`` findings clear.
+        """
+        return service.autoplace_fields(references=references, dry_run=dry_run)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_fix_readability(max_passes: int = 3) -> str:
+        """Iteratively fix schematic readability defects until clean or stable.
+
+        Runs the headless ``sch_visual_qa`` checks, then applies the matching
+        fixer and re-checks, looping until the sheet passes, no further progress
+        is made, or ``max_passes`` is reached:
+
+        - **off-sheet** symbols/labels -> grow the sheet one paper size (A4 -> A3 ...)
+        - **text overlap** -> auto-place Reference/Value fields onto clear body sides
+        - **symbol-body overlap** -> re-space the symbols on a body-sized grid, but
+          ONLY when the sheet has no wires, labels or power symbols (moving a
+          connected symbol would break its nets); otherwise it is reported.
+
+        Dense label clusters are reported for manual follow-up (label anchors are
+        electrical attachment points and cannot be moved safely). Returns a
+        per-pass log with the before/after QA status so the closing state is
+        explicit.
+        """
+        return service.fix_readability(max_passes=max_passes)
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_auto_place_functional(
+        symbol_list: list[str] | None = None,
+        anchor_ref: str | list[str] | None = None,
+    ) -> str:
+        """Place schematic symbols into semantically meaningful zones on the sheet.
+
+        Unlike the basic ``sch_auto_place_symbols`` which uses a plain grid,
+        this tool categorises each symbol by its **function** (MCU, connector,
+        power IC, sensor, passive, protection …) and places it in the
+        corresponding region of the schematic sheet.  The result is a readable,
+        professionally structured schematic with logical signal flow
+        (connectors on the left, processing in the centre, power/decoupling at
+        the bottom).
+
+        Zone layout (column × row, each cell = 25.4 × 17.78 mm)::
+
+            Col →    0-2          3-5          6-8
+            Row 0:   connectors   MCU          UI/LED/SW
+            Row 3:   power IC     sensors/IC   protection
+            Row 5:   power_pass   passives     transistors/filter
+            Row 7:   test points  ---          misc
+
+        The actual sheet size is read from the schematic file.  If the symbol
+        count would overflow the current sheet, a warning is appended
+        recommending ``sch_auto_resize_sheet`` to switch to a larger format
+        (A3, A2, …) before re-running this tool.
+
+        Symbols already placed (not in ``symbol_list``) are treated as fixed
+        obstacles and will not be overwritten.  Within each zone, symbols are
+        arranged in a compact row-major sub-grid.
+
+        Args:
+            symbol_list: Optional list of reference designators to place.  If
+                omitted, all symbols in the schematic are placed.
+            anchor_ref: Optional single reference or list of references to keep
+                fixed while re-placing the remaining symbols around them.
+
+        Returns:
+            A summary showing how many symbols were placed per functional zone,
+            plus an overflow warning if the sheet is too small.
+        """
+        return service.auto_place_functional(symbol_list=symbol_list, anchor_ref=anchor_ref)

--- a/tests/unit/test_schematic_layout_automation_architecture.py
+++ b/tests/unit/test_schematic_layout_automation_architecture.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_layout_automation_modules() -> None:
+    assert "kicad_mcp.schematic.layout_automation" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.layout_automation" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_layout_automation" in boundaries.DOMAIN_MODULES
+
+
+def test_layout_automation_service_has_no_fastmcp_or_registry_dependency() -> None:
+    service = boundaries.SRC_ROOT / "kicad_mcp" / "schematic" / "layout_automation.py"
+    imports = _imports(service)
+    assert not any(name.startswith("mcp") for name in imports)
+    assert "kicad_mcp.tools.schematic" not in imports
+
+
+def test_layout_automation_adapter_does_not_import_monolith() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_layout_automation.py"
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_layout_automation"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_layout_automation_register_stays_below_300_lines() -> None:
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_layout_automation.py"
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_layout_automation"] == 300
+
+
+def test_schematic_composition_root_delegates_layout_automation() -> None:
+    composition_root = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic.py"
+    source = composition_root.read_text(encoding="utf-8")
+    assert "schematic_layout_automation.register(" in source
+    for nested_tool in (
+        "def sch_auto_place_symbols(",
+        "def sch_autoplace_fields(",
+        "def sch_fix_readability(",
+        "def sch_auto_place_functional(",
+    ):
+        assert nested_tool not in source

--- a/tests/unit/test_schematic_layout_automation_registration.py
+++ b/tests/unit/test_schematic_layout_automation_registration.py
@@ -95,9 +95,7 @@ def test_registration_preserves_names_and_schemas() -> None:
     }
     assert tools["sch_autoplace_fields"].parameters["properties"]["dry_run"]["default"] is False
     assert tools["sch_fix_readability"].parameters == {
-        "properties": {
-            "max_passes": {"default": 3, "title": "Max Passes", "type": "integer"}
-        },
+        "properties": {"max_passes": {"default": 3, "title": "Max Passes", "type": "integer"}},
         "title": "sch_fix_readabilityArguments",
         "type": "object",
     }
@@ -131,7 +129,9 @@ def test_registration_preserves_descriptions() -> None:
         "symbols that are not in ``symbol_list`` are treated as immovable obstacles.\n"
     )
     assert "Mirrors KiCad's ``autoplace_fields``" in tools["sch_autoplace_fields"].description
-    assert "Iteratively fix schematic readability defects" in tools["sch_fix_readability"].description
+    assert (
+        "Iteratively fix schematic readability defects" in tools["sch_fix_readability"].description
+    )
     assert "semantically meaningful zones" in tools["sch_auto_place_functional"].description
 
 
@@ -156,8 +156,7 @@ def test_registration_delegates_exact_arguments() -> None:
     assert tools["sch_autoplace_fields"].fn(references=["R1"], dry_run=True) == "fields"
     assert tools["sch_fix_readability"].fn(max_passes=4) == "readability"
     assert (
-        tools["sch_auto_place_functional"].fn(symbol_list=["U1"], anchor_ref=["J1"])
-        == "functional"
+        tools["sch_auto_place_functional"].fn(symbol_list=["U1"], anchor_ref=["J1"]) == "functional"
     )
 
     assert service.calls == [

--- a/tests/unit/test_schematic_layout_automation_registration.py
+++ b/tests/unit/test_schematic_layout_automation_registration.py
@@ -1,0 +1,168 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_layout_automation import (
+    SchematicLayoutAutomationDependencies,
+    register,
+)
+
+
+class FakeLayoutAutomationService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def auto_place_symbols(
+        self,
+        symbol_list: list[str] | None = None,
+        strategy: str = "cluster",
+    ) -> str:
+        self.calls.append(
+            (
+                "auto_place_symbols",
+                {"symbol_list": symbol_list, "strategy": strategy},
+            )
+        )
+        return "symbols"
+
+    def autoplace_fields(
+        self,
+        references: list[str] | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        self.calls.append(
+            (
+                "autoplace_fields",
+                {"references": references, "dry_run": dry_run},
+            )
+        )
+        return "fields"
+
+    def fix_readability(self, max_passes: int = 3) -> str:
+        self.calls.append(("fix_readability", {"max_passes": max_passes}))
+        return "readability"
+
+    def auto_place_functional(
+        self,
+        symbol_list: list[str] | None = None,
+        anchor_ref: str | list[str] | None = None,
+    ) -> str:
+        self.calls.append(
+            (
+                "auto_place_functional",
+                {"symbol_list": symbol_list, "anchor_ref": anchor_ref},
+            )
+        )
+        return "functional"
+
+
+def _registered() -> tuple[FastMCP, FakeLayoutAutomationService]:
+    server = FastMCP("schematic-layout-automation-test")
+    service = FakeLayoutAutomationService()
+    register(server, SchematicLayoutAutomationDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_auto_place_symbols",
+        "sch_autoplace_fields",
+        "sch_fix_readability",
+        "sch_auto_place_functional",
+    }
+    assert tools["sch_auto_place_symbols"].parameters == {
+        "properties": {
+            "symbol_list": {
+                "anyOf": [
+                    {"items": {"type": "string"}, "type": "array"},
+                    {"type": "null"},
+                ],
+                "default": None,
+                "title": "Symbol List",
+            },
+            "strategy": {"default": "cluster", "title": "Strategy", "type": "string"},
+        },
+        "title": "sch_auto_place_symbolsArguments",
+        "type": "object",
+    }
+    assert tools["sch_autoplace_fields"].parameters["properties"]["dry_run"]["default"] is False
+    assert tools["sch_fix_readability"].parameters == {
+        "properties": {
+            "max_passes": {"default": 3, "title": "Max Passes", "type": "integer"}
+        },
+        "title": "sch_fix_readabilityArguments",
+        "type": "object",
+    }
+    assert tools["sch_auto_place_functional"].parameters["properties"]["anchor_ref"] == {
+        "anyOf": [
+            {"type": "string"},
+            {"items": {"type": "string"}, "type": "array"},
+            {"type": "null"},
+        ],
+        "default": None,
+        "title": "Anchor Ref",
+    }
+    for name, tool in tools.items():
+        assert tool.output_schema == {
+            "properties": {"result": {"title": "Result", "type": "string"}},
+            "required": ["result"],
+            "title": f"{name}Output",
+            "type": "object",
+        }
+        assert tool.annotations is None
+
+
+def test_registration_preserves_descriptions() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_auto_place_symbols"].description == (
+        "Place selected references with a deterministic cluster, linear, star, or grid layout.\n\n"
+        "Unlike the legacy behaviour, this version reads all already-placed symbols\n"
+        "first and avoids placing new symbols on top of them.  Fixed/already-placed\n"
+        "symbols that are not in ``symbol_list`` are treated as immovable obstacles.\n"
+    )
+    assert "Mirrors KiCad's ``autoplace_fields``" in tools["sch_autoplace_fields"].description
+    assert "Iteratively fix schematic readability defects" in tools["sch_fix_readability"].description
+    assert "semantically meaningful zones" in tools["sch_auto_place_functional"].description
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert get_tool_metadata("sch_auto_place_symbols") is None
+    for name in ("sch_autoplace_fields", "sch_fix_readability", "sch_auto_place_functional"):
+        metadata = get_tool_metadata(name)
+        assert metadata is not None
+        assert metadata.headless_compatible is True
+        assert metadata.requires_kicad_running is False
+        assert tools[name].annotations is None
+
+
+def test_registration_delegates_exact_arguments() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert tools["sch_auto_place_symbols"].fn(symbol_list=["R1"], strategy="grid") == "symbols"
+    assert tools["sch_autoplace_fields"].fn(references=["R1"], dry_run=True) == "fields"
+    assert tools["sch_fix_readability"].fn(max_passes=4) == "readability"
+    assert (
+        tools["sch_auto_place_functional"].fn(symbol_list=["U1"], anchor_ref=["J1"])
+        == "functional"
+    )
+
+    assert service.calls == [
+        ("auto_place_symbols", {"symbol_list": ["R1"], "strategy": "grid"}),
+        ("autoplace_fields", {"references": ["R1"], "dry_run": True}),
+        ("fix_readability", {"max_passes": 4}),
+        ("auto_place_functional", {"symbol_list": ["U1"], "anchor_ref": ["J1"]}),
+    ]

--- a/tests/unit/test_schematic_layout_automation_service.py
+++ b/tests/unit/test_schematic_layout_automation_service.py
@@ -7,7 +7,10 @@ from typing import Any
 
 import pytest
 
-from kicad_mcp.schematic.layout_automation import SchematicLayoutAutomationService
+from kicad_mcp.schematic.layout_automation import (
+    SchematicLayoutAutomationService,
+    SchematicLike,
+)
 
 
 class FakeComponent:
@@ -73,12 +76,12 @@ def _service(
     resize_log = resize_calls if resize_calls is not None else []
     reload_log = reload_calls if reload_calls is not None else []
 
-    def load_schematic(_path: Path) -> FakeSchematic:
+    def load_schematic(_path: Path) -> SchematicLike:
         if isinstance(loaded_value, Exception):
             raise loaded_value
         return loaded_value
 
-    def next_free_cell(_occupied: set[tuple[int, int]], **_kwargs: Any) -> tuple[float, float]:
+    def next_free_cell(_occupied: set[tuple[int, int]], **_kwargs: object) -> tuple[float, float]:
         return cell_values.pop(0) if cell_values else (25.4, 17.78)
 
     def run_visual_qa(_text: str) -> dict[str, Any]:
@@ -91,6 +94,14 @@ def _service(
     ) -> tuple[Callable[[str], str], list[str], list[str]]:
         return (lambda current: current + "-updated", ["R1"], ["R1"])
 
+    def reload_schematic() -> str:
+        reload_log.append(True)
+        return "Reloaded"
+
+    def resize_sheet_apply(path: Path, target: str) -> bool:
+        resize_log.append((path, target))
+        return True
+
     return SchematicLayoutAutomationService(
         active_schematic_file=lambda: schematic_file,
         load_schematic=load_schematic,
@@ -99,7 +110,7 @@ def _service(
         estimate_occupied_cells=lambda symbols: {(len(symbols), 0)} if symbols else set(),
         next_free_cell=next_free_cell,
         snap_point=lambda x, y, _enabled: (x + 0.1, y + 0.2),
-        reload_schematic=lambda: reload_log.append(True) or "Reloaded",
+        reload_schematic=reload_schematic,
         build_autoplace_fields_mutator=field_builder or default_field_builder,
         transactional_write_to_schematic_file=lambda path, mutator: transaction_log.append(
             (path, mutator)
@@ -107,13 +118,11 @@ def _service(
         run_visual_qa=run_visual_qa,
         read_sheet_paper=lambda _path: paper,
         paper_ladder=("A4", "A3", "A2", "A1", "A0"),
-        resize_sheet_apply=lambda path, target: resize_log.append((path, target)) or True,
+        resize_sheet_apply=resize_sheet_apply,
         schematic_has_connections=lambda _text: False,
         respace_symbols_apply=lambda _path: list(respace_result or []),
         autoplace_fields_apply=lambda _path: list(field_apply_result or []),
-        load_design_intent=lambda: SimpleNamespace(
-            functional_spacing_mm=functional_spacing_mm
-        ),
+        load_design_intent=lambda: SimpleNamespace(functional_spacing_mm=functional_spacing_mm),
         normalize_anchor_refs=lambda _anchor: list(normalized_anchors or []),
         sheet_usable_cols=lambda _paper: usable_cols,
         sheet_usable_rows=lambda _paper: usable_rows,
@@ -169,7 +178,7 @@ def test_auto_place_symbols_respects_fixed_obstacles_and_reports_missing(tmp_pat
 
     result = service.auto_place_symbols(["R1", "R404"], "grid")
 
-    assert r1.moves == [(50.9, 35.76)]
+    assert r1.moves == [pytest.approx((50.9, 35.76))]
     assert loaded.saved == [(schematic_file, True)]
     assert "Auto-placed 1 symbol(s) using the grid strategy." in result
     assert "respected 2 fixed obstacle(s)" in result
@@ -334,7 +343,7 @@ def test_auto_place_functional_preserves_anchor_and_reports_missing(tmp_path: Pa
 
     result = service.auto_place_functional(["R1", "J1", "R404"], anchor_ref="J1")
 
-    assert r1.moves == [(50.9, 53.54)]
+    assert r1.moves == [pytest.approx((50.9, 53.54))]
     assert anchor.moves == []
     assert loaded.saved == [(schematic_file, True)]
     assert "1 symbol(s) placed in 1 zone(s)" in result
@@ -374,9 +383,7 @@ def test_auto_place_functional_reports_overflow(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("strategy", ["cluster", "linear", "star", "grid"])
-def test_auto_place_symbols_accepts_all_existing_strategies(
-    tmp_path: Path, strategy: str
-) -> None:
+def test_auto_place_symbols_accepts_all_existing_strategies(tmp_path: Path, strategy: str) -> None:
     schematic_file = tmp_path / "board.kicad_sch"
     component = FakeComponent()
     service = _service(

--- a/tests/unit/test_schematic_layout_automation_service.py
+++ b/tests/unit/test_schematic_layout_automation_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -11,6 +11,11 @@ from kicad_mcp.schematic.layout_automation import (
     SchematicLayoutAutomationService,
     SchematicLike,
 )
+
+
+@dataclass(frozen=True)
+class FakeDesignIntent:
+    functional_spacing_mm: float
 
 
 class FakeComponent:
@@ -102,6 +107,26 @@ def _service(
         resize_log.append((path, target))
         return True
 
+    def load_design_intent() -> FakeDesignIntent:
+        return FakeDesignIntent(functional_spacing_mm=functional_spacing_mm)
+
+    def classify_symbol(*, ref: str, value: str, lib_id: str) -> str:
+        del ref, value, lib_id
+        return "passive"
+
+    def functional_zone_origin(
+        category: str,
+        *,
+        max_cols: int,
+        max_rows: int,
+        spacing_mm: float,
+    ) -> tuple[int, int]:
+        del category, max_cols, max_rows, spacing_mm
+        return functional_origin
+
+    def warn(event: str, **payload: object) -> None:
+        warning_log.append((event, dict(payload)))
+
     return SchematicLayoutAutomationService(
         active_schematic_file=lambda: schematic_file,
         load_schematic=load_schematic,
@@ -122,20 +147,20 @@ def _service(
         schematic_has_connections=lambda _text: False,
         respace_symbols_apply=lambda _path: list(respace_result or []),
         autoplace_fields_apply=lambda _path: list(field_apply_result or []),
-        load_design_intent=lambda: SimpleNamespace(functional_spacing_mm=functional_spacing_mm),
+        load_design_intent=load_design_intent,
         normalize_anchor_refs=lambda _anchor: list(normalized_anchors or []),
         sheet_usable_cols=lambda _paper: usable_cols,
         sheet_usable_rows=lambda _paper: usable_rows,
         paper_sizes_mm={"A4": (297.0, 210.0), "A3": (420.0, 297.0)},
-        classify_symbol=lambda **_kwargs: "passive",
-        functional_zone_origin=lambda *_args, **_kwargs: functional_origin,
+        classify_symbol=classify_symbol,
+        functional_zone_origin=functional_zone_origin,
         functional_zones=("passive", "connector"),
         zone_max_cols=3,
         auto_layout_origin_x_mm=25.4,
         auto_layout_origin_y_mm=17.78,
         auto_layout_column_spacing_mm=25.4,
         auto_layout_row_spacing_mm=17.78,
-        warn=lambda event, **payload: warning_log.append((event, payload)),
+        warn=warn,
     )
 
 
@@ -255,9 +280,16 @@ def test_autoplace_fields_writes_and_reloads(tmp_path: Path) -> None:
 
 def test_autoplace_fields_reports_no_matching_targets(tmp_path: Path) -> None:
     schematic_file = tmp_path / "board.kicad_sch"
+
+    def no_targets(
+        _path: Path,
+        _references: list[str] | None,
+    ) -> tuple[Callable[[str], str], list[str], list[str]]:
+        return (lambda value: value, [], [])
+
     service = _service(
         schematic_file,
-        field_builder=lambda _path, _refs: (lambda value: value, [], []),
+        field_builder=no_targets,
     )
 
     result = service.autoplace_fields(["R9"])

--- a/tests/unit/test_schematic_layout_automation_service.py
+++ b/tests/unit/test_schematic_layout_automation_service.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from kicad_mcp.schematic.layout_automation import SchematicLayoutAutomationService
+
+
+class FakeComponent:
+    def __init__(self) -> None:
+        self.moves: list[tuple[float, float]] = []
+
+    def move(self, x: float, y: float) -> None:
+        self.moves.append((x, y))
+
+
+class FakeComponents:
+    def __init__(self, values: dict[str, FakeComponent]) -> None:
+        self.values = values
+
+    def get(self, reference: str) -> FakeComponent | None:
+        return self.values.get(reference)
+
+
+class FakeSchematic:
+    def __init__(
+        self,
+        values: dict[str, FakeComponent] | None = None,
+        *,
+        save_error: Exception | None = None,
+    ) -> None:
+        self.components = FakeComponents(values or {})
+        self.save_error = save_error
+        self.saved: list[tuple[Path, bool]] = []
+
+    def save(self, path: Path, *, preserve_format: bool) -> None:
+        if self.save_error is not None:
+            raise self.save_error
+        self.saved.append((path, preserve_format))
+
+
+def _service(
+    schematic_file: Path,
+    *,
+    loaded: FakeSchematic | Exception | None = None,
+    parsed: dict[str, Any] | None = None,
+    warnings: list[tuple[str, dict[str, Any]]] | None = None,
+    next_cells: list[tuple[float, float]] | None = None,
+    visual_reports: list[dict[str, Any]] | None = None,
+    field_builder: Callable[..., tuple[Callable[[str], str], list[str], list[str]]] | None = None,
+    transactional_calls: list[tuple[Path, Callable[[str], str]]] | None = None,
+    resize_calls: list[tuple[Path, str]] | None = None,
+    respace_result: list[str] | None = None,
+    field_apply_result: list[str] | None = None,
+    reload_calls: list[bool] | None = None,
+    normalized_anchors: list[str] | None = None,
+    paper: str = "A4",
+    usable_cols: int = 9,
+    usable_rows: int = 9,
+    functional_origin: tuple[int, int] = (0, 0),
+    functional_spacing_mm: float = 12.7,
+) -> SchematicLayoutAutomationService:
+    loaded_value = loaded if loaded is not None else FakeSchematic()
+    parsed_value = parsed or {"symbols": [], "power_symbols": []}
+    warning_log = warnings if warnings is not None else []
+    cell_values = list(next_cells or [(25.4, 17.78)])
+    report_values = list(visual_reports or [{"status": "PASS", "findings": []}])
+    transaction_log = transactional_calls if transactional_calls is not None else []
+    resize_log = resize_calls if resize_calls is not None else []
+    reload_log = reload_calls if reload_calls is not None else []
+
+    def load_schematic(_path: Path) -> FakeSchematic:
+        if isinstance(loaded_value, Exception):
+            raise loaded_value
+        return loaded_value
+
+    def next_free_cell(_occupied: set[tuple[int, int]], **_kwargs: Any) -> tuple[float, float]:
+        return cell_values.pop(0) if cell_values else (25.4, 17.78)
+
+    def run_visual_qa(_text: str) -> dict[str, Any]:
+        if len(report_values) > 1:
+            return report_values.pop(0)
+        return report_values[0]
+
+    def default_field_builder(
+        _path: Path, _references: list[str] | None
+    ) -> tuple[Callable[[str], str], list[str], list[str]]:
+        return (lambda current: current + "-updated", ["R1"], ["R1"])
+
+    return SchematicLayoutAutomationService(
+        active_schematic_file=lambda: schematic_file,
+        load_schematic=load_schematic,
+        parse_schematic=lambda _path: parsed_value,
+        with_diagnostics=lambda message, path: f"diag:{path.name}:{message}",
+        estimate_occupied_cells=lambda symbols: {(len(symbols), 0)} if symbols else set(),
+        next_free_cell=next_free_cell,
+        snap_point=lambda x, y, _enabled: (x + 0.1, y + 0.2),
+        reload_schematic=lambda: reload_log.append(True) or "Reloaded",
+        build_autoplace_fields_mutator=field_builder or default_field_builder,
+        transactional_write_to_schematic_file=lambda path, mutator: transaction_log.append(
+            (path, mutator)
+        ),
+        run_visual_qa=run_visual_qa,
+        read_sheet_paper=lambda _path: paper,
+        paper_ladder=("A4", "A3", "A2", "A1", "A0"),
+        resize_sheet_apply=lambda path, target: resize_log.append((path, target)) or True,
+        schematic_has_connections=lambda _text: False,
+        respace_symbols_apply=lambda _path: list(respace_result or []),
+        autoplace_fields_apply=lambda _path: list(field_apply_result or []),
+        load_design_intent=lambda: SimpleNamespace(
+            functional_spacing_mm=functional_spacing_mm
+        ),
+        normalize_anchor_refs=lambda _anchor: list(normalized_anchors or []),
+        sheet_usable_cols=lambda _paper: usable_cols,
+        sheet_usable_rows=lambda _paper: usable_rows,
+        paper_sizes_mm={"A4": (297.0, 210.0), "A3": (420.0, 297.0)},
+        classify_symbol=lambda **_kwargs: "passive",
+        functional_zone_origin=lambda *_args, **_kwargs: functional_origin,
+        functional_zones=("passive", "connector"),
+        zone_max_cols=3,
+        auto_layout_origin_x_mm=25.4,
+        auto_layout_origin_y_mm=17.78,
+        auto_layout_column_spacing_mm=25.4,
+        auto_layout_row_spacing_mm=17.78,
+        warn=lambda event, **payload: warning_log.append((event, payload)),
+    )
+
+
+def test_auto_place_symbols_reports_load_failure(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    warnings: list[tuple[str, dict[str, Any]]] = []
+    service = _service(
+        schematic_file,
+        loaded=RuntimeError("broken"),
+        warnings=warnings,
+    )
+
+    result = service.auto_place_symbols(["R1"], "grid")
+
+    assert result == "Could not load the active schematic for auto-placement: broken"
+    assert warnings == [
+        (
+            "schematic_auto_place_load_failed",
+            {"schematic_file": str(schematic_file), "error": "broken"},
+        )
+    ]
+
+
+def test_auto_place_symbols_respects_fixed_obstacles_and_reports_missing(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    r1 = FakeComponent()
+    loaded = FakeSchematic({"R1": r1})
+    service = _service(
+        schematic_file,
+        loaded=loaded,
+        parsed={
+            "symbols": [
+                {"reference": "R1"},
+                {"reference": "R2", "x": 10.0, "y": 20.0},
+            ],
+            "power_symbols": [{"reference": "#PWR01", "x": 1.0, "y": 2.0}],
+        },
+        next_cells=[(50.8, 35.56)],
+    )
+
+    result = service.auto_place_symbols(["R1", "R404"], "grid")
+
+    assert r1.moves == [(50.9, 35.76)]
+    assert loaded.saved == [(schematic_file, True)]
+    assert "Auto-placed 1 symbol(s) using the grid strategy." in result
+    assert "respected 2 fixed obstacle(s)" in result
+    assert "Missing: R404." in result
+
+
+def test_auto_place_symbols_reports_save_failure(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    warnings: list[tuple[str, dict[str, Any]]] = []
+    loaded = FakeSchematic({"R1": FakeComponent()}, save_error=OSError("read-only"))
+    service = _service(
+        schematic_file,
+        loaded=loaded,
+        parsed={"symbols": [{"reference": "R1"}], "power_symbols": []},
+        warnings=warnings,
+    )
+
+    result = service.auto_place_symbols(["R1"])
+
+    assert result == "Could not save auto-placement changes: read-only"
+    assert warnings[-1] == (
+        "schematic_auto_place_save_failed",
+        {"schematic_file": str(schematic_file), "error": "read-only"},
+    )
+
+
+def test_autoplace_fields_dry_run_executes_mutator_without_writing(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    schematic_file.write_text("original", encoding="utf-8")
+    mutated: list[str] = []
+    transactions: list[tuple[Path, Callable[[str], str]]] = []
+
+    def build(
+        _path: Path, references: list[str] | None
+    ) -> tuple[Callable[[str], str], list[str], list[str]]:
+        assert references == ["R1"]
+
+        def mutator(current: str) -> str:
+            mutated.append(current)
+            return current + "-updated"
+
+        return mutator, ["R1"], ["R1"]
+
+    service = _service(
+        schematic_file,
+        field_builder=build,
+        transactional_calls=transactions,
+    )
+
+    result = service.autoplace_fields(["R1"], dry_run=True)
+
+    assert mutated == ["original"]
+    assert transactions == []
+    assert result == "Dry run: would reposition Reference/Value fields on 1 symbol(s): R1."
+
+
+def test_autoplace_fields_writes_and_reloads(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    transactions: list[tuple[Path, Callable[[str], str]]] = []
+    reloads: list[bool] = []
+    service = _service(
+        schematic_file,
+        transactional_calls=transactions,
+        reload_calls=reloads,
+    )
+
+    result = service.autoplace_fields()
+
+    assert len(transactions) == 1
+    assert transactions[0][0] == schematic_file
+    assert reloads == [True]
+    assert result == "Reloaded\nAuto-placed Reference/Value fields on 1 symbol(s): R1."
+
+
+def test_autoplace_fields_reports_no_matching_targets(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    service = _service(
+        schematic_file,
+        field_builder=lambda _path, _refs: (lambda value: value, [], []),
+    )
+
+    result = service.autoplace_fields(["R9"])
+
+    assert result == "diag:board.kicad_sch:No matching symbols found to auto-place fields for."
+
+
+def test_fix_readability_applies_available_fixes_until_pass(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    schematic_file.write_text("sheet", encoding="utf-8")
+    resize_calls: list[tuple[Path, str]] = []
+    reloads: list[bool] = []
+    service = _service(
+        schematic_file,
+        visual_reports=[
+            {
+                "status": "FAIL",
+                "findings": [
+                    {"code": "offsheet_symbol"},
+                    {"code": "symbol_overlap"},
+                    {"code": "text_overlap"},
+                ],
+            },
+            {"status": "PASS", "findings": []},
+        ],
+        resize_calls=resize_calls,
+        respace_result=["R1", "R2"],
+        field_apply_result=["R1"],
+        reload_calls=reloads,
+    )
+
+    result = service.fix_readability(max_passes=3)
+
+    assert resize_calls == [(schematic_file, "A3")]
+    assert reloads == [True]
+    assert "Readability fix: FAIL -> PASS over 2 pass(es)." in result
+    assert "grew sheet to A3" in result
+    assert "re-spaced 2 overlapping symbol(s)" in result
+    assert "auto-placed fields on 1 symbol(s)" in result
+
+
+def test_fix_readability_stops_when_no_safe_fix_exists(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    schematic_file.write_text("sheet", encoding="utf-8")
+    service = _service(
+        schematic_file,
+        visual_reports=[
+            {
+                "status": "FAIL",
+                "findings": [
+                    {"code": "label_overlap"},
+                    {"code": "dense_label_fanout"},
+                ],
+            }
+        ],
+    )
+
+    result = service.fix_readability(max_passes=0)
+
+    assert "over 1 pass(es)" in result
+    assert "No automatic fixes were applied." in result
+    assert "dense_label_fanout, label_overlap" in result
+
+
+def test_auto_place_functional_preserves_anchor_and_reports_missing(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    r1 = FakeComponent()
+    anchor = FakeComponent()
+    loaded = FakeSchematic({"R1": r1, "J1": anchor})
+    service = _service(
+        schematic_file,
+        loaded=loaded,
+        parsed={
+            "symbols": [
+                {"reference": "R1", "value": "10k", "lib_id": "Device:R"},
+                {"reference": "J1", "value": "Conn", "lib_id": "Connector:Conn_01x02"},
+            ],
+            "power_symbols": [],
+        },
+        normalized_anchors=["J1"],
+        functional_origin=(1, 2),
+    )
+
+    result = service.auto_place_functional(["R1", "J1", "R404"], anchor_ref="J1")
+
+    assert r1.moves == [(50.9, 53.54)]
+    assert anchor.moves == []
+    assert loaded.saved == [(schematic_file, True)]
+    assert "1 symbol(s) placed in 1 zone(s)" in result
+    assert "Anchored refs preserved: J1." in result
+    assert "Missing refs: R404." in result
+    assert "Functional spacing target: 12.70 mm." in result
+
+
+def test_auto_place_functional_reports_load_failure(tmp_path: Path) -> None:
+    service = _service(tmp_path / "board.kicad_sch", loaded=RuntimeError("bad file"))
+
+    assert service.auto_place_functional() == (
+        "Could not load the active schematic for functional placement: bad file"
+    )
+
+
+def test_auto_place_functional_reports_overflow(tmp_path: Path) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    component = FakeComponent()
+    loaded = FakeSchematic({"R1": component})
+    service = _service(
+        schematic_file,
+        loaded=loaded,
+        parsed={
+            "symbols": [{"reference": "R1", "value": "10k", "lib_id": "Device:R"}],
+            "power_symbols": [],
+        },
+        usable_cols=1,
+        usable_rows=1,
+        functional_origin=(5, 5),
+        next_cells=[(1000.0, 1000.0)],
+    )
+
+    result = service.auto_place_functional(["R1"])
+
+    assert "WARNING: 1 symbol(s) could not fit within the 'A4' sheet" in result
+
+
+@pytest.mark.parametrize("strategy", ["cluster", "linear", "star", "grid"])
+def test_auto_place_symbols_accepts_all_existing_strategies(
+    tmp_path: Path, strategy: str
+) -> None:
+    schematic_file = tmp_path / "board.kicad_sch"
+    component = FakeComponent()
+    service = _service(
+        schematic_file,
+        loaded=FakeSchematic({"R1": component}),
+        parsed={"symbols": [{"reference": "R1"}], "power_symbols": []},
+    )
+
+    result = service.auto_place_symbols(["R1"], strategy)
+
+    assert f"using the {strategy} strategy" in result
+    assert component.moves


### PR DESCRIPTION
## Summary

- extract `sch_auto_place_symbols`, `sch_autoplace_fields`, `sch_fix_readability`, and `sch_auto_place_functional` into a FastMCP-independent `SchematicLayoutAutomationService`
- add a 100-line thin MCP adapter that preserves the existing public names, descriptions, schemas, annotations, metadata, responses, and write/reload behavior
- keep legacy helper/monkeypatch seams in `tools.schematic` through explicit dependency injection
- extend architecture guards and add red-green service, registration, and composition-root tests
- reduce `src/kicad_mcp/tools/schematic.py::register()` from 1,110 lines to 699 lines

## Issue progress

Progresses #434. This PR deliberately does **not** close the issue: the composition root is smaller and the extracted adapter is below the 300-line limit, but the remaining `schematic.register()` span is still 699 lines and needs another bounded extraction.

## Verification

- exact pre/post MCP contract JSON match for all four tools (identical SHA-256)
- 24 focused unit/architecture/registration tests pass
- 17 existing layout/readability integration tests pass
- focused coverage: 96.27% total; service 96%, adapter 100% (required: 83%)
- Ruff scoped format/check pass
- mypy: 185 source files, no issues
- Pyright: 0 errors, 0 warnings
- architecture boundary, tool contract, metadata sync, tools-reference, parity and parity-regression checks pass
- representative latency benchmark passes
- wheel + sdist build and package metadata validation pass
- runtime policy, no-pcbnew/SWIG, and strict MkDocs build pass
- full unit suite passed to 100% with exit code 0 (5 existing platform-dependent skips; one pre-existing AsyncMock runtime warning)

## Rebase verification

Rebased onto `main` after #460 landed the GitPython 3.1.56 security floor and KiCad 10.0.5 stable baseline.

Fresh verification on rebased HEAD `aefe491`:

- 44 focused layout/security/compatibility tests passed
- scoped Ruff format/check passed
- mypy passed across 185 source files
- Pyright reported 0 errors and 0 warnings
- architecture boundary check passed
- working tree and remote branch are synchronized
