### PR TITLE
fix: map live pads to footprint references

### DIFF
--- a/src/kicad_mcp/pcb/basic_inspection.py
+++ b/src/kicad_mcp/pcb/basic_inspection.py
@@ -6,6 +6,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Protocol, cast
 
+from .pad_mapping import map_pads_to_footprints
+
 
 class LimitItems(Protocol):
     """Apply the configured response item limit while preserving total count."""
@@ -23,6 +25,8 @@ class BasicInspectionBoard(Protocol):
     def get_shapes(self) -> Iterable[object]: ...
 
     def get_pads(self) -> Iterable[object]: ...
+
+    def get_footprints(self) -> Iterable[object]: ...
 
     def get_enabled_layers(self) -> Iterable[int]: ...
 
@@ -47,20 +51,12 @@ class TextLike(Protocol):
     def text(self) -> TextValueLike: ...
 
 
-class PadParentLike(Protocol):
-    @property
-    def reference_field(self) -> TextLike: ...
-
-
 class NetLike(Protocol):
     @property
     def name(self) -> str: ...
 
 
 class PadLike(Protocol):
-    @property
-    def parent(self) -> PadParentLike: ...
-
     @property
     def number(self) -> str | int: ...
 
@@ -150,13 +146,15 @@ class PcbBasicInspectionService:
 
     def get_pads(self) -> str:
         """List live board pads with references, nets, and coordinates."""
-        pads, total = self.limit_items(self._board().get_pads())
+        board = self._board()
+        mapped = map_pads_to_footprints(board.get_pads(), board.get_footprints())
+        pads, total = self.limit_items(mapped)
         if not pads:
             return self.with_pcb_diagnostics("No pads are present on the active board.")
         lines = [f"Pads ({total} total):"]
-        for index, raw_pad in enumerate(pads, start=1):
-            pad = cast(PadLike, raw_pad)
-            reference = pad.parent.reference_field.text.value
+        for index, mapped_pad in enumerate(pads, start=1):
+            pad = cast(PadLike, mapped_pad.pad)
+            reference = mapped_pad.reference or "(unmapped)"
             number = pad.number
             net_name = pad.net.name or "(none)"
             x_mm = self.nm_to_mm(self.coord_nm(pad.position, "x"))

