### PR TITLE
refactor(schematic): extract connectivity authoring service

### DIFF
--- a/docs/superpowers/plans/2026-07-26-schematic-connectivity-authoring-service.md
+++ b/docs/superpowers/plans/2026-07-26-schematic-connectivity-authoring-service.md
@@ -1,0 +1,187 @@
+# Schematic Connectivity Authoring Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract schematic pin-terminal authoring, pin-to-pin routing, and junction repair into a FastMCP-independent service and thin adapter without changing the public MCP contract.
+
+**Architecture:** `tools.schematic` remains the composition root and injects existing parsing, geometry, transaction, and reload helpers into `SchematicConnectivityAuthoringService`. A separate adapter owns the three public FastMCP functions and their decorators.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic, pytest, Ruff, mypy, Pyright.
+
+## Global Constraints
+
+- Preserve exact public tool names, signatures, docstrings, schemas, annotations, metadata, response strings, and transaction/reload behavior.
+- Keep `run_auto_add_missing_junctions` in `tools.schematic` for fixer imports and monkeypatch seams.
+- Domain service imports no FastMCP and no schematic registry module.
+- Adapter `register()` stays at or below 300 lines.
+- Work is delivered as reviewable test-first commits.
+
+---
+
+### Task 1: Lock architecture and MCP registration contracts
+
+**Files:**
+- Create: `tests/unit/test_schematic_connectivity_authoring_architecture.py`
+- Create: `tests/unit/test_schematic_connectivity_authoring_registration.py`
+
+**Interfaces:**
+- Consumes: current full-server contracts for the three public tools.
+- Produces: failing imports for the not-yet-created service adapter and explicit architecture expectations.
+
+- [ ] **Step 1: Write the architecture test**
+
+Assert that the future service and adapter are tracked by `scripts/check_architecture_boundaries.py`, the service imports neither FastMCP nor the monolith, the adapter does not import the monolith, adapter `register()` is at most 300 lines, and the composition root no longer defines the three nested functions.
+
+- [ ] **Step 2: Write the adapter contract test**
+
+Register the future adapter against a fake service. Assert exact tool names, descriptions, parameter schemas, output schemas, metadata, annotations, argument delegation, and returned strings.
+
+- [ ] **Step 3: Run the tests and confirm red**
+
+Run:
+
+```bash
+uv run --all-extras pytest -q \
+  tests/unit/test_schematic_connectivity_authoring_architecture.py \
+  tests/unit/test_schematic_connectivity_authoring_registration.py
+```
+
+Expected: collection fails because `kicad_mcp.tools.schematic_connectivity_authoring` does not exist.
+
+- [ ] **Step 4: Commit the red contract tests**
+
+```bash
+git add tests/unit/test_schematic_connectivity_authoring_*.py
+git commit -m "test(schematic): lock connectivity authoring extraction contract"
+```
+
+### Task 2: Define service behavior with direct unit tests
+
+**Files:**
+- Create: `tests/unit/test_schematic_connectivity_authoring_service.py`
+
+**Interfaces:**
+- Produces: behavior contract for `SchematicConnectivityAuthoringService` methods `add_pin_labels`, `route_wire_between_pins`, and `add_missing_junctions`.
+
+- [ ] **Step 1: Add pin-label behavior tests**
+
+Cover invalid connection records, missing references, missing pins, power-symbol fallback, signal labels, power terminals, dense terminal staggering, no-op output, target-specific transaction writes, and reload/target-detail output.
+
+- [ ] **Step 2: Add routing behavior tests**
+
+Cover missing references, missing pins, already-overlapping pins, successful routed segments, obstacle warning propagation, transactional writes, and reload output.
+
+- [ ] **Step 3: Add junction-repair behavior test**
+
+Assert the module-level repair callback runs before reload and the response order remains `reload + summary`.
+
+- [ ] **Step 4: Run the service tests and confirm red**
+
+Expected: collection fails because `kicad_mcp.schematic.connectivity_authoring` does not exist.
+
+- [ ] **Step 5: Commit the red service tests**
+
+```bash
+git add tests/unit/test_schematic_connectivity_authoring_service.py
+git commit -m "test(schematic): define connectivity authoring service behavior"
+```
+
+### Task 3: Implement the FastMCP-independent service
+
+**Files:**
+- Create: `src/kicad_mcp/schematic/connectivity_authoring.py`
+- Test: `tests/unit/test_schematic_connectivity_authoring_service.py`
+
+**Interfaces:**
+- Produces: `SchematicConnectivityAuthoringService` with the three methods defined above.
+
+- [ ] **Step 1: Add narrow Protocols and callable aliases**
+
+Define target and bounding-box protocols plus typed callable fields for parsing, pin lookup, geometry, block creation, transactions, reload, and logging.
+
+- [ ] **Step 2: Move pin-label orchestration**
+
+Copy the existing behavior exactly and replace direct helper calls with injected dependencies.
+
+- [ ] **Step 3: Move pin-routing orchestration**
+
+Validate with `RouteWireBetweenPinsInput`, resolve pins, route around obstacles, append wire blocks transactionally, and preserve current messages.
+
+- [ ] **Step 4: Move missing-junction orchestration**
+
+Call the injected fixer, then reload, and return the existing combined response.
+
+- [ ] **Step 5: Run service tests, Ruff, mypy, and Pyright**
+
+All direct service tests and static checks must pass.
+
+- [ ] **Step 6: Commit the service**
+
+```bash
+git add src/kicad_mcp/schematic/connectivity_authoring.py tests/unit/test_schematic_connectivity_authoring_service.py
+git commit -m "refactor(schematic): extract connectivity authoring service"
+```
+
+### Task 4: Add adapter and delegate composition-root registration
+
+**Files:**
+- Create: `src/kicad_mcp/tools/schematic_connectivity_authoring.py`
+- Modify: `src/kicad_mcp/tools/schematic.py`
+- Modify: `scripts/check_architecture_boundaries.py`
+- Test: `tests/unit/test_schematic_connectivity_authoring_architecture.py`
+- Test: `tests/unit/test_schematic_connectivity_authoring_registration.py`
+
+**Interfaces:**
+- Consumes: `SchematicConnectivityAuthoringService`.
+- Produces: unchanged public FastMCP tools and a smaller schematic composition root.
+
+- [ ] **Step 1: Implement the thin adapter**
+
+Copy exact public signatures and docstrings. Apply `headless_compatible` only to `sch_add_missing_junctions`. Delegate directly to the service.
+
+- [ ] **Step 2: Compose the service in `tools.schematic`**
+
+Inject all existing helpers, remove the three nested tools, and call `schematic_connectivity_authoring.register(...)` at the former registration location.
+
+- [ ] **Step 3: Extend architecture guards**
+
+Track the service as pure, prohibit adapter-to-monolith imports, and enforce the 300-line adapter limit.
+
+- [ ] **Step 4: Run focused unit and integration tests**
+
+Run new unit tests plus all existing pin-label, routing, junction, and fixer integration tests.
+
+- [ ] **Step 5: Compare full-server MCP contracts**
+
+Generate JSON for the three tools on `main` and the branch; require an empty diff and identical SHA-256 values.
+
+- [ ] **Step 6: Commit adapter/delegation changes**
+
+```bash
+git add scripts/check_architecture_boundaries.py src/kicad_mcp/tools/schematic.py \
+  src/kicad_mcp/tools/schematic_connectivity_authoring.py \
+  tests/unit/test_schematic_connectivity_authoring_architecture.py \
+  tests/unit/test_schematic_connectivity_authoring_registration.py
+git commit -m "refactor(schematic): delegate connectivity authoring registration"
+```
+
+### Task 5: Repository verification and PR
+
+**Files:**
+- Modify only if generated artifacts intentionally require updates; otherwise expect no generated diff.
+
+- [ ] **Step 1: Run generated-contract gates**
+
+Run architecture, tool-contract, metadata, tools-reference, parity, and parity-regression checks.
+
+- [ ] **Step 2: Run quality gates**
+
+Run scoped Ruff format/check, full mypy, scoped Pyright, representative latency, package build/metadata, runtime policy, no-pcbnew, and strict docs.
+
+- [ ] **Step 3: Run full unit suite**
+
+Run `python scripts/run_pytest.py unit` and record the complete result.
+
+- [ ] **Step 4: Push and create a PR**
+
+The PR must reference #434 but must not close it unless the final composition-root register span is at or below 300 lines.

