### PR TITLE
fix: verify footprint rotation updates

### DIFF
--- a/src/kicad_mcp/pcb/footprint_transform.py
+++ b/src/kicad_mcp/pcb/footprint_transform.py
@@ -1,0 +1,79 @@
+"""Footprint transform helpers shared by live PCB mutation tools."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+from kipy.geometry import Angle
+
+RotationAttribute = Literal["angle", "orientation"]
+_SUPPORTED_ROTATION_ATTRIBUTES: tuple[RotationAttribute, ...] = ("angle", "orientation")
+
+
+class FootprintRotationError(RuntimeError):
+    """Raised when a requested footprint rotation cannot be applied or verified."""
+
+
+def _rotation_degrees(value: object) -> float:
+    if isinstance(value, Angle):
+        return float(value.degrees)
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    degrees = getattr(value, "degrees", None)
+    if isinstance(degrees, int | float) and not isinstance(degrees, bool):
+        return float(degrees)
+    raise FootprintRotationError("Footprint rotation value does not expose numeric degrees.")
+
+
+def apply_footprint_rotation(footprint: object, rotation_deg: float) -> RotationAttribute:
+    """Assign a KiCad ``Angle`` through the first writable rotation surface."""
+    if not math.isfinite(rotation_deg):
+        raise FootprintRotationError("Requested footprint rotation must be finite.")
+
+    requested = Angle.from_degrees(rotation_deg)
+    available: list[RotationAttribute] = []
+    failures: list[str] = []
+    for attribute in _SUPPORTED_ROTATION_ATTRIBUTES:
+        try:
+            getattr(footprint, attribute)
+        except AttributeError:
+            continue
+        available.append(attribute)
+        try:
+            setattr(footprint, attribute, requested)
+        except Exception as exc:  # KiCad IPC surfaces raise generated transport/type errors.
+            failures.append(f"{attribute}: {type(exc).__name__}")
+            continue
+        return attribute
+
+    if not available:
+        raise FootprintRotationError(
+            "Footprint does not expose a supported angle or orientation surface."
+        )
+    detail = ", ".join(failures) if failures else ", ".join(available)
+    raise FootprintRotationError(f"Requested footprint rotation could not be applied ({detail}).")
+
+
+def verify_footprint_rotation(
+    footprint: object,
+    attribute: RotationAttribute,
+    requested_deg: float,
+    *,
+    tolerance_deg: float = 1e-3,
+) -> float:
+    """Read back and verify a footprint rotation using wrapped angular distance."""
+    try:
+        actual = _rotation_degrees(getattr(footprint, attribute))
+    except AttributeError as exc:
+        raise FootprintRotationError(
+            f"Footprint rotation verification failed: '{attribute}' is unavailable."
+        ) from exc
+
+    delta = (actual - requested_deg + 180.0) % 360.0 - 180.0
+    if abs(delta) > tolerance_deg:
+        raise FootprintRotationError(
+            "Footprint rotation verification failed: "
+            f"requested {requested_deg:.6f} degrees, observed {actual:.6f} degrees."
+        )
+    return actual

--- a/src/kicad_mcp/tools/pcb.py
+++ b/src/kicad_mcp/tools/pcb.py
@@ -24,7 +24,7 @@ from kipy.board_types import (
     Via,
     Zone,
 )
-from kipy.geometry import Angle, PolygonWithHoles, PolyLine, PolyLineNode, Vector2
+from kipy.geometry import PolygonWithHoles, PolyLine, PolyLineNode, Vector2
 from kipy.proto.board import board_types_pb2
 from kipy.proto.board.board_types_pb2 import BoardLayer, ViaType, ZoneType
 from kipy.proto.common import types as common_types
@@ -64,6 +64,11 @@ from ..operating_modes import OperatingMode, active_operating_mode
 from ..pcb.basic_inspection import PcbBasicInspectionService
 from ..pcb.board_inspection import PcbBoardInspectionService
 from ..pcb.file_inspection import PcbFileInspectionService
+from ..pcb.footprint_transform import (
+    FootprintRotationError,
+    apply_footprint_rotation,
+    verify_footprint_rotation,
+)
 from ..pcb.groups_inspection import PcbGroupsInspectionService
 from ..pcb.origin_management import PcbOriginService
 from ..pcb.session_inspection import PcbSessionInspectionService
@@ -3233,19 +3238,24 @@ def _register_board_mutation_tools(mcp: FastMCP) -> None:
             return f"Footprint '{reference}' was not found on the active board."
 
         footprint.position = Vector2.from_xy_mm(x_mm, y_mm)
-        if hasattr(footprint, "angle"):
-            try:
-                footprint.angle = Angle.from_degrees(rotation_deg)
-            except Exception as exc:
-                logger.debug("footprint_angle_not_supported", error=str(exc))
-        elif hasattr(footprint, "orientation"):
-            try:
-                footprint.orientation = rotation_deg
-            except Exception as exc:
-                logger.debug("footprint_orientation_not_supported", error=str(exc))
+        rotation_attribute = apply_footprint_rotation(footprint, rotation_deg)
         with board_transaction() as board:
             board.update_items([cast(BoardItem, footprint)])
-        return f"Moved footprint '{reference}' to ({x_mm}, {y_mm}) mm."
+
+        refreshed = _find_footprint_by_reference(reference)
+        if refreshed is None:
+            raise FootprintRotationError(
+                f"Footprint '{reference}' could not be reloaded to verify its rotation."
+            )
+        actual_rotation = verify_footprint_rotation(
+            refreshed,
+            rotation_attribute,
+            rotation_deg,
+        )
+        return (
+            f"Moved footprint '{reference}' to ({x_mm}, {y_mm}) mm "
+            f"with verified rotation {actual_rotation:.3f} degrees."
+        )
 
     @mcp.tool()
     @requires_kicad_running

--- a/tests/unit/test_pcb_footprint_rotation.py
+++ b/tests/unit/test_pcb_footprint_rotation.py
@@ -1,0 +1,247 @@
+"""Footprint rotation persistence regressions for issue #499."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from kipy.geometry import Angle
+
+from kicad_mcp.pcb.footprint_transform import (
+    FootprintRotationError,
+    apply_footprint_rotation,
+    verify_footprint_rotation,
+)
+from kicad_mcp.server import build_server
+from tests.conftest import call_tool_text
+
+
+class _StrictRotationSurface:
+    def __init__(
+        self,
+        attribute: str,
+        *,
+        reject: bool = False,
+        initial_degrees: float = 0.0,
+    ) -> None:
+        self.attribute = attribute
+        self.reject = reject
+        self.assigned_values: list[object] = []
+        self._value = Angle.from_degrees(initial_degrees)
+
+    def __getattr__(self, name: str) -> object:
+        if name == self.attribute:
+            return self._value
+        raise AttributeError(name)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name.startswith("_") or name in {"attribute", "reject", "assigned_values"}:
+            object.__setattr__(self, name, value)
+            return
+        if name == self.attribute:
+            self.assigned_values.append(value)
+            if self.reject:
+                raise TypeError(f"{name} is not writable")
+            if not isinstance(value, Angle):
+                raise TypeError(f"{name} requires Angle")
+            object.__setattr__(self, "_value", value)
+            return
+        object.__setattr__(self, name, value)
+
+
+class _LiveFootprint(_StrictRotationSurface):
+    def __init__(
+        self,
+        attribute: str = "orientation",
+        *,
+        reject: bool = False,
+        initial_degrees: float = 0.0,
+    ) -> None:
+        super().__init__(attribute, reject=reject, initial_degrees=initial_degrees)
+        self.reference_field = SimpleNamespace(text=SimpleNamespace(value="X2"))
+        self.position = None
+
+
+@pytest.mark.parametrize("attribute", ["angle", "orientation"])
+def test_apply_footprint_rotation_assigns_an_angle(attribute: str) -> None:
+    footprint = _StrictRotationSurface(attribute)
+
+    selected = apply_footprint_rotation(footprint, 180.0)
+
+    assert selected == attribute
+    assert len(footprint.assigned_values) == 1
+    assert isinstance(footprint.assigned_values[0], Angle)
+    assert footprint.assigned_values[0].degrees == pytest.approx(180.0)
+
+
+def test_apply_footprint_rotation_fails_when_no_supported_surface_exists() -> None:
+    with pytest.raises(FootprintRotationError, match="angle or orientation"):
+        apply_footprint_rotation(object(), 90.0)
+
+
+def test_apply_footprint_rotation_fails_when_setter_rejects_angle() -> None:
+    footprint = _StrictRotationSurface("orientation", reject=True)
+
+    with pytest.raises(FootprintRotationError, match="could not be applied"):
+        apply_footprint_rotation(footprint, 90.0)
+
+
+def test_verify_footprint_rotation_accepts_equivalent_wrapped_degrees() -> None:
+    footprint = _StrictRotationSurface("orientation", initial_degrees=-180.0)
+
+    assert verify_footprint_rotation(footprint, "orientation", 180.0) == pytest.approx(-180.0)
+
+
+def test_verify_footprint_rotation_rejects_mismatch() -> None:
+    footprint = _StrictRotationSurface("orientation", initial_degrees=90.0)
+
+    with pytest.raises(FootprintRotationError, match="verification failed"):
+        verify_footprint_rotation(footprint, "orientation", 180.0)
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_move_footprint_applies_and_reports_verified_rotation(mock_board: object) -> None:
+    footprint = _LiveFootprint()
+    mock_board.get_footprints.return_value = [footprint]
+    server = build_server("full")
+
+    result = await call_tool_text(
+        server,
+        "pcb_move_footprint",
+        {"reference": "X2", "x_mm": 10.0, "y_mm": 20.0, "rotation_deg": 180.0},
+    )
+
+    assert len(footprint.assigned_values) == 1
+    assert isinstance(footprint.assigned_values[0], Angle)
+    assert footprint.assigned_values[0].degrees == pytest.approx(180.0)
+    assert "verified rotation 180.000 degrees" in result
+    mock_board.update_items.assert_called_once()
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_move_footprint_fails_when_rotation_setter_rejects_angle(mock_board: object) -> None:
+    footprint = _LiveFootprint(reject=True)
+    mock_board.get_footprints.return_value = [footprint]
+    server = build_server("full")
+
+    result = await call_tool_text(
+        server,
+        "pcb_move_footprint",
+        {"reference": "X2", "x_mm": 10.0, "y_mm": 20.0, "rotation_deg": 180.0},
+    )
+
+    assert "TOOL_EXECUTION_FAILED" in result
+    assert "could not be applied" in result
+    mock_board.update_items.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_move_footprint_fails_when_post_update_rotation_mismatches(
+    mock_board: object,
+) -> None:
+    initial = _LiveFootprint()
+    refreshed = _LiveFootprint(initial_degrees=90.0)
+    mock_board.get_footprints.side_effect = [[initial], [refreshed]]
+    server = build_server("full")
+
+    result = await call_tool_text(
+        server,
+        "pcb_move_footprint",
+        {"reference": "X2", "x_mm": 10.0, "y_mm": 20.0, "rotation_deg": 180.0},
+    )
+
+    assert "TOOL_EXECUTION_FAILED" in result
+    assert "verification failed" in result
+    mock_board.update_items.assert_called_once()
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+@pytest.mark.parametrize("tool_name", ["pcb_place_component", "pcb_move_component"])
+async def test_component_move_aliases_use_verified_rotation_path(
+    mock_board: object,
+    tool_name: str,
+) -> None:
+    footprint = _LiveFootprint()
+    mock_board.get_footprints.return_value = [footprint]
+    server = build_server("full")
+
+    result = await call_tool_text(
+        server,
+        tool_name,
+        {"reference": "X2", "x_mm": 10.0, "y_mm": 20.0, "rotation_deg": 180.0},
+    )
+
+    assert "verified rotation 180.000 degrees" in result
+    assert isinstance(footprint.assigned_values[0], Angle)
+
+
+class _DualRotationSurface:
+    def __init__(self) -> None:
+        self._angle = Angle.from_degrees(0.0)
+        self._orientation = Angle.from_degrees(0.0)
+        self.orientation_assignments: list[object] = []
+
+    @property
+    def angle(self) -> Angle:
+        return self._angle
+
+    @angle.setter
+    def angle(self, _value: object) -> None:
+        raise TypeError("angle is read-only")
+
+    @property
+    def orientation(self) -> Angle:
+        return self._orientation
+
+    @orientation.setter
+    def orientation(self, value: object) -> None:
+        self.orientation_assignments.append(value)
+        if not isinstance(value, Angle):
+            raise TypeError("orientation requires Angle")
+        self._orientation = value
+
+
+def test_apply_footprint_rotation_falls_back_to_writable_orientation() -> None:
+    footprint = _DualRotationSurface()
+
+    selected = apply_footprint_rotation(footprint, 45.0)
+
+    assert selected == "orientation"
+    assert len(footprint.orientation_assignments) == 1
+    assert isinstance(footprint.orientation_assignments[0], Angle)
+    assert footprint.orientation.degrees == pytest.approx(45.0)
+
+
+def test_apply_footprint_rotation_rejects_non_finite_degrees() -> None:
+    with pytest.raises(FootprintRotationError, match="must be finite"):
+        apply_footprint_rotation(_StrictRotationSurface("orientation"), float("inf"))
+
+
+@pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
+async def test_move_footprint_fails_when_updated_reference_cannot_be_reloaded(
+    mock_board: object,
+) -> None:
+    initial = _LiveFootprint()
+    mock_board.get_footprints.side_effect = [[initial], []]
+    server = build_server("full")
+
+    result = await call_tool_text(
+        server,
+        "pcb_move_footprint",
+        {"reference": "X2", "x_mm": 10.0, "y_mm": 20.0, "rotation_deg": 180.0},
+    )
+
+    assert "TOOL_EXECUTION_FAILED" in result
+    assert "could not be reloaded" in result
+    mock_board.update_items.assert_called_once()
+
+
+def test_verify_footprint_rotation_allows_ipc_round_trip_tolerance() -> None:
+    footprint = _StrictRotationSurface("orientation", initial_degrees=180.0005)
+
+    assert verify_footprint_rotation(footprint, "orientation", 180.0) == pytest.approx(180.0005)