--- a/src/kicad_mcp/pcb/pad_mapping.py
+++ b/src/kicad_mcp/pcb/pad_mapping.py
@@ -1,0 +1,85 @@
+"""Map live KiCad pads to their containing footprint instances."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MappedPad:
+    """One authoritative board pad enriched with its footprint reference."""
+
+    pad: object
+    pad_id: str | None
+    reference: str | None
+
+
+def pad_id(pad: object) -> str | None:
+    """Return a stable KiCad pad identifier when the IPC object exposes one."""
+    value = getattr(getattr(pad, "id", None), "value", None)
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def footprint_reference(footprint: object) -> str | None:
+    """Return a placed footprint reference through the supported field surface."""
+    value = getattr(
+        getattr(getattr(footprint, "reference_field", None), "text", None),
+        "value",
+        None,
+    )
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def footprint_pads(footprint: object) -> list[object]:
+    """Read pads from the official ``FootprintInstance.definition.pads`` relationship."""
+    pads = getattr(getattr(footprint, "definition", None), "pads", None)
+    if pads is None:
+        return []
+    try:
+        return list(pads)
+    except TypeError:
+        return []
+
+
+def map_pads_to_footprints(
+    pads: Iterable[object],
+    footprints: Iterable[object],
+) -> list[MappedPad]:
+    """Deduplicate board pads and enrich them with stable footprint references."""
+    references: dict[str, str | None] = {}
+    for footprint in footprints:
+        reference = footprint_reference(footprint)
+        for pad in footprint_pads(footprint):
+            identifier = pad_id(pad)
+            if identifier is None:
+                continue
+            if identifier not in references:
+                references[identifier] = reference
+            elif references[identifier] != reference:
+                references[identifier] = None
+
+    mapped: list[MappedPad] = []
+    seen: set[tuple[str, str | int]] = set()
+    for pad in pads:
+        identifier = pad_id(pad)
+        identity: tuple[str, str | int] = (
+            ("id", identifier) if identifier is not None else ("object", id(pad))
+        )
+        if identity in seen:
+            continue
+        seen.add(identity)
+        mapped.append(
+            MappedPad(
+                pad=pad,
+                pad_id=identifier,
+                reference=references.get(identifier) if identifier is not None else None,
+            )
+        )
+    return mapped

--- a/src/kicad_mcp/tools/net_analysis.py
+++ b/src/kicad_mcp/tools/net_analysis.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 from mcp.server.fastmcp import FastMCP
 
 from ..connection import KiCadConnectionError, get_board
+from ..pcb.pad_mapping import MappedPad, footprint_pads, map_pads_to_footprints
 from ..utils.units import nm_to_mm
 from .export_support import _get_pcb_file
 from .metadata import headless_compatible
@@ -37,21 +38,20 @@ def _board_vias(board: object) -> list[Any]:
         return []
 
 
-def _board_pads(board: object) -> list[Any]:
+def _board_footprints(board: object) -> list[Any]:
     try:
-        return list(cast(Any, board).get_pads())
+        return list(cast(Any, board).get_footprints())
     except (AttributeError, TypeError, OSError):
-        pads: list[Any] = []
-        try:
-            footprints = cast(Any, board).get_footprints()
-        except (AttributeError, TypeError, OSError):
-            return pads
-        for footprint in footprints:
-            try:
-                pads.extend(list(footprint.get_pads()))
-            except (AttributeError, TypeError, OSError):
-                continue
-        return pads
+        return []
+
+
+def _mapped_board_pads(board: object) -> list[MappedPad]:
+    footprints = _board_footprints(board)
+    try:
+        pads = list(cast(Any, board).get_pads())
+    except (AttributeError, TypeError, OSError):
+        pads = [pad for footprint in footprints for pad in footprint_pads(footprint)]
+    return map_pads_to_footprints(pads, footprints)
 
 
 def _collect_nets_from_board() -> list[dict[str, Any]]:
@@ -64,7 +64,8 @@ def _collect_nets_from_board() -> list[dict[str, Any]]:
 
     tracks = _board_tracks(board)
     vias = _board_vias(board)
-    pads = _board_pads(board)
+    mapped_pads = _mapped_board_pads(board)
+    pads = [mapped.pad for mapped in mapped_pads]
 
     result: list[dict[str, Any]] = []
     for net in nets:
@@ -113,6 +114,29 @@ def _nets() -> list[dict[str, Any]]:
         return _collect_nets_from_board()
     except (RuntimeError, KiCadConnectionError):
         return _collect_nets_from_file()
+
+
+def _file_pad_details(net_name: str) -> list[dict[str, object]]:
+    """Return footprint pad details from balanced PCB S-expression blocks."""
+    from .board_file import _normalize_board_content, _parse_board_footprint_blocks
+
+    content = _normalize_board_content(_get_pcb_file().read_text(encoding="utf-8", errors="ignore"))
+    footprints = _parse_board_footprint_blocks(content)
+    details: list[dict[str, object]] = []
+    for reference, entry in footprints.items():
+        pad_nets = cast(dict[str, str], entry.get("pad_nets", {}))
+        layer = str(entry.get("layer_name", "unknown"))
+        for pad_number, mapped_net_name in pad_nets.items():
+            if mapped_net_name != net_name:
+                continue
+            details.append(
+                {
+                    "reference": reference,
+                    "pad": pad_number,
+                    "layer": layer,
+                }
+            )
+    return details
 
 
 def register(mcp: FastMCP) -> None:
@@ -171,47 +195,20 @@ def register(mcp: FastMCP) -> None:
         net = matches[0]
         net_code = net.get("code")
 
-        # Collect footprint pads on this net
-        pads_on_net: list[dict[str, object]] = []
+        # Collect authoritative board pads and enrich them with containing references.
         try:
             board = get_board()
-            for footprint in board.get_footprints():
-                for pad in footprint.get_pads():  # type: ignore[attr-defined]
-                    if _object_net_name(pad) == net_name:
-                        pads_on_net.append(
-                            {
-                                "reference": footprint.reference_field.text.value,
-                                "pad": pad.number,
-                                "layer": str(pad.layer),
-                            }
-                        )
-        except Exception:
-            # File fallback — parse footprint pad nets by stable net name.
-            import re
-
-            from .board_file import _normalize_board_content
-
-            content = _normalize_board_content(
-                _get_pcb_file().read_text(encoding="utf-8", errors="ignore")
-            )
-            escaped_name = re.escape(net_name)
-            pad_net_re = re.compile(
-                r'\(pad\s+"([^"]*)"\s+\w+.*?\(net\s+\d+\s+"' + escaped_name + r'"\)',
-                re.DOTALL,
-            )
-            for fp_match in re.finditer(r"\(footprint\s+.*?\)", content, re.DOTALL):
-                block = fp_match.group()
-                ref_m = re.search(r'\(property\s+"Reference"\s+"([^"]*)"', block)
-                if not ref_m:
-                    continue
-                for pad_m in pad_net_re.finditer(block):
-                    pads_on_net.append(
-                        {
-                            "reference": ref_m.group(1),
-                            "pad": pad_m.group(1),
-                            "layer": "unknown",
-                        }
-                    )
+            pads_on_net = [
+                {
+                    "reference": mapped.reference or "(unmapped)",
+                    "pad": getattr(mapped.pad, "number", ""),
+                    "layer": str(getattr(mapped.pad, "layer", "unknown")),
+                }
+                for mapped in _mapped_board_pads(board)
+                if _object_net_name(mapped.pad) == net_name
+            ]
+        except (KiCadConnectionError, OSError, AttributeError, TypeError):
+            pads_on_net = _file_pad_details(net_name)
 
         payload: dict[str, object] = {
             "net_name": net_name,

--- a/tests/integration/test_pcb_tools.py
+++ b/tests/integration/test_pcb_tools.py
@@ -161,12 +161,19 @@ async def test_pcb_read_tools_report_active_board_items(
         net=SimpleNamespace(name="GND"),
         type=ViaType.VT_THROUGH,
     )
+    pad = SimpleNamespace(
+        id=SimpleNamespace(value="pad-1"),
+        number="1",
+        net=SimpleNamespace(name="USB_DP"),
+        position=SimpleNamespace(x_nm=6_500_000, y_nm=7_500_000),
+    )
     footprint = SimpleNamespace(
         reference_field=SimpleNamespace(text=SimpleNamespace(value="U1")),
         value_field=SimpleNamespace(text=SimpleNamespace(value="MCU")),
         position=SimpleNamespace(x_nm=6_000_000, y_nm=7_000_000),
         layer=BoardLayer.BL_B_Cu,
         id=SimpleNamespace(value="fp-1"),
+        definition=SimpleNamespace(pads=[pad]),
     )
     zone = SimpleNamespace(
         name="GND_FILL",
@@ -174,12 +181,6 @@ async def test_pcb_read_tools_report_active_board_items(
         layers=[BoardLayer.BL_F_Cu, BoardLayer.BL_B_Cu],
     )
     shape = SimpleNamespace(layer=BoardLayer.BL_Edge_Cuts)
-    pad = SimpleNamespace(
-        parent=SimpleNamespace(reference_field=SimpleNamespace(text=SimpleNamespace(value="U1"))),
-        number="1",
-        net=SimpleNamespace(name="USB_DP"),
-        position=SimpleNamespace(x_nm=6_500_000, y_nm=7_500_000),
-    )
     mock_board.get_tracks.return_value = [track]
     mock_board.get_vias.return_value = [via]
     mock_board.get_footprints.return_value = [footprint]

--- a/tests/unit/test_pcb_basic_inspection_service.py
+++ b/tests/unit/test_pcb_basic_inspection_service.py
@@ -130,23 +130,36 @@ def test_shapes_preserve_types_layers_and_empty_diagnostics() -> None:
 
 def test_pads_preserve_reference_net_and_coordinate_formatting() -> None:
     pad = SimpleNamespace(
-        parent=SimpleNamespace(reference_field=SimpleNamespace(text=SimpleNamespace(value="U1"))),
+        id=SimpleNamespace(value="pad-7"),
         number="7",
         net=SimpleNamespace(name="GND"),
         position=SimpleNamespace(x=1_250_000, y=-2_500_000),
     )
+    footprint = SimpleNamespace(
+        reference_field=SimpleNamespace(text=SimpleNamespace(value="U1")),
+        definition=SimpleNamespace(pads=[SimpleNamespace(id=SimpleNamespace(value="pad-7"))]),
+    )
 
-    def get_pads() -> list[object]:
-        return [pad]
-
-    def no_pads() -> list[object]:
-        return []
-
-    assert _service(SimpleNamespace(get_pads=get_pads)).get_pads() == "\n".join(
+    board = SimpleNamespace(get_pads=lambda: [pad], get_footprints=lambda: [footprint])
+    assert _service(board).get_pads() == "\n".join(
         ["Pads (1 total):", "1. U1:7 net=GND @ (1.25, -2.50) mm"]
     )
-    assert _service(SimpleNamespace(get_pads=no_pads)).get_pads() == (
-        "diag::No pads are present on the active board."
+
+    no_pads = SimpleNamespace(get_pads=lambda: [], get_footprints=lambda: [])
+    assert _service(no_pads).get_pads() == ("diag::No pads are present on the active board.")
+
+
+def test_pads_report_unmapped_reference_without_crashing() -> None:
+    pad = SimpleNamespace(
+        id=SimpleNamespace(value="orphan"),
+        number="2",
+        net=SimpleNamespace(name=""),
+        position=SimpleNamespace(x=0, y=0),
+    )
+    board = SimpleNamespace(get_pads=lambda: [pad], get_footprints=lambda: [])
+
+    assert _service(board).get_pads() == "\n".join(
+        ["Pads (1 total):", "1. (unmapped):2 net=(none) @ (0.00, 0.00) mm"]
     )
 
 

--- a/tests/unit/test_pcb_net_inspector.py
+++ b/tests/unit/test_pcb_net_inspector.py
@@ -4,7 +4,15 @@ Tools: pcb_get_net_statistics, pcb_net_inspector, pcb_export_stats.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kicad_mcp.server import build_server
 from kicad_mcp.tools.net_analysis import _collect_nets_from_file, _nets
+from tests.conftest import call_tool_text
 
 
 def test_collect_nets_from_file_empty(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -88,3 +96,71 @@ def test_collect_nets_from_board_uses_net_names_not_deprecated_codes(monkeypatch
             "total_track_length_mm": 1.0,
         }
     ]
+
+
+@pytest.mark.anyio
+async def test_net_inspector_maps_live_board_pads_through_footprint_definition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pad = SimpleNamespace(
+        id=SimpleNamespace(value="pad-1"),
+        number="1",
+        net=SimpleNamespace(name="GND"),
+        position=SimpleNamespace(x=1_000_000, y=2_000_000),
+        layer=0,
+    )
+    footprint = SimpleNamespace(
+        reference_field=SimpleNamespace(text=SimpleNamespace(value="U1")),
+        definition=SimpleNamespace(pads=[SimpleNamespace(id=SimpleNamespace(value="pad-1"))]),
+    )
+    board = SimpleNamespace(
+        get_nets=lambda: [SimpleNamespace(name="GND", class_name="Default")],
+        get_tracks=lambda: [],
+        get_vias=lambda: [],
+        get_pads=lambda: [pad],
+        get_footprints=lambda: [footprint],
+    )
+    monkeypatch.setattr("kicad_mcp.tools.net_analysis.get_board", lambda: board)
+    server = build_server("full")
+
+    payload = json.loads(await call_tool_text(server, "pcb_net_inspector", {"net_name": "GND"}))
+
+    assert payload["pad_count"] == 1
+    assert payload["footprint_pads"] == [{"reference": "U1", "pad": "1", "layer": "0"}]
+
+
+@pytest.mark.anyio
+async def test_net_inspector_file_fallback_parses_balanced_nested_footprints(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pcb_file = tmp_path / "nested.kicad_pcb"
+    pcb_file.write_text(
+        """(kicad_pcb
+  (version 20250216)
+  (net 1 "GND")
+  (footprint "Example:Nested"
+    (layer "F.Cu")
+    (property "Reference" "U1" (at 1 2) (layer "F.SilkS"))
+    (fp_rect (start -1 -1) (end 1 1)
+      (stroke (width 0.1) (type solid)) (fill none) (layer "F.CrtYd"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+  )
+)
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "kicad_mcp.tools.net_analysis._nets",
+        lambda: [{"name": "GND", "code": 1, "pad_count": 1}],
+    )
+    monkeypatch.setattr(
+        "kicad_mcp.tools.net_analysis.get_board",
+        lambda: (_ for _ in ()).throw(OSError("offline")),
+    )
+    monkeypatch.setattr("kicad_mcp.tools.net_analysis._get_pcb_file", lambda: pcb_file)
+    server = build_server("full")
+
+    payload = json.loads(await call_tool_text(server, "pcb_net_inspector", {"net_name": "GND"}))
+
+    assert payload["footprint_pads"] == [{"reference": "U1", "pad": "1", "layer": "F.Cu"}]

--- a/tests/unit/test_pcb_pad_mapping.py
+++ b/tests/unit/test_pcb_pad_mapping.py
@@ -1,0 +1,66 @@
+"""Live KiCad pad-to-footprint mapping regressions for issue #501."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from kicad_mcp.pcb.pad_mapping import (
+    footprint_pads,
+    map_pads_to_footprints,
+)
+
+
+def _pad(pad_id: str | None, number: str = "1") -> object:
+    identifier = SimpleNamespace(value=pad_id) if pad_id is not None else SimpleNamespace()
+    return SimpleNamespace(id=identifier, number=number)
+
+
+def _footprint(reference: str, pads: list[object]) -> object:
+    return SimpleNamespace(
+        reference_field=SimpleNamespace(text=SimpleNamespace(value=reference)),
+        definition=SimpleNamespace(pads=pads),
+    )
+
+
+def test_map_pads_uses_official_footprint_definition_pad_ids() -> None:
+    board_pad = _pad("pad-1")
+    footprint_pad = _pad("pad-1")
+
+    mapped = map_pads_to_footprints([board_pad], [_footprint("U1", [footprint_pad])])
+
+    assert len(mapped) == 1
+    assert mapped[0].pad is board_pad
+    assert mapped[0].pad_id == "pad-1"
+    assert mapped[0].reference == "U1"
+
+
+def test_map_pads_deduplicates_duplicate_board_pad_ids() -> None:
+    first = _pad("pad-1")
+    duplicate = _pad("pad-1")
+
+    mapped = map_pads_to_footprints([first, duplicate], [_footprint("U1", [_pad("pad-1")])])
+
+    assert [(item.pad, item.reference) for item in mapped] == [(first, "U1")]
+
+
+def test_map_pads_marks_conflicting_or_missing_ids_unmapped() -> None:
+    conflict = _pad("shared")
+    missing = _pad(None, number="2")
+    footprints = [
+        _footprint("U1", [_pad("shared")]),
+        _footprint("U2", [_pad("shared")]),
+    ]
+
+    mapped = map_pads_to_footprints([conflict, missing], footprints)
+
+    assert [(item.pad_id, item.reference) for item in mapped] == [
+        ("shared", None),
+        (None, None),
+    ]
+
+
+def test_footprint_pads_reads_definition_pads_and_ignores_unsupported_surfaces() -> None:
+    pads = [_pad("p1"), _pad("p2")]
+
+    assert footprint_pads(_footprint("U1", pads)) == pads
+    assert footprint_pads(SimpleNamespace()) == []


### PR DESCRIPTION
## Purpose

Fix KiCad 10 pad inspection and net-detail results by mapping authoritative live board pads to their containing footprint instances through supported KiPy relationships.

Closes #501.
Refs #495.

## Confirmed root cause

The affected code depended on two unsupported relationships:

- `pcb_get_pads` read `pad.parent.reference_field...`, but `kipy.board_types.Pad` has no `parent` attribute.
- `pcb_net_inspector` called `footprint.get_pads()`, but `FootprintInstance` has no such method.

When the live inspector path failed, it used a non-balanced footprint regex that stopped at the first closing parenthesis and could not reliably reach nested properties and pad blocks.

KiPy inspection confirms the supported model:

- board pads expose stable `pad.id.value` identifiers;
- `FootprintInstance.definition.pads` exposes the contained pads;
- the same pad ID can be used to enrich the authoritative `board.get_pads()` collection with footprint references.

## Changes

- add one FastMCP-independent live pad-to-footprint mapping helper
- map footprint references through `FootprintInstance.definition.pads` and stable pad IDs
- deduplicate repeated board pad IDs
- mark missing or conflicting IDs as explicitly unmapped instead of guessing
- route `pcb_get_pads` through the shared mapping
- preserve pad number, net name, coordinates, response limits, and total counts
- route live `pcb_net_inspector` details through the same authoritative mapping
- use the mapped pad collection for net `pad_count`, keeping counts and details consistent
- replace the nested-footprint regex fallback with the existing balanced PCB S-expression parser
- preserve public tool names and response schemas

## Verification

### Red-first regressions

Current `main` was reproduced before implementation:

- a KiCad 10-style pad without `parent` caused `pcb_get_pads` to raise `AttributeError`
- the same live board reported `pad_count: 1` and `footprint_pads: []` in `pcb_net_inspector`
- a nested PCB footprint fixture produced no file-backed pad details with the old regex

### Focused and integration tests

- pad mapping/basic inspection/net inspector focused suite: 17 passed
- existing registration and public PCB read/integration surface: 34 passed
- targeted pre-push hook: passed

Coverage includes:

- official `definition.pads` ID mapping
- duplicate board pad ID deduplication
- conflicting/missing IDs remaining unmapped
- parent-less KiCad 10 pad objects
- explicit `(unmapped)` output without crashing
- live inspector reference/pad/layer details
- consistent live pad counts
- balanced nested footprint file fallback

### Static and repository checks

- source/test Ruff format: 549 files clean
- source/test Ruff lint: passed
- strict mypy: 217 source files, no issues
- architecture boundaries: passed
- tool contract lint: passed
- generated tool reference check: passed
- staged pre-commit set: passed, including private-key and hardcoded-secret detection

### Full unit suite

Exact commit `5a939bca3395e3154744b16c2d58ef6c10a01833` was checked out on a clean MSI worker with:

- Node 24.11.0
- Python 3.13.12
- uv 0.10.8

The full unit suite completed at 100% with exit code 0. The only warning was the existing Windows fallback `AsyncMock` warning.

## Compatibility, risk, and rollback

Public tool names, inputs, and JSON/text response shapes remain compatible. Duplicate IDs are now normalized, and pads that cannot be mapped safely are shown as `(unmapped)` rather than causing a crash or receiving a guessed reference.

Rollback is a single revert of this PR.