--- a/docs/superpowers/specs/2026-07-26-schematic-connectivity-authoring-service-design.md
+++ b/docs/superpowers/specs/2026-07-26-schematic-connectivity-authoring-service-design.md
@@ -1,0 +1,95 @@
+# Schematic Connectivity Authoring Service Design
+
+## Context
+
+`src/kicad_mcp/tools/schematic.py::register()` is 699 lines after the layout-automation extraction. Three remaining nested tools form one coherent capability boundary:
+
+- `sch_add_pin_labels`
+- `sch_route_wire_between_pins`
+- `sch_add_missing_junctions`
+
+They all author or repair schematic connectivity and currently mix FastMCP registration with file parsing, pin resolution, geometry, transaction orchestration, and reload behavior.
+
+## Goal
+
+Move connectivity-authoring orchestration behind a FastMCP-independent service while preserving the exact public MCP contract and legacy helper seams.
+
+## Non-goals
+
+- No routing algorithm change.
+- No schema, description, annotation, metadata, error-message, transaction, reload, or target-resolution change.
+- No extraction of `sch_add_jumper`, `sch_annotate`, or `sch_reload`; those remain a separate bounded change.
+- No broad movement of low-level schematic geometry helpers.
+
+## Architecture
+
+Create `SchematicConnectivityAuthoringService` in `src/kicad_mcp/schematic/connectivity_authoring.py`.
+
+The service receives all monolith-owned helpers through constructor injection. It exposes:
+
+```python
+add_pin_labels(
+    connections: list[dict[str, Any]],
+    stub_mm: float = 5.08,
+    global_labels: bool = True,
+    sheet: str | None = None,
+    sheet_file: str | None = None,
+) -> str
+
+route_wire_between_pins(
+    ref1: str,
+    pin1: str,
+    ref2: str,
+    pin2: str,
+    snap_to_grid: bool = True,
+) -> str
+
+add_missing_junctions() -> str
+```
+
+Create `src/kicad_mcp/tools/schematic_connectivity_authoring.py` as a thin FastMCP adapter. The adapter owns decorators, docstrings, public signatures, and `headless_compatible` metadata only.
+
+`src/kicad_mcp/tools/schematic.py` remains the composition root. It constructs the service with existing helpers, delegates registration to the adapter, and keeps `run_auto_add_missing_junctions` available for `tools.fixers` and existing monkeypatch tests.
+
+## Dependency boundary
+
+The domain service must not import:
+
+- FastMCP or `mcp`
+- `kicad_mcp.tools.schematic`
+- KiCad GUI/IPC modules directly
+
+The adapter must not import the schematic monolith.
+
+Target, configuration, loaded-symbol, bounding-box, and block-builder surfaces are represented by small Protocols or callable aliases in the service module.
+
+## Contract preservation
+
+Tests must compare all three tools against the current full-server contract:
+
+- name
+- description
+- input schema
+- output schema
+- inferred annotations
+- tool metadata
+
+The committed tool-surface snapshot and generated tools documentation must remain unchanged.
+
+## Error and transaction behavior
+
+- Missing references and pins keep the same returned strings.
+- Pin-label partial-success reporting remains unchanged.
+- Pin-label target selection still accepts `sheet` or `sheet_file` and reports target detail.
+- Writes continue through the existing transactional functions.
+- Reload remains best-effort and retains existing response ordering.
+- Missing-junction repair continues to call the module-level fixer seam before reload.
+
+## Verification
+
+- Red-green service and adapter tests.
+- Existing pin-label, routing, and junction integration tests.
+- Exact full-server contract comparison.
+- Architecture-boundary and register-span checks.
+- Ruff, mypy, Pyright, tool-contract, metadata, parity, strict docs, and representative latency checks.
+- Full repository CI after PR creation.

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -35,6 +35,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "schematic"
     / "circuit_compilation.py",
+    "kicad_mcp.schematic.connectivity_authoring": SRC_ROOT
+    / "kicad_mcp"
+    / "schematic"
+    / "connectivity_authoring.py",
     "kicad_mcp.schematic.destructive_edit": SRC_ROOT
     / "kicad_mcp"
     / "schematic"