### PR DESCRIPTION
## Purpose

Prevent `pcb_move_footprint`, `pcb_place_component`, and `pcb_move_component` from returning false success when the requested footprint rotation was not applied or did not persist.

Closes #499.
Refs #495.

## Confirmed root cause

The shared move implementation used inconsistent rotation types:

- `angle` received `Angle.from_degrees(...)`
- `orientation` received the raw `float`
- setter exceptions were reduced to debug logs
- `update_items()` still ran
- the tool returned a successful `Moved footprint ...` response without reading the saved rotation back

A red-first regression reproduced this with a KiCad-like `orientation` setter that accepts only `kipy.geometry.Angle`: the setter rejected `180.0`, orientation remained unchanged, and the tool still reported success.

## Changes

- add a FastMCP-independent footprint rotation helper
- convert requested degrees to `Angle.from_degrees(...)` for both `angle` and `orientation`
- fall back from a read-only/rejected `angle` surface to a writable `orientation` surface
- reject non-finite requested rotations
- fail closed when no supported rotation surface is writable
- update the footprint, reload it by reference, and verify the persisted rotation
- compare wrapped angular distance with a 0.001-degree tolerance
- fail closed if the footprint cannot be reloaded or the saved angle does not match
- return successful output only with the final position and verified rotation
- keep the three public tool aliases on the same corrected implementation path