@@ -83,6 +87,10 @@ DOMAIN_MODULES = {
     / "kicad_mcp"
     / "tools"
     / "schematic_circuit_compilation.py",
+    "kicad_mcp.tools.schematic_connectivity_authoring": SRC_ROOT
+    / "kicad_mcp"
+    / "tools"
+    / "schematic_connectivity_authoring.py",
     "kicad_mcp.tools.schematic_destructive_edit": SRC_ROOT
     / "kicad_mcp"
     / "tools"
@@ -150,6 +158,7 @@ PURE_HELPERS = {
     "kicad_mcp.schematic.back_annotation",
     "kicad_mcp.schematic.basic_authoring",
     "kicad_mcp.schematic.circuit_compilation",
+    "kicad_mcp.schematic.connectivity_authoring",
     "kicad_mcp.schematic.destructive_edit",
     "kicad_mcp.schematic.document_settings",
     "kicad_mcp.schematic.hierarchy_authoring",
@@ -180,6 +189,7 @@ ADAPTER_FORBIDDEN_IMPORT_PREFIXES = {
     "kicad_mcp.tools.schematic_back_annotation": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_basic_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_circuit_compilation": ("kicad_mcp.tools.schematic",),
+    "kicad_mcp.tools.schematic_connectivity_authoring": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_destructive_edit": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_document_settings": ("kicad_mcp.tools.schematic",),
     "kicad_mcp.tools.schematic_hierarchy_authoring": ("kicad_mcp.tools.schematic",),
@@ -198,6 +208,7 @@ REGISTER_LINE_LIMITS = {
     "kicad_mcp.tools.schematic_back_annotation": 300,
     "kicad_mcp.tools.schematic_basic_authoring": 300,
     "kicad_mcp.tools.schematic_circuit_compilation": 300,
+    "kicad_mcp.tools.schematic_connectivity_authoring": 300,
     "kicad_mcp.tools.schematic_destructive_edit": 300,
     "kicad_mcp.tools.schematic_document_settings": 300,
     "kicad_mcp.tools.schematic_hierarchy_authoring": 300,

--- a/src/kicad_mcp/schematic/connectivity_authoring.py
+++ b/src/kicad_mcp/schematic/connectivity_authoring.py
@@ -1,0 +1,347 @@
+"""FastMCP-independent schematic connectivity authoring orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..models.schematic import RouteWireBetweenPinsInput
+
+
+class SchematicTargetLike(Protocol):
+    @property
+    def path(self) -> Path: ...
+
+    @property
+    def description(self) -> str: ...
+
+
+class BoundingBoxLike(Protocol):
+    """Obstacle bounds consumed by the injected router."""
+
+    @property
+    def x_min(self) -> float: ...
+
+    @property
+    def y_min(self) -> float: ...
+
+    @property
+    def x_max(self) -> float: ...
+
+    @property
+    def y_max(self) -> float: ...
+
+
+ParsedSchematic = dict[str, Any]
+Mutator = Callable[[str], str]
+PinPositions = dict[str, tuple[float, float]]
+WireSegment = tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class SchematicConnectivityAuthoringService:
+    """Author and repair schematic connectivity without depending on FastMCP."""
+
+    resolve_target: Callable[[str | None, str | None], SchematicTargetLike]
+    parse_schematic: Callable[[Path], ParsedSchematic]
+    project_name: Callable[[], str]
+    new_uuid: Callable[[], str]
+    get_pin_positions: Callable[[str, str, float, float, int, int], PinPositions]
+    get_pin_alias_positions: Callable[[str, str, float, float, int, int], PinPositions]
+    pin_label_stub_direction: Callable[
+        [tuple[float, float], tuple[float, float], Iterable[tuple[float, float]]],
+        tuple[float, float],
+    ]
+    is_origin_pin_power_symbol: Callable[[str, str], bool]
+    is_power_net: Callable[[str], bool]
+    load_lib_symbol: Callable[[str, str], str | None]
+    wire_block: Callable[[float, float, float, float], str]
+    power_symbol_rotation_from_vector: Callable[[float, float], int]
+    place_symbol_block: Callable[..., str]
+    terminal_rotation_from_vector: Callable[[float, float], int]
+    label_block: Callable[[str, float, float, int, bool], str]
+    append_before_sheet_instances: Callable[[str, str], str]
+    transactional_write: Callable[[Mutator, Path | None], str]
+    reload_schematic: Callable[[], str]
+    format_target_detail: Callable[[SchematicTargetLike], str]
+    active_schematic_file: Callable[[], Path]
+    split_lib_id: Callable[[str], tuple[str, str]]
+    get_symbol_bboxes: Callable[[str], list[BoundingBoxLike]]
+    route_avoiding_obstacles: Callable[
+        [
+            tuple[float, float],
+            tuple[float, float],
+            list[BoundingBoxLike],
+            bool,
+        ],
+        tuple[list[WireSegment], str | None],
+    ]
+    run_auto_add_missing_junctions: Callable[[], str]
+    snap_tolerance_mm: float
+
+    def add_pin_labels(
+        self,
+        connections: list[dict[str, Any]],
+        stub_mm: float = 5.08,
+        global_labels: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Add outward pin stubs plus labels or power terminals."""
+        target = self.resolve_target(sheet, sheet_file)
+        data = self.parse_schematic(target.path)
+        placed: dict[str, dict[str, Any]] = {}
+        placed_kind: dict[str, str] = {}
+        for sym in data.get("symbols", []):
+            ref = str(sym.get("reference", ""))
+            if ref:
+                placed[ref] = sym
+                placed_kind[ref] = "symbol"
+        for sym in data.get("power_symbols", []):
+            ref = str(sym.get("reference", ""))
+            if ref:
+                placed[ref] = sym
+                placed_kind[ref] = "power_symbol"
+
+        project_name = self.project_name()
+        root_uuid = str(data.get("uuid") or self.new_uuid())
+        wire_blocks: list[str] = []
+        terminal_blocks: list[str] = []
+        power_lib_defs: dict[str, str] = {}
+        occupied_terminals: list[tuple[float, float]] = []
+        dense_terminal_mode = len(connections) >= 12
+        terminal_clearance_mm = self.snap_tolerance_mm if dense_terminal_mode else 6.0
+        stagger_step_mm = 2.54
+        max_stagger_steps = 12 if dense_terminal_mode else 5
+        results: list[str] = []
+        if dense_terminal_mode:
+            results.append(
+                "dense terminal mode: preserving each pin's natural row/column; "
+                "only exact terminal-coordinate collisions are staggered"
+            )
+
+        for conn in connections:
+            ref = str(conn.get("reference", ""))
+            pin = str(conn.get("pin", ""))
+            net = str(conn.get("net", conn.get("name", "")))
+            if not (ref and pin and net):
+                results.append(f"SKIP {conn}: needs reference, pin, net")
+                continue
+            sym = placed.get(ref)
+            if sym is None:
+                results.append(f"{ref}.{pin}: reference not found")
+                continue
+            is_power_symbol_ref = placed_kind.get(ref) == "power_symbol"
+            lib_id = str(sym.get("lib_id", ""))
+            if ":" not in lib_id:
+                results.append(
+                    f"{ref}.{pin}: symbol type not supported: unresolved lib_id '{lib_id}'"
+                )
+                continue
+            library, symbol_name = lib_id.split(":", 1)
+            is_power_symbol = library == "power" or ref.startswith("#PWR")
+            ox = float(sym.get("x", 0.0))
+            oy = float(sym.get("y", 0.0))
+            rot = int(sym.get("rotation", 0) or 0)
+            unit = int(sym.get("unit", 1) or 1)
+            pin_positions = self.get_pin_positions(library, symbol_name, ox, oy, rot, unit)
+            point = pin_positions.get(pin)
+            if point is None:
+                aliases = self.get_pin_alias_positions(
+                    library,
+                    symbol_name,
+                    ox,
+                    oy,
+                    rot,
+                    unit,
+                )
+                point = aliases.get(pin) or aliases.get(pin.upper())
+            if point is None and is_power_symbol_ref:
+                if pin != "1":
+                    results.append(f"{ref}.{pin}: symbol type not supported for pin '{pin}'")
+                    continue
+                point = (ox, oy)
+                pin_positions = {"1": point}
+            if point is None:
+                if (
+                    is_power_symbol
+                    and pin == "1"
+                    and self.is_origin_pin_power_symbol(
+                        symbol_name,
+                        str(sym.get("value", "")),
+                    )
+                ):
+                    point = (round(ox, 4), round(oy, 4))
+                    pin_positions = {"1": point}
+                elif is_power_symbol and not pin_positions:
+                    results.append(
+                        f"{ref}.{pin}: symbol type not supported: "
+                        f"{lib_id} has no resolvable pin geometry"
+                    )
+                    continue
+                else:
+                    results.append(f"{ref}.{pin}: pin not found")
+                    continue
+            px, py = point
+            ux, uy = self.pin_label_stub_direction(point, (ox, oy), pin_positions.values())
+            length = max(stub_mm, 10.16) if uy else stub_mm
+            ex = round(px + ux * length, 4)
+            ey = round(py + uy * length, 4)
+            stagger_steps = 0
+            while stagger_steps < max_stagger_steps and any(
+                abs(ex - qx) < terminal_clearance_mm and abs(ey - qy) < terminal_clearance_mm
+                for qx, qy in occupied_terminals
+            ):
+                length += stagger_step_mm
+                ex = round(px + ux * length, 4)
+                ey = round(py + uy * length, 4)
+                stagger_steps += 1
+            occupied_terminals.append((ex, ey))
+            wire_blocks.append(self.wire_block(px, py, ex, ey))
+            suffix = f"; staggered {stagger_steps} step(s)" if stagger_steps else ""
+
+            if self.is_power_net(net):
+                if net not in power_lib_defs:
+                    lib_def = self.load_lib_symbol("power", net)
+                    if lib_def is None:
+                        results.append(f"{ref}.{pin}: power symbol '{net}' was not found")
+                        wire_blocks.pop()
+                        occupied_terminals.pop()
+                        continue
+                    power_lib_defs[net] = lib_def
+                terminal_blocks.append(
+                    self.place_symbol_block(
+                        lib_id=f"power:{net}",
+                        x=ex,
+                        y=ey,
+                        reference=f"#PWR{self.new_uuid()[:4]}",
+                        value=net,
+                        rotation=self.power_symbol_rotation_from_vector(ux, uy),
+                        project_name=project_name,
+                        root_uuid=root_uuid,
+                    )
+                )
+                results.append(f"{ref}.{pin} -> {net} (power) @ ({ex}, {ey}){suffix}")
+            else:
+                rotation = self.terminal_rotation_from_vector(ux, uy)
+                terminal_blocks.append(self.label_block(net, ex, ey, rotation, global_labels))
+                results.append(f"{ref}.{pin} -> {net} @ ({ex}, {ey}){suffix}")
+
+        if not (wire_blocks or terminal_blocks):
+            return "No pin labels were added.\n" + "\n".join(results)
+
+        def mutator(current: str) -> str:
+            updated = current
+            for net_name, lib_def in power_lib_defs.items():
+                lib_id = f"power:{net_name}"
+                if f'(symbol "{lib_id}"' in updated:
+                    continue
+                if "(lib_symbols)" in updated:
+                    updated = updated.replace(
+                        "(lib_symbols)",
+                        f"(lib_symbols\n\t{lib_def}\n\t)",
+                        1,
+                    )
+                else:
+                    updated = updated.replace(
+                        "\t(lib_symbols\n",
+                        f"\t(lib_symbols\n\t{lib_def}\n",
+                        1,
+                    )
+            for block in (*wire_blocks, *terminal_blocks):
+                updated = self.append_before_sheet_instances(updated, block)
+            return updated
+
+        self.transactional_write(mutator, target.path)
+        return (
+            f"{self.reload_schematic()}\n{self.format_target_detail(target)}\n"
+            f"Added {len(wire_blocks)} pin terminal(s) with stubs:\n" + "\n".join(results)
+        )
+
+    def route_wire_between_pins(
+        self,
+        ref1: str,
+        pin1: str,
+        ref2: str,
+        pin2: str,
+        snap_to_grid: bool = True,
+    ) -> str:
+        """Route deterministic Manhattan segments between two symbol pins."""
+        payload = RouteWireBetweenPinsInput(
+            ref1=ref1,
+            pin1=pin1,
+            ref2=ref2,
+            pin2=pin2,
+            snap_to_grid=snap_to_grid,
+        )
+        data = self.parse_schematic(self.active_schematic_file())
+        symbols = {symbol["reference"]: symbol for symbol in data["symbols"]}
+        first = symbols.get(payload.ref1)
+        second = symbols.get(payload.ref2)
+        if first is None:
+            return f"Reference '{payload.ref1}' was not found in the schematic."
+        if second is None:
+            return f"Reference '{payload.ref2}' was not found in the schematic."
+
+        first_library, first_symbol = self.split_lib_id(str(first["lib_id"]))
+        second_library, second_symbol = self.split_lib_id(str(second["lib_id"]))
+        first_pins = self.get_pin_positions(
+            first_library,
+            first_symbol,
+            float(first["x"]),
+            float(first["y"]),
+            int(first["rotation"]),
+            int(first["unit"]),
+        )
+        second_pins = self.get_pin_positions(
+            second_library,
+            second_symbol,
+            float(second["x"]),
+            float(second["y"]),
+            int(second["rotation"]),
+            int(second["unit"]),
+        )
+        start = first_pins.get(payload.pin1)
+        end = second_pins.get(payload.pin2)
+        if start is None:
+            return f"Pin {payload.pin1} was not found on {payload.ref1}."
+        if end is None:
+            return f"Pin {payload.pin2} was not found on {payload.ref2}."
+
+        content = self.active_schematic_file().read_text(encoding="utf-8", errors="ignore")
+        obstacles = self.get_symbol_bboxes(content)
+        segments, routing_warning = self.route_avoiding_obstacles(
+            start,
+            end,
+            obstacles,
+            payload.snap_to_grid,
+        )
+        if not segments:
+            return (
+                f"{payload.ref1}:{payload.pin1} and {payload.ref2}:{payload.pin2} already overlap."
+            )
+
+        def mutator(current: str) -> str:
+            updated = current
+            for segment in segments:
+                updated = self.append_before_sheet_instances(
+                    updated,
+                    self.wire_block(*segment),
+                )
+            return updated
+
+        self.transactional_write(mutator, None)
+        result = self.reload_schematic()
+        return (
+            f"{result}\nRouted {len(segments)} wire segment(s) between "
+            f"{payload.ref1}:{payload.pin1} and {payload.ref2}:{payload.pin2}."
+            + (f"\n{routing_warning}" if routing_warning else "")
+        )
+
+    def add_missing_junctions(self) -> str:
+        """Repair T-intersection junctions and reload the active schematic."""
+        summary = self.run_auto_add_missing_junctions()
+        result = self.reload_schematic()
+        return f"{result}\n{summary}"

--- a/src/kicad_mcp/tools/schematic.py
+++ b/src/kicad_mcp/tools/schematic.py
@@ -30,7 +30,6 @@ from ..models.schematic import (
     AddWireInput,
     AnnotateInput,
     PowerSymbolInput,
-    RouteWireBetweenPinsInput,
     UpdatePropertiesInput,
 )
 from ..models.visual_qa import run_visual_qa as _run_visual_qa
@@ -40,6 +39,11 @@ from ..schematic.basic_authoring import SchematicBasicAuthoringService
 from ..schematic.circuit_compilation import (
     PreparedCircuitInputs,
     SchematicCircuitCompilationService,
+)
+from ..schematic.connectivity_authoring import (
+    BoundingBoxLike,
+    SchematicConnectivityAuthoringService,
+    SchematicTargetLike,
 )
 from ..schematic.destructive_edit import SchematicDestructiveEditService
 from ..schematic.document_settings import SchematicDocumentSettingsService
@@ -81,6 +85,7 @@ from . import (
     schematic_back_annotation,
     schematic_basic_authoring,
     schematic_circuit_compilation,
+    schematic_connectivity_authoring,
     schematic_destructive_edit,
     schematic_document_settings,
     schematic_hierarchy_authoring,
@@ -5552,6 +5557,35 @@ def _load_layout_design_intent() -> FunctionalDesignIntentLike:
     return load_design_intent()
 
 
+def _connectivity_symbol_bboxes(content: str) -> list[BoundingBoxLike]:
+    return cast(list[BoundingBoxLike], _get_symbol_bboxes(content))
+
+
+def _connectivity_route_avoiding_obstacles(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    obstacles: list[BoundingBoxLike],
+    snap_to_grid: bool,
+) -> tuple[list[tuple[float, float, float, float]], str | None]:
+    return _route_avoiding_obstacles(
+        start,
+        end,
+        cast(list[BBox], obstacles),
+        snap_to_grid,
+    )
+
+
+def _connectivity_target_detail(target: SchematicTargetLike) -> str:
+    return _format_target_detail(cast(_SchematicTarget, target))
+
+
+def _connectivity_transactional_write(
+    mutator: Callable[[str], str],
+    path: Path | None,
+) -> str:
+    return transactional_write(mutator, path)
+
+
 def register(mcp: FastMCP) -> None:
     """Register schematic tools."""
     inspection_service = SchematicInspectionService(
@@ -5874,187 +5908,42 @@ def register(mcp: FastMCP) -> None:
         ),
     )
 
-    @mcp.tool()
-    def sch_add_pin_labels(
-        connections: list[dict[str, Any]],
-        stub_mm: float = 5.08,
-        global_labels: bool = True,
-        sheet: str | None = None,
-        sheet_file: str | None = None,
-    ) -> str:
-        """Connect placed-symbol pins to nets with a short outward wire stub plus a
-        terminal placed clear of the symbol body (avoids label-on-pin overlap).
-
-        Each connection is ``{"reference": "U3", "pin": "VIN" | "5", "net":
-        "5V_SYS"}``; the pin may be a number or a name. The stub direction is
-        derived from the symbol edge the pin sits on, so the terminal lands outside
-        the symbol and reads outward. Power nets get conventional power symbols;
-        other nets get labels. Pins that share a ``net`` are joined by their
-        common terminal name. This is the clean alternative to placing bare
-        labels directly on pins.
-        """
-        target = _resolve_schematic_target(sheet=sheet, sheet_file=sheet_file)
-        data = parse_schematic_file(target.path)
-        placed: dict[str, dict[str, Any]] = {}
-        placed_kind: dict[str, str] = {}
-        for sym in data.get("symbols", []):
-            ref = str(sym.get("reference", ""))
-            if ref:
-                placed[ref] = sym
-                placed_kind[ref] = "symbol"
-        for sym in data.get("power_symbols", []):
-            ref = str(sym.get("reference", ""))
-            if ref:
-                placed[ref] = sym
-                placed_kind[ref] = "power_symbol"
-
-        cfg = get_config()
-        project_name = cfg.project_file.stem if cfg.project_file is not None else "KiCadMCP"
-        root_uuid = str(data.get("uuid") or new_uuid())
-        wire_blocks: list[str] = []
-        terminal_blocks: list[str] = []
-        power_lib_defs: dict[str, str] = {}
-        occupied_terminals: list[tuple[float, float]] = []
-        dense_terminal_mode = len(connections) >= 12
-        terminal_clearance_mm = SNAP_TOLERANCE_MM if dense_terminal_mode else 6.0
-        stagger_step_mm = 2.54
-        max_stagger_steps = 12 if dense_terminal_mode else 5
-        results: list[str] = []
-        if dense_terminal_mode:
-            results.append(
-                "dense terminal mode: preserving each pin's natural row/column; "
-                "only exact terminal-coordinate collisions are staggered"
-            )
-        for conn in connections:
-            ref = str(conn.get("reference", ""))
-            pin = str(conn.get("pin", ""))
-            net = str(conn.get("net", conn.get("name", "")))
-            if not (ref and pin and net):
-                results.append(f"SKIP {conn}: needs reference, pin, net")
-                continue
-            sym = placed.get(ref)
-            if sym is None:
-                results.append(f"{ref}.{pin}: reference not found")
-                continue
-            is_power_symbol_ref = placed_kind.get(ref) == "power_symbol"
-            lib_id = str(sym.get("lib_id", ""))
-            if ":" not in lib_id:
-                results.append(
-                    f"{ref}.{pin}: symbol type not supported: unresolved lib_id '{lib_id}'"
-                )
-                continue
-            library, symbol_name = lib_id.split(":", 1)
-            is_power_symbol = library == "power" or ref.startswith("#PWR")
-            ox = float(sym.get("x", 0.0))
-            oy = float(sym.get("y", 0.0))
-            rot = int(sym.get("rotation", 0) or 0)
-            unit = int(sym.get("unit", 1) or 1)
-            pin_positions = get_pin_positions(library, symbol_name, ox, oy, rot, unit)
-            point = pin_positions.get(pin)
-            if point is None:
-                aliases = get_pin_alias_positions(library, symbol_name, ox, oy, rot, unit)
-                point = aliases.get(pin) or aliases.get(pin.upper())
-            if point is None and is_power_symbol_ref:
-                if pin != "1":
-                    results.append(f"{ref}.{pin}: symbol type not supported for pin '{pin}'")
-                    continue
-                point = (ox, oy)
-                pin_positions = {"1": point}
-            if point is None:
-                if (
-                    is_power_symbol
-                    and pin == "1"
-                    and _is_origin_pin_power_symbol(symbol_name, str(sym.get("value", "")))
-                ):
-                    point = (round(ox, 4), round(oy, 4))
-                    pin_positions = {"1": point}
-                elif is_power_symbol and not pin_positions:
-                    results.append(
-                        f"{ref}.{pin}: symbol type not supported: "
-                        f"{lib_id} has no resolvable pin geometry"
-                    )
-                    continue
-                else:
-                    results.append(f"{ref}.{pin}: pin not found")
-                    continue
-            if point is None:
-                results.append(f"{ref}.{pin}: pin not found")
-                continue
-            px, py = point
-            ux, uy = _pin_label_stub_direction(point, (ox, oy), pin_positions.values())
-            # KiCad places a symbol's Reference/Value text close to its vertical
-            # body extents.  A 5.08 mm up/down stub can land the generated
-            # terminal on top of that field text (notably vertical R/C symbols),
-            # so vertical terminals get a longer minimum clearance while keeping
-            # horizontal side-pin behavior unchanged.
-            length = max(stub_mm, 10.16) if uy else stub_mm
-            ex = round(px + ux * length, 4)
-            ey = round(py + uy * length, 4)
-            stagger_steps = 0
-            while stagger_steps < max_stagger_steps and any(
-                abs(ex - qx) < terminal_clearance_mm and abs(ey - qy) < terminal_clearance_mm
-                for qx, qy in occupied_terminals
-            ):
-                length += stagger_step_mm
-                ex = round(px + ux * length, 4)
-                ey = round(py + uy * length, 4)
-                stagger_steps += 1
-            occupied_terminals.append((ex, ey))
-            wire_blocks.append(wire_block(px, py, ex, ey))
-            suffix = f"; staggered {stagger_steps} step(s)" if stagger_steps else ""
-            if _is_power_net(net):
-                if net not in power_lib_defs:
-                    lib_def = load_lib_symbol("power", net)
-                    if lib_def is None:
-                        results.append(f"{ref}.{pin}: power symbol '{net}' was not found")
-                        wire_blocks.pop()
-                        occupied_terminals.pop()
-                        continue
-                    power_lib_defs[net] = lib_def
-                terminal_blocks.append(
-                    place_symbol_block(
-                        lib_id=f"power:{net}",
-                        x=ex,
-                        y=ey,
-                        reference=f"#PWR{new_uuid()[:4]}",
-                        value=net,
-                        rotation=_power_symbol_rotation_from_vector(ux, uy),
-                        project_name=project_name,
-                        root_uuid=root_uuid,
-                    )
-                )
-                results.append(f"{ref}.{pin} -> {net} (power) @ ({ex}, {ey}){suffix}")
-            else:
-                rotation = _terminal_rotation_from_vector(ux, uy)
-                terminal_blocks.append(
-                    label_block(net, ex, ey, rotation, global_label=global_labels)
-                )
-                results.append(f"{ref}.{pin} -> {net} @ ({ex}, {ey}){suffix}")
-
-        if not (wire_blocks or terminal_blocks):
-            return "No pin labels were added.\n" + "\n".join(results)
-
-        def mutator(current: str) -> str:
-            updated = current
-            for net_name, lib_def in power_lib_defs.items():
-                lib_id = f"power:{net_name}"
-                if f'(symbol "{lib_id}"' in updated:
-                    continue
-                if "(lib_symbols)" in updated:
-                    updated = updated.replace("(lib_symbols)", f"(lib_symbols\n\t{lib_def}\n\t)", 1)
-                else:
-                    updated = updated.replace(
-                        "\t(lib_symbols\n", f"\t(lib_symbols\n\t{lib_def}\n", 1
-                    )
-            for block in (*wire_blocks, *terminal_blocks):
-                updated = _append_before_sheet_instances(updated, block)
-            return updated
-
-        transactional_write(mutator, target.path)
-        return (
-            f"{_reload_schematic()}\n{_format_target_detail(target)}\n"
-            f"Added {len(wire_blocks)} pin terminal(s) with stubs:\n" + "\n".join(results)
-        )
+    connectivity_authoring_service = SchematicConnectivityAuthoringService(
+        resolve_target=lambda sheet, sheet_file: _resolve_schematic_target(
+            sheet=sheet,
+            sheet_file=sheet_file,
+        ),
+        parse_schematic=parse_schematic_file,
+        project_name=_project_name,
+        new_uuid=new_uuid,
+        get_pin_positions=get_pin_positions,
+        get_pin_alias_positions=get_pin_alias_positions,
+        pin_label_stub_direction=_pin_label_stub_direction,
+        is_origin_pin_power_symbol=_is_origin_pin_power_symbol,
+        is_power_net=_is_power_net,
+        load_lib_symbol=load_lib_symbol,
+        wire_block=wire_block,
+        power_symbol_rotation_from_vector=_power_symbol_rotation_from_vector,
+        place_symbol_block=place_symbol_block,
+        terminal_rotation_from_vector=_terminal_rotation_from_vector,
+        label_block=label_block,
+        append_before_sheet_instances=_append_before_sheet_instances,
+        transactional_write=_connectivity_transactional_write,
+        reload_schematic=_reload_schematic,
+        format_target_detail=_connectivity_target_detail,
+        active_schematic_file=_get_schematic_file,
+        split_lib_id=_split_lib_id,
+        get_symbol_bboxes=_connectivity_symbol_bboxes,
+        route_avoiding_obstacles=_connectivity_route_avoiding_obstacles,
+        run_auto_add_missing_junctions=run_auto_add_missing_junctions,
+        snap_tolerance_mm=SNAP_TOLERANCE_MM,
+    )
+    schematic_connectivity_authoring.register(
+        mcp,
+        schematic_connectivity_authoring.SchematicConnectivityAuthoringDependencies(
+            service=connectivity_authoring_service,
+        ),
+    )
 
     @mcp.tool()
     @headless_compatible
@@ -6126,91 +6015,6 @@ def register(mcp: FastMCP) -> None:
     def sch_reload() -> str:
         """Ask KiCad to reload the active schematic."""
         return _reload_schematic()
-
-    @mcp.tool()
-    def sch_route_wire_between_pins(
-        ref1: str,
-        pin1: str,
-        ref2: str,
-        pin2: str,
-        snap_to_grid: bool = True,
-    ) -> str:
-        """Route deterministic Manhattan wire segments between two placed symbol pins."""
-        payload = RouteWireBetweenPinsInput(
-            ref1=ref1,
-            pin1=pin1,
-            ref2=ref2,
-            pin2=pin2,
-            snap_to_grid=snap_to_grid,
-        )
-        data = parse_schematic_file(_get_schematic_file())
-        symbols = {symbol["reference"]: symbol for symbol in data["symbols"]}
-        first = symbols.get(payload.ref1)
-        second = symbols.get(payload.ref2)
-        if first is None:
-            return f"Reference '{payload.ref1}' was not found in the schematic."
-        if second is None:
-            return f"Reference '{payload.ref2}' was not found in the schematic."
-
-        first_library, first_symbol = _split_lib_id(str(first["lib_id"]))
-        second_library, second_symbol = _split_lib_id(str(second["lib_id"]))
-        first_pins = get_pin_positions(
-            first_library,
-            first_symbol,
-            float(first["x"]),
-            float(first["y"]),
-            int(first["rotation"]),
-            int(first["unit"]),
-        )
-        second_pins = get_pin_positions(
-            second_library,
-            second_symbol,
-            float(second["x"]),
-            float(second["y"]),
-            int(second["rotation"]),
-            int(second["unit"]),
-        )
-        start = first_pins.get(payload.pin1)
-        end = second_pins.get(payload.pin2)
-        if start is None:
-            return f"Pin {payload.pin1} was not found on {payload.ref1}."
-        if end is None:
-            return f"Pin {payload.pin2} was not found on {payload.ref2}."
-
-        content = _get_schematic_file().read_text(encoding="utf-8", errors="ignore")
-        obstacles = _get_symbol_bboxes(content)
-        segments, routing_warning = _route_avoiding_obstacles(
-            start,
-            end,
-            obstacles,
-            payload.snap_to_grid,
-        )
-        if not segments:
-            return (
-                f"{payload.ref1}:{payload.pin1} and {payload.ref2}:{payload.pin2} already overlap."
-            )
-
-        def mutator(current: str) -> str:
-            updated = current
-            for segment in segments:
-                updated = _append_before_sheet_instances(updated, wire_block(*segment))
-            return updated
-
-        transactional_write(mutator)
-        result = _reload_schematic()
-        return (
-            f"{result}\nRouted {len(segments)} wire segment(s) between "
-            f"{payload.ref1}:{payload.pin1} and {payload.ref2}:{payload.pin2}."
-            + (f"\n{routing_warning}" if routing_warning else "")
-        )
-
-    @mcp.tool()
-    @headless_compatible
-    def sch_add_missing_junctions() -> str:
-        """Insert missing schematic junctions at T-intersection wire endpoints."""
-        summary = run_auto_add_missing_junctions()
-        result = _reload_schematic()
-        return f"{result}\n{summary}"
 
     layout_automation_service = SchematicLayoutAutomationService(
         active_schematic_file=_get_schematic_file,

--- a/src/kicad_mcp/tools/schematic_connectivity_authoring.py
+++ b/src/kicad_mcp/tools/schematic_connectivity_authoring.py
@@ -1,0 +1,75 @@
+"""Thin FastMCP adapter for schematic connectivity authoring."""
+
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from ..schematic.connectivity_authoring import SchematicConnectivityAuthoringService
+from .metadata import headless_compatible
+
+
+@dataclass(frozen=True)
+class SchematicConnectivityAuthoringDependencies:
+    """Connectivity-authoring service injected by the schematic composition root."""
+
+    service: SchematicConnectivityAuthoringService
+
+
+def register(mcp: FastMCP, dependencies: SchematicConnectivityAuthoringDependencies) -> None:
+    """Register schematic connectivity-authoring tools."""
+    service = dependencies.service
+
+    @mcp.tool()
+    def sch_add_pin_labels(
+        connections: list[dict[str, Any]],
+        stub_mm: float = 5.08,
+        global_labels: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        """Connect placed-symbol pins to nets with a short outward wire stub plus a
+        terminal placed clear of the symbol body (avoids label-on-pin overlap).
+
+        Each connection is ``{"reference": "U3", "pin": "VIN" | "5", "net":
+        "5V_SYS"}``; the pin may be a number or a name. The stub direction is
+        derived from the symbol edge the pin sits on, so the terminal lands outside
+        the symbol and reads outward. Power nets get conventional power symbols;
+        other nets get labels. Pins that share a ``net`` are joined by their
+        common terminal name. This is the clean alternative to placing bare
+        labels directly on pins.
+        """
+        return service.add_pin_labels(
+            connections=connections,
+            stub_mm=stub_mm,
+            global_labels=global_labels,
+            sheet=sheet,
+            sheet_file=sheet_file,
+        )
+
+    @mcp.tool()
+    def sch_route_wire_between_pins(
+        ref1: str,
+        pin1: str,
+        ref2: str,
+        pin2: str,
+        snap_to_grid: bool = True,
+    ) -> str:
+        """Route deterministic Manhattan wire segments between two placed symbol pins."""
+        return service.route_wire_between_pins(
+            ref1=ref1,
+            pin1=pin1,
+            ref2=ref2,
+            pin2=pin2,
+            snap_to_grid=snap_to_grid,
+        )
+
+    @mcp.tool()
+    @headless_compatible
+    def sch_add_missing_junctions() -> str:
+        """Insert missing schematic junctions at T-intersection wire endpoints."""
+        return service.add_missing_junctions()

--- a/tests/unit/test_schematic_connectivity_authoring_architecture.py
+++ b/tests/unit/test_schematic_connectivity_authoring_architecture.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import check_architecture_boundaries as boundaries
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imports.add(node.module or "")
+    return imports
+
+
+def _function_span(path: Path, name: str) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    matches = [
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1
+    node = matches[0]
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_architecture_checker_tracks_connectivity_authoring_modules() -> None:
+    assert "kicad_mcp.schematic.connectivity_authoring" in boundaries.DOMAIN_MODULES
+    assert "kicad_mcp.schematic.connectivity_authoring" in boundaries.PURE_HELPERS
+    assert "kicad_mcp.tools.schematic_connectivity_authoring" in boundaries.DOMAIN_MODULES
+
+
+def test_connectivity_authoring_service_has_no_fastmcp_or_registry_dependency() -> None:
+    service = boundaries.SRC_ROOT / "kicad_mcp" / "schematic" / "connectivity_authoring.py"
+    imports = _imports(service)
+    assert not any(name.startswith("mcp") for name in imports)
+    assert "kicad_mcp.tools.schematic" not in imports
+
+
+def test_connectivity_authoring_adapter_does_not_import_monolith() -> None:
+    adapter = (
+        boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_connectivity_authoring.py"
+    )
+    assert "kicad_mcp.tools.schematic" not in _imports(adapter)
+    assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
+        "kicad_mcp.tools.schematic_connectivity_authoring"
+    ] == ("kicad_mcp.tools.schematic",)
+
+
+def test_connectivity_authoring_register_stays_below_300_lines() -> None:
+    adapter = (
+        boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_connectivity_authoring.py"
+    )
+    assert _function_span(adapter, "register") <= 300
+    assert boundaries.REGISTER_LINE_LIMITS[
+        "kicad_mcp.tools.schematic_connectivity_authoring"
+    ] == 300
+
+
+def test_schematic_composition_root_delegates_connectivity_authoring() -> None:
+    composition_root = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic.py"
+    source = composition_root.read_text(encoding="utf-8")
+    assert "schematic_connectivity_authoring.register(" in source
+    for nested_tool in (
+        "def sch_add_pin_labels(",
+        "def sch_route_wire_between_pins(",
+        "def sch_add_missing_junctions(",
+    ):
+        assert nested_tool not in source
+    assert "def run_auto_add_missing_junctions(" in source

--- a/tests/unit/test_schematic_connectivity_authoring_architecture.py
+++ b/tests/unit/test_schematic_connectivity_authoring_architecture.py
@@ -42,9 +42,7 @@ def test_connectivity_authoring_service_has_no_fastmcp_or_registry_dependency() 
 
 
 def test_connectivity_authoring_adapter_does_not_import_monolith() -> None:
-    adapter = (
-        boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_connectivity_authoring.py"
-    )
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_connectivity_authoring.py"
     assert "kicad_mcp.tools.schematic" not in _imports(adapter)
     assert boundaries.ADAPTER_FORBIDDEN_IMPORT_PREFIXES[
         "kicad_mcp.tools.schematic_connectivity_authoring"
@@ -52,13 +50,11 @@ def test_connectivity_authoring_adapter_does_not_import_monolith() -> None:
 
 
 def test_connectivity_authoring_register_stays_below_300_lines() -> None:
-    adapter = (
-        boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_connectivity_authoring.py"
-    )
+    adapter = boundaries.SRC_ROOT / "kicad_mcp" / "tools" / "schematic_connectivity_authoring.py"
     assert _function_span(adapter, "register") <= 300
-    assert boundaries.REGISTER_LINE_LIMITS[
-        "kicad_mcp.tools.schematic_connectivity_authoring"
-    ] == 300
+    assert (
+        boundaries.REGISTER_LINE_LIMITS["kicad_mcp.tools.schematic_connectivity_authoring"] == 300
+    )
 
 
 def test_schematic_composition_root_delegates_connectivity_authoring() -> None:

--- a/tests/unit/test_schematic_connectivity_authoring_registration.py
+++ b/tests/unit/test_schematic_connectivity_authoring_registration.py
@@ -91,14 +91,13 @@ def test_registration_preserves_names_descriptions_and_schemas() -> None:
         "the symbol and reads outward. Power nets get conventional power symbols;\n"
         "other nets get labels. Pins that share a ``net`` are joined by their\n"
         "common terminal name. This is the clean alternative to placing bare\n"
-        "labels directly on pins."
+        "labels directly on pins.\n"
     )
     assert tools["sch_route_wire_between_pins"].description == (
         "Route deterministic Manhattan wire segments between two placed symbol pins."
     )
     assert tools["sch_add_missing_junctions"].description == (
-        "Insert missing schematic junctions at T-intersection wire endpoints. "
-        "This KiCad MCP Pro tool supports production EDA automation workflows for MCP clients."
+        "Insert missing schematic junctions at T-intersection wire endpoints."
     )
 
     assert tools["sch_add_pin_labels"].parameters == {
@@ -157,15 +156,14 @@ def test_registration_preserves_names_descriptions_and_schemas() -> None:
             "title": f"{name}Output",
             "type": "object",
         }
-        assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is None
-        assert tool.annotations.destructiveHint is True
-        assert tool.annotations.idempotentHint is False
+        assert tool.annotations is None
 
 
 def test_registration_preserves_headless_metadata() -> None:
     server, _service = _registered()
-    metadata = {tool.name: get_tool_metadata(tool.name) for tool in server._tool_manager.list_tools()}
+    metadata = {
+        tool.name: get_tool_metadata(tool.name) for tool in server._tool_manager.list_tools()
+    }
 
     assert metadata["sch_add_pin_labels"] is None
     assert metadata["sch_route_wire_between_pins"] is None

--- a/tests/unit/test_schematic_connectivity_authoring_registration.py
+++ b/tests/unit/test_schematic_connectivity_authoring_registration.py
@@ -1,0 +1,226 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from kicad_mcp.tools.metadata import get_tool_metadata
+from kicad_mcp.tools.schematic_connectivity_authoring import (
+    SchematicConnectivityAuthoringDependencies,
+    register,
+)
+
+
+class FakeConnectivityAuthoringService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def add_pin_labels(
+        self,
+        connections: list[dict[str, Any]],
+        stub_mm: float = 5.08,
+        global_labels: bool = True,
+        sheet: str | None = None,
+        sheet_file: str | None = None,
+    ) -> str:
+        self.calls.append(
+            (
+                "add_pin_labels",
+                {
+                    "connections": connections,
+                    "stub_mm": stub_mm,
+                    "global_labels": global_labels,
+                    "sheet": sheet,
+                    "sheet_file": sheet_file,
+                },
+            )
+        )
+        return "pin-labels"
+
+    def route_wire_between_pins(
+        self,
+        ref1: str,
+        pin1: str,
+        ref2: str,
+        pin2: str,
+        snap_to_grid: bool = True,
+    ) -> str:
+        self.calls.append(
+            (
+                "route_wire_between_pins",
+                {
+                    "ref1": ref1,
+                    "pin1": pin1,
+                    "ref2": ref2,
+                    "pin2": pin2,
+                    "snap_to_grid": snap_to_grid,
+                },
+            )
+        )
+        return "routed"
+
+    def add_missing_junctions(self) -> str:
+        self.calls.append(("add_missing_junctions", {}))
+        return "junctions"
+
+
+def _registered() -> tuple[FastMCP, FakeConnectivityAuthoringService]:
+    server = FastMCP("schematic-connectivity-authoring-test")
+    service = FakeConnectivityAuthoringService()
+    register(server, SchematicConnectivityAuthoringDependencies(service=service))  # type: ignore[arg-type]
+    return server, service
+
+
+def test_registration_preserves_names_descriptions_and_schemas() -> None:
+    server, _service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert set(tools) == {
+        "sch_add_pin_labels",
+        "sch_route_wire_between_pins",
+        "sch_add_missing_junctions",
+    }
+    assert tools["sch_add_pin_labels"].description == (
+        "Connect placed-symbol pins to nets with a short outward wire stub plus a\n"
+        "terminal placed clear of the symbol body (avoids label-on-pin overlap).\n\n"
+        'Each connection is ``{"reference": "U3", "pin": "VIN" | "5", "net":\n'
+        '"5V_SYS"}``; the pin may be a number or a name. The stub direction is\n'
+        "derived from the symbol edge the pin sits on, so the terminal lands outside\n"
+        "the symbol and reads outward. Power nets get conventional power symbols;\n"
+        "other nets get labels. Pins that share a ``net`` are joined by their\n"
+        "common terminal name. This is the clean alternative to placing bare\n"
+        "labels directly on pins."
+    )
+    assert tools["sch_route_wire_between_pins"].description == (
+        "Route deterministic Manhattan wire segments between two placed symbol pins."
+    )
+    assert tools["sch_add_missing_junctions"].description == (
+        "Insert missing schematic junctions at T-intersection wire endpoints. "
+        "This KiCad MCP Pro tool supports production EDA automation workflows for MCP clients."
+    )
+
+    assert tools["sch_add_pin_labels"].parameters == {
+        "properties": {
+            "connections": {
+                "items": {"additionalProperties": True, "type": "object"},
+                "title": "Connections",
+                "type": "array",
+            },
+            "stub_mm": {"default": 5.08, "title": "Stub Mm", "type": "number"},
+            "global_labels": {
+                "default": True,
+                "title": "Global Labels",
+                "type": "boolean",
+            },
+            "sheet": {
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+                "default": None,
+                "title": "Sheet",
+            },
+            "sheet_file": {
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+                "default": None,
+                "title": "Sheet File",
+            },
+        },
+        "required": ["connections"],
+        "title": "sch_add_pin_labelsArguments",
+        "type": "object",
+    }
+    assert tools["sch_route_wire_between_pins"].parameters == {
+        "properties": {
+            "ref1": {"title": "Ref1", "type": "string"},
+            "pin1": {"title": "Pin1", "type": "string"},
+            "ref2": {"title": "Ref2", "type": "string"},
+            "pin2": {"title": "Pin2", "type": "string"},
+            "snap_to_grid": {
+                "default": True,
+                "title": "Snap To Grid",
+                "type": "boolean",
+            },
+        },
+        "required": ["ref1", "pin1", "ref2", "pin2"],
+        "title": "sch_route_wire_between_pinsArguments",
+        "type": "object",
+    }
+    assert tools["sch_add_missing_junctions"].parameters == {
+        "properties": {},
+        "title": "sch_add_missing_junctionsArguments",
+        "type": "object",
+    }
+    for name, tool in tools.items():
+        assert tool.output_schema == {
+            "properties": {"result": {"title": "Result", "type": "string"}},
+            "required": ["result"],
+            "title": f"{name}Output",
+            "type": "object",
+        }
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is None
+        assert tool.annotations.destructiveHint is True
+        assert tool.annotations.idempotentHint is False
+
+
+def test_registration_preserves_headless_metadata() -> None:
+    server, _service = _registered()
+    metadata = {tool.name: get_tool_metadata(tool.name) for tool in server._tool_manager.list_tools()}
+
+    assert metadata["sch_add_pin_labels"] is None
+    assert metadata["sch_route_wire_between_pins"] is None
+    junctions = metadata["sch_add_missing_junctions"]
+    assert junctions is not None
+    assert junctions.headless_compatible is True
+    assert junctions.requires_kicad_running is False
+
+
+def test_registration_delegates_exact_arguments() -> None:
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    assert (
+        tools["sch_add_pin_labels"].fn(
+            connections=[{"reference": "U1", "pin": "1", "net": "3V3"}],
+            stub_mm=7.62,
+            global_labels=False,
+            sheet="Power",
+            sheet_file=None,
+        )
+        == "pin-labels"
+    )
+    assert (
+        tools["sch_route_wire_between_pins"].fn(
+            ref1="U1",
+            pin1="1",
+            ref2="R1",
+            pin2="2",
+            snap_to_grid=False,
+        )
+        == "routed"
+    )
+    assert tools["sch_add_missing_junctions"].fn() == "junctions"
+
+    assert service.calls == [
+        (
+            "add_pin_labels",
+            {
+                "connections": [{"reference": "U1", "pin": "1", "net": "3V3"}],
+                "stub_mm": 7.62,
+                "global_labels": False,
+                "sheet": "Power",
+                "sheet_file": None,
+            },
+        ),
+        (
+            "route_wire_between_pins",
+            {
+                "ref1": "U1",
+                "pin1": "1",
+                "ref2": "R1",
+                "pin2": "2",
+                "snap_to_grid": False,
+            },
+        ),
+        ("add_missing_junctions", {}),
+    ]

--- a/tests/unit/test_schematic_connectivity_authoring_service.py
+++ b/tests/unit/test_schematic_connectivity_authoring_service.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kicad_mcp.schematic.connectivity_authoring import SchematicConnectivityAuthoringService
+
+
+@dataclass(frozen=True)
+class FakeTarget:
+    path: Path
+    description: str = "root"
+
+
+@dataclass
+class ServiceHarness:
+    service: SchematicConnectivityAuthoringService
+    writes: list[tuple[Path | None, str]]
+    calls: list[tuple[str, Any]]
+
+
+def _harness(
+    tmp_path: Path,
+    *,
+    parsed: dict[str, Any] | None = None,
+    pin_positions: dict[tuple[str, str], dict[str, tuple[float, float]]] | None = None,
+    aliases: dict[tuple[str, str], dict[str, tuple[float, float]]] | None = None,
+    route_segments: list[tuple[float, float, float, float]] | None = None,
+    route_warning: str | None = None,
+    power_net: Callable[[str], bool] | None = None,
+    power_lib: str | None = "(symbol \"power:3V3\")",
+) -> ServiceHarness:
+    target = FakeTarget(tmp_path / "board.kicad_sch")
+    target.path.write_text("(kicad_sch\n\t(sheet_instances)\n)", encoding="utf-8")
+    parsed_value = parsed or {"uuid": "root-uuid", "symbols": [], "power_symbols": []}
+    position_map = pin_positions or {}
+    alias_map = aliases or {}
+    writes: list[tuple[Path | None, str]] = []
+    calls: list[tuple[str, Any]] = []
+
+    def transactional_write(mutator: Callable[[str], str], path: Path | None = None) -> str:
+        before = target.path.read_text(encoding="utf-8")
+        after = mutator(before)
+        writes.append((path, after))
+        return str(path or target.path)
+
+    def wire_block(x1: float, y1: float, x2: float, y2: float) -> str:
+        calls.append(("wire_block", (x1, y1, x2, y2)))
+        return f"WIRE({x1},{y1}->{x2},{y2})"
+
+    def label_block(
+        name: str,
+        x: float,
+        y: float,
+        rotation: int,
+        global_label: bool = False,
+    ) -> str:
+        calls.append(("label_block", (name, x, y, rotation, global_label)))
+        return f"LABEL({name},{x},{y},{rotation},{global_label})"
+
+    def place_symbol_block(**kwargs: Any) -> str:
+        calls.append(("place_symbol_block", kwargs))
+        return f"POWER({kwargs['value']},{kwargs['x']},{kwargs['y']})"
+
+    def append_before_sheet_instances(content: str, block: str) -> str:
+        return content.replace("\t(sheet_instances)", f"\t{block}\n\t(sheet_instances)", 1)
+
+    def get_positions(
+        library: str,
+        symbol_name: str,
+        _x: float,
+        _y: float,
+        _rotation: int,
+        _unit: int,
+    ) -> dict[str, tuple[float, float]]:
+        return dict(position_map.get((library, symbol_name), {}))
+
+    def get_aliases(
+        library: str,
+        symbol_name: str,
+        _x: float,
+        _y: float,
+        _rotation: int,
+        _unit: int,
+    ) -> dict[str, tuple[float, float]]:
+        return dict(alias_map.get((library, symbol_name), {}))
+
+    def route(
+        start: tuple[float, float],
+        end: tuple[float, float],
+        obstacles: list[object],
+        snap_to_grid: bool,
+    ) -> tuple[list[tuple[float, float, float, float]], str | None]:
+        calls.append(("route", (start, end, obstacles, snap_to_grid)))
+        return list(route_segments or []), route_warning
+
+    service = SchematicConnectivityAuthoringService(
+        resolve_target=lambda sheet, sheet_file: target,
+        parse_schematic=lambda path: parsed_value,
+        project_name=lambda: "Demo",
+        new_uuid=lambda: "abcd-1234",
+        get_pin_positions=get_positions,
+        get_pin_alias_positions=get_aliases,
+        pin_label_stub_direction=lambda point, origin, all_points: (1.0, 0.0),
+        is_origin_pin_power_symbol=lambda symbol_name, value: True,
+        is_power_net=power_net or (lambda name: name in {"3V3", "GND"}),
+        load_lib_symbol=lambda library, name: power_lib,
+        wire_block=wire_block,
+        power_symbol_rotation_from_vector=lambda ux, uy: 270,
+        place_symbol_block=place_symbol_block,
+        terminal_rotation_from_vector=lambda ux, uy: 0,
+        label_block=label_block,
+        append_before_sheet_instances=append_before_sheet_instances,
+        transactional_write=transactional_write,
+        reload_schematic=lambda: "Reloaded",
+        format_target_detail=lambda resolved: f"Target schematic: {resolved.path.name}",
+        active_schematic_file=lambda: target.path,
+        split_lib_id=lambda lib_id: tuple(lib_id.split(":", 1)),  # type: ignore[return-value]
+        get_symbol_bboxes=lambda content: ["bbox"],
+        route_avoiding_obstacles=route,
+        run_auto_add_missing_junctions=lambda: "Inserted 2 missing junction(s).",
+        snap_tolerance_mm=0.001,
+    )
+    return ServiceHarness(service=service, writes=writes, calls=calls)
+
+
+def _symbol(reference: str = "U1", lib_id: str = "Device:R") -> dict[str, Any]:
+    return {
+        "reference": reference,
+        "lib_id": lib_id,
+        "value": "R",
+        "x": 10.0,
+        "y": 20.0,
+        "rotation": 0,
+        "unit": 1,
+    }
+
+
+def test_add_pin_labels_reports_invalid_and_missing_connections_without_write(tmp_path: Path) -> None:
+    harness = _harness(tmp_path, parsed={"uuid": "root", "symbols": [], "power_symbols": []})
+
+    result = harness.service.add_pin_labels(
+        [
+            {"reference": "U1", "pin": "1"},
+            {"reference": "U404", "pin": "1", "net": "SIG"},
+        ]
+    )
+
+    assert result == (
+        "No pin labels were added.\n"
+        "SKIP {'reference': 'U1', 'pin': '1'}: needs reference, pin, net\n"
+        "U404.1: reference not found"
+    )
+    assert harness.writes == []
+
+
+def test_add_pin_labels_writes_signal_stub_and_target_detail(tmp_path: Path) -> None:
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [_symbol()], "power_symbols": []},
+        pin_positions={("Device", "R"): {"1": (12.0, 20.0)}},
+        power_net=lambda name: False,
+    )
+
+    result = harness.service.add_pin_labels(
+        [{"reference": "U1", "pin": "1", "net": "SIG"}],
+        stub_mm=5.08,
+        global_labels=False,
+        sheet="Power",
+    )
+
+    assert result == (
+        "Reloaded\nTarget schematic: board.kicad_sch\n"
+        "Added 1 pin terminal(s) with stubs:\n"
+        "U1.1 -> SIG @ (17.08, 20.0)"
+    )
+    assert len(harness.writes) == 1
+    path, content = harness.writes[0]
+    assert path == tmp_path / "board.kicad_sch"
+    assert "WIRE(12.0,20.0->17.08,20.0)" in content
+    assert "LABEL(SIG,17.08,20.0,0,False)" in content
+
+
+def test_add_pin_labels_resolves_alias_and_places_power_symbol(tmp_path: Path) -> None:
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [_symbol()], "power_symbols": []},
+        aliases={("Device", "R"): {"VIN": (12.0, 20.0)}},
+    )
+
+    result = harness.service.add_pin_labels(
+        [{"reference": "U1", "pin": "VIN", "net": "3V3"}]
+    )
+
+    assert "U1.VIN -> 3V3 (power) @ (17.08, 20.0)" in result
+    assert any(name == "place_symbol_block" for name, _payload in harness.calls)
+    assert "POWER(3V3,17.08,20.0)" in harness.writes[0][1]
+
+
+def test_add_pin_labels_accepts_power_symbol_origin_pin_fallback(tmp_path: Path) -> None:
+    power = _symbol(reference="#PWR01", lib_id="power:GND")
+    power["value"] = "GND"
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [], "power_symbols": [power]},
+        pin_positions={("power", "GND"): {}},
+    )
+
+    result = harness.service.add_pin_labels(
+        [{"reference": "#PWR01", "pin": "1", "net": "GND"}]
+    )
+
+    assert "#PWR01.1 -> GND (power) @ (15.08, 20.0)" in result
+    assert len(harness.writes) == 1
+
+
+def test_add_pin_labels_skips_missing_power_library_symbol(tmp_path: Path) -> None:
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [_symbol()], "power_symbols": []},
+        pin_positions={("Device", "R"): {"1": (12.0, 20.0)}},
+        power_lib=None,
+    )
+
+    result = harness.service.add_pin_labels(
+        [{"reference": "U1", "pin": "1", "net": "3V3"}]
+    )
+
+    assert result == "No pin labels were added.\nU1.1: power symbol '3V3' was not found"
+    assert harness.writes == []
+
+
+def test_route_wire_between_pins_reports_missing_reference_and_pin(tmp_path: Path) -> None:
+    missing_ref = _harness(
+        tmp_path,
+        parsed={"symbols": [_symbol("U1")], "power_symbols": []},
+    )
+    assert (
+        missing_ref.service.route_wire_between_pins("U1", "1", "R404", "2")
+        == "Reference 'R404' was not found in the schematic."
+    )
+
+    missing_pin = _harness(
+        tmp_path,
+        parsed={"symbols": [_symbol("U1"), _symbol("R1")], "power_symbols": []},
+        pin_positions={("Device", "R"): {}},
+    )
+    assert (
+        missing_pin.service.route_wire_between_pins("U1", "1", "R1", "2")
+        == "Pin 1 was not found on U1."
+    )
+
+
+def test_route_wire_between_pins_reports_overlap_without_write(tmp_path: Path) -> None:
+    harness = _harness(
+        tmp_path,
+        parsed={"symbols": [_symbol("U1"), _symbol("R1")], "power_symbols": []},
+        pin_positions={("Device", "R"): {"1": (1.0, 1.0), "2": (1.0, 1.0)}},
+        route_segments=[],
+    )
+
+    result = harness.service.route_wire_between_pins("U1", "1", "R1", "2")
+
+    assert result == "U1:1 and R1:2 already overlap."
+    assert harness.writes == []
+
+
+def test_route_wire_between_pins_writes_segments_and_warning(tmp_path: Path) -> None:
+    harness = _harness(
+        tmp_path,
+        parsed={"symbols": [_symbol("U1"), _symbol("R1")], "power_symbols": []},
+        pin_positions={("Device", "R"): {"1": (1.0, 1.0), "2": (5.0, 5.0)}},
+        route_segments=[(1.0, 1.0, 5.0, 1.0), (5.0, 1.0, 5.0, 5.0)],
+        route_warning="WARNING: obstacle_bypass_failed",
+    )
+
+    result = harness.service.route_wire_between_pins(
+        "U1", "1", "R1", "2", snap_to_grid=False
+    )
+
+    assert result == (
+        "Reloaded\nRouted 2 wire segment(s) between U1:1 and R1:2.\n"
+        "WARNING: obstacle_bypass_failed"
+    )
+    assert len(harness.writes) == 1
+    assert harness.writes[0][0] is None
+    assert "WIRE(1.0,1.0->5.0,1.0)" in harness.writes[0][1]
+    assert "WIRE(5.0,1.0->5.0,5.0)" in harness.writes[0][1]
+
+
+def test_add_missing_junctions_runs_fixer_before_reload(tmp_path: Path) -> None:
+    order: list[str] = []
+    harness = _harness(tmp_path)
+    service = harness.service
+    object.__setattr__(service, "run_auto_add_missing_junctions", lambda: order.append("fix") or "Fixed")
+    object.__setattr__(service, "reload_schematic", lambda: order.append("reload") or "Reloaded")
+
+    result = service.add_missing_junctions()
+
+    assert order == ["fix", "reload"]
+    assert result == "Reloaded\nFixed"

--- a/tests/unit/test_schematic_connectivity_authoring_service.py
+++ b/tests/unit/test_schematic_connectivity_authoring_service.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from kicad_mcp.schematic.connectivity_authoring import SchematicConnectivityAuthoringService
+from kicad_mcp.schematic.connectivity_authoring import (
+    BoundingBoxLike,
+    SchematicConnectivityAuthoringService,
+)
 
 
 @dataclass(frozen=True)
 class FakeTarget:
     path: Path
     description: str = "root"
+
+
+@dataclass(frozen=True)
+class FakeBoundingBox:
+    x_min: float = 0.0
+    y_min: float = 0.0
+    x_max: float = 1.0
+    y_max: float = 1.0
 
 
 @dataclass
@@ -30,7 +41,7 @@ def _harness(
     route_segments: list[tuple[float, float, float, float]] | None = None,
     route_warning: str | None = None,
     power_net: Callable[[str], bool] | None = None,
-    power_lib: str | None = "(symbol \"power:3V3\")",
+    power_lib: str | None = '(symbol "power:3V3")',
 ) -> ServiceHarness:
     target = FakeTarget(tmp_path / "board.kicad_sch")
     target.path.write_text("(kicad_sch\n\t(sheet_instances)\n)", encoding="utf-8")
@@ -60,9 +71,29 @@ def _harness(
         calls.append(("label_block", (name, x, y, rotation, global_label)))
         return f"LABEL({name},{x},{y},{rotation},{global_label})"
 
-    def place_symbol_block(**kwargs: Any) -> str:
-        calls.append(("place_symbol_block", kwargs))
-        return f"POWER({kwargs['value']},{kwargs['x']},{kwargs['y']})"
+    def place_symbol_block(
+        *,
+        lib_id: str,
+        x: float,
+        y: float,
+        reference: str,
+        value: str,
+        rotation: int,
+        project_name: str,
+        root_uuid: str,
+    ) -> str:
+        payload: dict[str, object] = {
+            "lib_id": lib_id,
+            "x": x,
+            "y": y,
+            "reference": reference,
+            "value": value,
+            "rotation": rotation,
+            "project_name": project_name,
+            "root_uuid": root_uuid,
+        }
+        calls.append(("place_symbol_block", payload))
+        return f"POWER({value},{x},{y})"
 
     def append_before_sheet_instances(content: str, block: str) -> str:
         return content.replace("\t(sheet_instances)", f"\t{block}\n\t(sheet_instances)", 1)
@@ -90,11 +121,15 @@ def _harness(
     def route(
         start: tuple[float, float],
         end: tuple[float, float],
-        obstacles: list[object],
+        obstacles: list[BoundingBoxLike],
         snap_to_grid: bool,
     ) -> tuple[list[tuple[float, float, float, float]], str | None]:
         calls.append(("route", (start, end, obstacles, snap_to_grid)))
         return list(route_segments or []), route_warning
+
+    def split_lib_id(lib_id: str) -> tuple[str, str]:
+        library, symbol_name = lib_id.split(":", 1)
+        return library, symbol_name
 
     service = SchematicConnectivityAuthoringService(
         resolve_target=lambda sheet, sheet_file: target,
@@ -117,8 +152,8 @@ def _harness(
         reload_schematic=lambda: "Reloaded",
         format_target_detail=lambda resolved: f"Target schematic: {resolved.path.name}",
         active_schematic_file=lambda: target.path,
-        split_lib_id=lambda lib_id: tuple(lib_id.split(":", 1)),  # type: ignore[return-value]
-        get_symbol_bboxes=lambda content: ["bbox"],
+        split_lib_id=split_lib_id,
+        get_symbol_bboxes=lambda content: [FakeBoundingBox()],
         route_avoiding_obstacles=route,
         run_auto_add_missing_junctions=lambda: "Inserted 2 missing junction(s).",
         snap_tolerance_mm=0.001,
@@ -138,7 +173,9 @@ def _symbol(reference: str = "U1", lib_id: str = "Device:R") -> dict[str, Any]:
     }
 
 
-def test_add_pin_labels_reports_invalid_and_missing_connections_without_write(tmp_path: Path) -> None:
+def test_add_pin_labels_reports_invalid_and_missing_connections_without_write(
+    tmp_path: Path,
+) -> None:
     harness = _harness(tmp_path, parsed={"uuid": "root", "symbols": [], "power_symbols": []})
 
     result = harness.service.add_pin_labels(
@@ -190,9 +227,7 @@ def test_add_pin_labels_resolves_alias_and_places_power_symbol(tmp_path: Path) -
         aliases={("Device", "R"): {"VIN": (12.0, 20.0)}},
     )
 
-    result = harness.service.add_pin_labels(
-        [{"reference": "U1", "pin": "VIN", "net": "3V3"}]
-    )
+    result = harness.service.add_pin_labels([{"reference": "U1", "pin": "VIN", "net": "3V3"}])
 
     assert "U1.VIN -> 3V3 (power) @ (17.08, 20.0)" in result
     assert any(name == "place_symbol_block" for name, _payload in harness.calls)
@@ -208,9 +243,7 @@ def test_add_pin_labels_accepts_power_symbol_origin_pin_fallback(tmp_path: Path)
         pin_positions={("power", "GND"): {}},
     )
 
-    result = harness.service.add_pin_labels(
-        [{"reference": "#PWR01", "pin": "1", "net": "GND"}]
-    )
+    result = harness.service.add_pin_labels([{"reference": "#PWR01", "pin": "1", "net": "GND"}])
 
     assert "#PWR01.1 -> GND (power) @ (15.08, 20.0)" in result
     assert len(harness.writes) == 1
@@ -224,9 +257,7 @@ def test_add_pin_labels_skips_missing_power_library_symbol(tmp_path: Path) -> No
         power_lib=None,
     )
 
-    result = harness.service.add_pin_labels(
-        [{"reference": "U1", "pin": "1", "net": "3V3"}]
-    )
+    result = harness.service.add_pin_labels([{"reference": "U1", "pin": "1", "net": "3V3"}])
 
     assert result == "No pin labels were added.\nU1.1: power symbol '3V3' was not found"
     assert harness.writes == []
@@ -276,13 +307,10 @@ def test_route_wire_between_pins_writes_segments_and_warning(tmp_path: Path) -> 
         route_warning="WARNING: obstacle_bypass_failed",
     )
 