## Verification

### TDD and focused tests

Red-first public-tool tests reproduced all five affected behaviors before implementation:

- raw float assigned to a strict KiCad-like orientation setter
- setter failure followed by a success response
- post-update orientation mismatch followed by a success response
- `pcb_place_component` using the same unverified path
- `pcb_move_component` using the same unverified path

Final focused results:

- footprint rotation unit/regression tests: 15 passed
- rotation tests plus existing PCB mutation surface: 16 passed
- targeted pre-push tests: 48 passed

Coverage includes:

- `Angle` assignment through `angle`
- `Angle` assignment through `orientation`
- read-only `angle` fallback to `orientation`
- unsupported rotation surfaces
- rejected setters
- non-finite degree input
- wrapped 0/360-degree comparison
- accepted sub-millidegree round-trip variance
- persisted orientation mismatch
- missing post-update footprint
- all three public tool names

### Static and repository checks

- source-wide Ruff format: 217 files clean
- source-wide Ruff lint: passed
- strict mypy: 216 source files, no issues
- architecture boundaries: passed
- tool contract lint: passed
- generated tool reference check: passed
- full pre-commit set: passed, including private-key and hardcoded-secret detection
- targeted pre-push hook: passed

### Full unit suite

Exact commit `2f3b1a15639de0c5f1178741c24b38a9a64c8ed7` was checked out on a clean MSI worker with:

- Node 24.11.0
- Python 3.13.12
- uv 0.10.8

The full unit suite completed at 100% with exit code 0. The only warning was the existing Windows fallback `AsyncMock` warning.

## Compatibility, risk, and rollback

Public tool names and input schemas are unchanged. Successful output now includes verified rotation, and previously silent rotation failures become explicit tool failures. This is intentional fail-closed behavior for a PCB mutation path.

Rollback is a single revert of this PR.