-    result = harness.service.route_wire_between_pins(
-        "U1", "1", "R1", "2", snap_to_grid=False
-    )
+    result = harness.service.route_wire_between_pins("U1", "1", "R1", "2", snap_to_grid=False)
 
     assert result == (
-        "Reloaded\nRouted 2 wire segment(s) between U1:1 and R1:2.\n"
-        "WARNING: obstacle_bypass_failed"
+        "Reloaded\nRouted 2 wire segment(s) between U1:1 and R1:2.\nWARNING: obstacle_bypass_failed"
     )
     assert len(harness.writes) == 1
     assert harness.writes[0][0] is None
@@ -294,8 +322,17 @@ def test_add_missing_junctions_runs_fixer_before_reload(tmp_path: Path) -> None:
     order: list[str] = []
     harness = _harness(tmp_path)
     service = harness.service
-    object.__setattr__(service, "run_auto_add_missing_junctions", lambda: order.append("fix") or "Fixed")
-    object.__setattr__(service, "reload_schematic", lambda: order.append("reload") or "Reloaded")
+
+    def fix() -> str:
+        order.append("fix")
+        return "Fixed"
+
+    def reload() -> str:
+        order.append("reload")
+        return "Reloaded"
+
+    object.__setattr__(service, "run_auto_add_missing_junctions", fix)
+    object.__setattr__(service, "reload_schematic", reload)
 
     result = service.add_missing_junctions()
 


### PR DESCRIPTION
## Summary

- extract `sch_add_pin_labels`, `sch_route_wire_between_pins`, and `sch_add_missing_junctions` into a FastMCP-independent `SchematicConnectivityAuthoringService`
- add a 53-line thin MCP adapter that preserves exact public signatures, descriptions, schemas, annotations, metadata, transaction paths, reload ordering, and response strings
- keep `run_auto_add_missing_junctions` in the schematic composition root for fixer imports and existing monkeypatch seams
- add direct service, registration, architecture-boundary, integration, and exact full-server contract coverage
- reduce `src/kicad_mcp/tools/schematic.py::register()` from 699 lines to 469 lines

## Issue progress

Progresses #434. This PR deliberately does **not** close the issue: the connectivity adapter is below the 300-line limit, but the remaining schematic composition-root `register()` is 469 lines. The remaining nested tools are `sch_add_jumper`, `sch_annotate`, and `sch_reload`.

## Verification

- exact old/new full-server MCP contract JSON match for all three tools; identical SHA-256 `f5aeb60adba8e24f49a28bdcb079a0795b659ac23087aa3ae3813b554deb39e1`
- 17 direct service/adapter/architecture tests passed
- 9 existing pin-label, routing, and missing-junction integration tests passed
- 4 fixer/validation-loop integration tests passed
- combined focused unit/integration run: 26 tests passed
- focused coverage: 90.05% total; service 89%, adapter 100% (required: 83%)
- architecture boundary and tool-contract checks passed
- metadata, generated tools reference, parity, and parity-regression checks passed
- representative latency benchmark passed
- scoped Ruff format/check passed
- mypy passed across 187 source files
- Pyright reported 0 errors and 0 warnings
- wheel + sdist build and package metadata validation passed
- runtime policy, no-pcbnew/SWIG, and strict MkDocs build passed
- full unit suite passed to 100% with exit code 0 (5 existing platform-dependent skips; one pre-existing AsyncMock runtime warning)

## Architecture impact

- `src/kicad_mcp/tools/schematic.py::register()`: 699 -> 469 lines
- `src/kicad_mcp/tools/schematic_connectivity_authoring.py::register()`: 53 lines
- domain service imports neither FastMCP nor the schematic registry
- adapter is guarded against importing the monolith
