### PR TITLE
fix: share project-aware footprint resolution

### DIFF
--- a/src/kicad_mcp/library_resolution.py
+++ b/src/kicad_mcp/library_resolution.py
@@ -1,0 +1,42 @@
+"""Active-project KiCad library resolution shared by tool surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import get_config
+from .utils.library_tables import (
+    footprint_library_dirs as discover_footprint_library_dirs,
+)
+from .utils.library_tables import resolve_footprint_file
+
+
+def active_project_dir() -> Path | None:
+    """Return the configured project directory used for KiCad table expansion."""
+    cfg = get_config()
+    if cfg.project_file is not None:
+        return cfg.project_file.parent
+    return cfg.project_dir
+
+
+def footprint_library_dirs() -> dict[str, Path]:
+    """Return all active configured and table-discovered footprint libraries."""
+    cfg = get_config()
+    return discover_footprint_library_dirs(
+        configured_root=cfg.footprint_library_dir,
+        project_dir=active_project_dir(),
+    )
+
+
+def footprint_file(library: str, footprint: str) -> Path:
+    """Resolve one footprint against the active project and KiCad configuration."""
+    cfg = get_config()
+    return resolve_footprint_file(
+        library,
+        footprint,
+        configured_root=cfg.footprint_library_dir,
+        project_dir=active_project_dir(),
+    )
+
+
+__all__ = ["active_project_dir", "footprint_file", "footprint_library_dirs"]

--- a/src/kicad_mcp/tools/library.py
+++ b/src/kicad_mcp/tools/library.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import threading
 from dataclasses import dataclass
@@ -13,6 +12,15 @@ from typing import Any, cast
 from mcp.server.fastmcp import FastMCP
 
 from ..config import get_config
+from ..library_resolution import (
+    active_project_dir as _project_dir,
+)
+from ..library_resolution import (
+    footprint_file as _footprint_file,
+)
+from ..library_resolution import (
+    footprint_library_dirs as _footprint_library_dirs,
+)
 from ..models import contract_verifier as cv
 from ..models.component_contracts import find_component_contract
 from ..models.verdict import Finding, Verdict, VerdictReport, stable_finding_id
@@ -25,6 +33,15 @@ from ..utils.component_search import (
     MouserClient,
     NexarClient,
     normalize_lcsc_code,
+)
+from ..utils.library_tables import (
+    lib_table_paths as _lib_table_paths,
+)
+from ..utils.library_tables import (
+    parse_lib_table as _parse_lib_table,
+)
+from ..utils.library_tables import (
+    resolve_kicad_env,
 )
 from ..utils.sexpr import _extract_block, _sexpr_string
 from .metadata import headless_compatible
@@ -49,74 +66,8 @@ def _footprint_library_dir() -> Path:
 
 
 def _resolve_kicad_env(uri: str, project_dir: Path | None) -> str:
-    """Substitute KiCad library-table variables (``${KIPRJMOD}``, ``${ENV}``) in a URI."""
-
-    def _sub(match: re.Match[str]) -> str:
-        name = match.group(1)
-        if name == "KIPRJMOD" and project_dir is not None:
-            return str(project_dir)
-        return os.environ.get(name, match.group(0))
-
-    return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", _sub, uri)
-
-
-def _parse_lib_table(path: Path, project_dir: Path | None) -> dict[str, Path]:
-    """Parse a KiCad sym-/fp-lib-table, returning ``{nickname: resolved_path}``.
-
-    Only ``KiCad``-type entries are returned (legacy/other plugin types are skipped),
-    with ``${KIPRJMOD}`` and environment-variable references resolved.
-    """
-    libs: dict[str, Path] = {}
-    try:
-        content = path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return libs
-    # Split into one chunk per (lib ...) entry; nested parens make a single regex for the
-    # whole entry unreliable, so parse name/type/uri within each chunk.
-    for chunk in re.split(r"\(lib\b", content)[1:]:
-        name = re.search(r'\(name\s+"?([^")\s]+)"?\)', chunk)
-        type_ = re.search(r'\(type\s+"?([^")\s]+)"?\)', chunk)
-        uri = re.search(r'\(uri\s+"([^"]+)"\)', chunk)
-        if not (name and uri):
-            continue
-        if type_ and type_.group(1).lower() != "kicad":
-            continue
-        resolved = Path(_resolve_kicad_env(uri.group(1), project_dir))
-        if resolved.exists():
-            libs[name.group(1)] = resolved
-    return libs
-
-
-def _lib_table_paths(table_name: str, project_dir: Path | None) -> list[Path]:
-    """Locate the project-level then global KiCad library tables of ``table_name``."""
-    paths: list[Path] = []
-    if project_dir is not None:
-        candidate = project_dir / table_name
-        if candidate.exists():
-            paths.append(candidate)
-    config_roots = [
-        os.environ.get("APPDATA"),
-        os.path.expanduser("~/.config"),
-        os.path.expanduser("~/Library/Preferences"),
-    ]
-    for root in config_roots:
-        if not root:
-            continue
-        kicad_root = Path(root) / "kicad"
-        if not kicad_root.is_dir():
-            continue
-        for version_dir in sorted(kicad_root.glob("*")):
-            candidate = version_dir / table_name
-            if candidate.exists():
-                paths.append(candidate)
-    return paths
-
-
-def _project_dir() -> Path | None:
-    cfg = get_config()
-    if cfg.project_file is not None:
-        return cfg.project_file.parent
-    return None
+    """Compatibility wrapper around shared KiCad environment substitution."""
+    return resolve_kicad_env(uri, project_dir)
 
 
 def _symbol_library_files() -> dict[str, Path]:
@@ -183,31 +134,6 @@ def _read_symbol_file(library: str) -> str | None:
     if path is None or not path.exists():
         return None
     return path.read_text(encoding="utf-8", errors="ignore")
-
-
-def _footprint_library_dirs() -> dict[str, Path]:
-    """Map every discoverable footprint-library nickname to its ``.pretty`` directory.
-
-    Combines the configured directory with project and global ``fp-lib-table`` entries
-    (issue #78), so footprint libraries registered through KiCad's library tables resolve.
-    """
-    dirs: dict[str, Path] = {}
-    cfg = get_config()
-    if cfg.footprint_library_dir is not None and cfg.footprint_library_dir.exists():
-        for pretty in sorted(cfg.footprint_library_dir.glob("*.pretty")):
-            dirs.setdefault(pretty.stem, pretty)
-    project_dir = _project_dir()
-    for table in _lib_table_paths("fp-lib-table", project_dir):
-        for nickname, pretty_path in _parse_lib_table(table, project_dir).items():
-            dirs.setdefault(nickname, pretty_path)
-    return dirs
-
-
-def _footprint_file(library: str, footprint: str) -> Path:
-    pretty_dir = _footprint_library_dirs().get(library)
-    if pretty_dir is None:
-        pretty_dir = _footprint_library_dir() / f"{library}.pretty"
-    return pretty_dir / f"{footprint}.kicad_mod"
 
 
 def _component_search_client(source: str) -> ComponentSearchClient:
@@ -611,7 +537,7 @@ def register(mcp: FastMCP) -> None:
     def lib_list_libraries() -> str:
         """List configured symbol and footprint libraries."""
         symbol_libs = sorted(path.stem for path in _symbol_library_dir().glob("*.kicad_sym"))
-        footprint_libs = sorted(path.name for path in _footprint_library_dir().glob("*.pretty"))
+        footprint_libs = sorted(f"{nickname}.pretty" for nickname in _footprint_library_dirs())
         lines = [f"Symbol libraries ({len(symbol_libs)} total):"]
         lines.extend(f"- {name}" for name in symbol_libs[:50])
         lines.append("")
@@ -757,14 +683,13 @@ def register(mcp: FastMCP) -> None:
         if page_size < 1:
             return "page_size must be >= 1."
         page_size = min(page_size, 500)
-        root = _footprint_library_dir()
         results: list[str] = []
-        for library in root.glob("*.pretty"):
-            if library_filter and library_filter.lower() not in library.stem.lower():
+        for nickname, library_dir in _footprint_library_dirs().items():
+            if library_filter and library_filter.lower() not in nickname.lower():
                 continue
-            for footprint in library.glob("*.kicad_mod"):
+            for footprint in library_dir.glob("*.kicad_mod"):
                 if query.lower() in footprint.stem.lower():
-                    results.append(f"{library.stem}:{footprint.stem}")
+                    results.append(f"{nickname}:{footprint.stem}")
         total = len(results)
         if total == 0:
             return f"No footprints matched '{query}'."
@@ -788,8 +713,8 @@ def register(mcp: FastMCP) -> None:
     @headless_compatible
     def lib_list_footprints(library: str) -> str:
         """List footprints in a specific library."""
-        library_dir = _footprint_library_dir() / f"{library}.pretty"
-        if not library_dir.exists():
+        library_dir = _footprint_library_dirs().get(library)
+        if library_dir is None or not library_dir.exists():
             return f"Footprint library '{library}' was not found."
         footprints = sorted(path.stem for path in library_dir.glob("*.kicad_mod"))
         lines = [f"Footprints in {library} ({len(footprints)} total):"]

--- a/src/kicad_mcp/tools/pcb.py
+++ b/src/kicad_mcp/tools/pcb.py
@@ -33,6 +33,7 @@ from mcp.server.fastmcp import FastMCP
 from ..config import get_config
 from ..connection import KiCadConnectionError, board_transaction, get_board
 from ..ipc.command_queue import get_command_queue
+from ..library_resolution import footprint_file as _footprint_file
 from ..models.common import _FootprintLike, _PadLike
 from ..models.pcb import (
     AddCircleInput,
@@ -2068,13 +2069,6 @@ def _inner_layer_graphic_block(
             f'(uuid "{uuid.uuid4()}"))'
         )
     raise ValueError("shape_type must be one of: line, rect, text.")
-
-
-def _footprint_file(library: str, footprint: str) -> Path:
-    cfg = get_config()
-    if cfg.footprint_library_dir is None or not cfg.footprint_library_dir.exists():
-        raise FileNotFoundError("No KiCad footprint library directory is configured.")
-    return cfg.footprint_library_dir / f"{library}.pretty" / f"{footprint}.kicad_mod"
 
 
 def _split_footprint_assignment(assignment: str) -> tuple[str, str]:

--- a/src/kicad_mcp/utils/library_tables.py
+++ b/src/kicad_mcp/utils/library_tables.py
@@ -1,0 +1,117 @@
+"""KiCad library-table discovery shared by library and PCB workflows."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def resolve_kicad_env(uri: str, project_dir: Path | None) -> str:
+    """Substitute KiCad table variables without erasing unknown values."""
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name == "KIPRJMOD" and project_dir is not None:
+            return str(project_dir)
+        return os.environ.get(name, match.group(0))
+
+    return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", _sub, uri)
+
+
+def parse_lib_table(path: Path, project_dir: Path | None) -> dict[str, Path]:
+    """Parse KiCad table entries into existing, resolved library paths."""
+    libraries: dict[str, Path] = {}
+    try:
+        content = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return libraries
+
+    for chunk in re.split(r"\(lib\b", content)[1:]:
+        name = re.search(r'\(name\s+"?([^")\s]+)"?\)', chunk)
+        type_ = re.search(r'\(type\s+"?([^")\s]+)"?\)', chunk)
+        uri = re.search(r'\(uri\s+"([^"]+)"\)', chunk)
+        if not (name and uri):
+            continue
+        if type_ and type_.group(1).lower() != "kicad":
+            continue
+        resolved = Path(resolve_kicad_env(uri.group(1), project_dir))
+        if resolved.exists():
+            libraries[name.group(1)] = resolved
+    return libraries
+
+
+def lib_table_paths(table_name: str, project_dir: Path | None) -> list[Path]:
+    """Locate project-level and then global KiCad library tables."""
+    paths: list[Path] = []
+    if project_dir is not None:
+        candidate = project_dir / table_name
+        if candidate.exists():
+            paths.append(candidate)
+
+    config_roots = [
+        os.environ.get("APPDATA"),
+        os.path.expanduser("~/.config"),
+        os.path.expanduser("~/Library/Preferences"),
+    ]
+    for root in config_roots:
+        if not root:
+            continue
+        kicad_root = Path(root) / "kicad"
+        if not kicad_root.is_dir():
+            continue
+        for version_dir in sorted(kicad_root.glob("*")):
+            candidate = version_dir / table_name
+            if candidate.exists():
+                paths.append(candidate)
+    return paths
+
+
+def footprint_library_dirs(
+    *,
+    configured_root: Path | None,
+    project_dir: Path | None,
+) -> dict[str, Path]:
+    """Map discoverable footprint nicknames to their ``.pretty`` directories."""
+    directories: dict[str, Path] = {}
+    if configured_root is not None and configured_root.exists():
+        for pretty in sorted(configured_root.glob("*.pretty")):
+            directories.setdefault(pretty.stem, pretty)
+
+    for table in lib_table_paths("fp-lib-table", project_dir):
+        for nickname, pretty_path in parse_lib_table(table, project_dir).items():
+            directories.setdefault(nickname, pretty_path)
+    return directories
+
+
+def resolve_footprint_file(
+    library: str,
+    footprint: str,
+    *,
+    configured_root: Path | None,
+    project_dir: Path | None,
+) -> Path:
+    """Resolve one footprint through configured and table-based libraries."""
+    pretty_dir = footprint_library_dirs(
+        configured_root=configured_root,
+        project_dir=project_dir,
+    ).get(library)
+    if pretty_dir is not None:
+        return pretty_dir / f"{footprint}.kicad_mod"
+
+    if configured_root is not None and configured_root.exists():
+        return configured_root / f"{library}.pretty" / f"{footprint}.kicad_mod"
+
+    raise FileNotFoundError(
+        f"Footprint library '{library}' was not found in configured directories "
+        "or KiCad fp-lib-table entries."
+    )
+
+
+__all__ = [
+    "footprint_library_dirs",
+    "lib_table_paths",
+    "parse_lib_table",
+    "resolve_footprint_file",
+    "resolve_kicad_env",
+]

--- a/tests/integration/test_library_tools_extended.py
+++ b/tests/integration/test_library_tools_extended.py
@@ -513,3 +513,52 @@ async def test_library_live_component_edge_cases(
     assert "Footprint hint" not in no_auto_footprint
     assert "Could not update schematic properties" in update_failed
     assert ("U2", "LCSC", "C999") in updates
+
+
+@pytest.mark.anyio
+async def test_project_fp_lib_table_is_visible_to_library_tools(
+    sample_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kicad_mcp.config import reset_config
+
+    pretty_dir = sample_project / "footprints" / "Gateway.pretty"
+    pretty_dir.mkdir(parents=True)
+    (pretty_dir / "Custom.kicad_mod").write_text(
+        (
+            '(footprint "Custom"\n'
+            '\t(layer "F.Cu")\n'
+            '\t(property "Reference" "REF**")\n'
+            '\t(property "Value" "Custom")\n'
+            ")\n"
+        ),
+        encoding="utf-8",
+    )
+    (sample_project / "fp-lib-table").write_text(
+        '(fp_lib_table (lib (name "Gateway") (type "KiCad") '
+        '(uri "${KIPRJMOD}/footprints/Gateway.pretty") (options "") (descr "")))\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("KICAD_MCP_FOOTPRINT_LIBRARY_DIR")
+    reset_config()
+
+    server = build_server("full")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
+
+    libraries = await call_tool_text(server, "lib_list_libraries", {})
+    search = await call_tool_text(server, "lib_search_footprints", {"query": "Custom"})
+    listing = await call_tool_text(
+        server,
+        "lib_list_footprints",
+        {"library": "Gateway"},
+    )
+    info = await call_tool_text(
+        server,
+        "lib_get_footprint_info",
+        {"library": "Gateway", "footprint": "Custom"},
+    )
+
+    assert "Gateway.pretty" in libraries
+    assert "Gateway:Custom" in search
+    assert "- Custom" in listing
+    assert "Footprint: Gateway:Custom" in info

--- a/tests/integration/test_pcb_tools.py
+++ b/tests/integration/test_pcb_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -1458,3 +1459,68 @@ async def test_pcb_sync_from_root_collects_linked_child_sheet_components(
     assert "No schematic symbols were found" not in result
     assert "New footprints added: 1" in result
     assert '(property "Reference" "R9"' in pcb_text
+
+
+@pytest.mark.anyio
+async def test_pcb_sync_from_schematic_resolves_project_fp_lib_table(
+    sample_project: Path,
+    mock_kicad,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kicad_mcp.config import reset_config
+
+    _allow_schematic_sync(monkeypatch)
+    monkeypatch.setattr("kicad_mcp.tools.pcb._board_is_open", lambda: False)
+    monkeypatch.setattr(
+        "kicad_mcp.tools.pcb._export_schematic_net_map",
+        lambda: ({("J1", "1"): "VIN", ("J1", "2"): "GND"}, ""),
+    )
+
+    pretty_dir = sample_project / "footprints" / "Gateway.pretty"
+    pretty_dir.mkdir(parents=True)
+    (pretty_dir / "Custom.kicad_mod").write_text(
+        (
+            '(footprint "Custom"\n'
+            '\t(layer "F.Cu")\n'
+            '\t(property "Reference" "REF**" (at 0 -1 0) (layer "F.SilkS"))\n'
+            '\t(property "Value" "Custom" (at 0 1 0) (layer "F.Fab"))\n'
+            '\t(pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu"))\n'
+            '\t(pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu"))\n'
+            ")\n"
+        ),
+        encoding="utf-8",
+    )
+    (sample_project / "fp-lib-table").write_text(
+        '(fp_lib_table (lib (name "Gateway") (type "KiCad") '
+        '(uri "${KIPRJMOD}/footprints/Gateway.pretty") (options "") (descr "")))\n',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("KICAD_MCP_FOOTPRINT_LIBRARY_DIR")
+    reset_config()
+
+    server = build_server("full")
+    await call_tool_text(
+        server,
+        "sch_build_circuit",
+        {
+            "symbols": [
+                {
+                    "library": "Device",
+                    "symbol_name": "R",
+                    "reference": "J1",
+                    "value": "Custom",
+                    "footprint": "Gateway:Custom",
+                    "x_mm": 50.8,
+                    "y_mm": 50.8,
+                }
+            ]
+        },
+    )
+
+    result = await call_tool_text(server, "pcb_sync_from_schematic", {})
+    pcb_text = (sample_project / "demo.kicad_pcb").read_text(encoding="utf-8")
+
+    assert "New footprints added: 1" in result
+    assert '(property "Reference" "J1"' in pcb_text
+    assert '(net "VIN")' in pcb_text
+    assert '(net "GND")' in pcb_text

--- a/tests/unit/test_library_discovery.py
+++ b/tests/unit/test_library_discovery.py
@@ -48,3 +48,129 @@ def test_parse_lib_table_resolves_kiprjmod_and_skips_non_kicad(tmp_path: Path) -
 
 def test_parse_lib_table_handles_unreadable_table(tmp_path: Path) -> None:
     assert _parse_lib_table(tmp_path / "does-not-exist", tmp_path) == {}
+
+
+def test_shared_footprint_resolver_finds_project_table_entry(tmp_path: Path) -> None:
+    from kicad_mcp.utils.library_tables import resolve_footprint_file
+
+    project_dir = tmp_path / "project"
+    pretty_dir = project_dir / "footprints" / "Gateway.pretty"
+    pretty_dir.mkdir(parents=True)
+    footprint = pretty_dir / "Custom.kicad_mod"
+    footprint.write_text('(footprint "Custom")\n', encoding="utf-8")
+    (project_dir / "fp-lib-table").write_text(
+        '(fp_lib_table (lib (name "Gateway") (type "KiCad") '
+        '(uri "${KIPRJMOD}/footprints/Gateway.pretty") (options "") (descr "")))\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_footprint_file(
+            "Gateway",
+            "Custom",
+            configured_root=None,
+            project_dir=project_dir,
+        )
+        == footprint
+    )
+
+
+def test_shared_footprint_resolver_preserves_configured_root_fallback(tmp_path: Path) -> None:
+    from kicad_mcp.utils.library_tables import resolve_footprint_file
+
+    configured_root = tmp_path / "footprints"
+    configured_root.mkdir()
+
+    assert (
+        resolve_footprint_file(
+            "Resistor_SMD",
+            "R_0805",
+            configured_root=configured_root,
+            project_dir=None,
+        )
+        == configured_root / "Resistor_SMD.pretty" / "R_0805.kicad_mod"
+    )
+
+
+def test_shared_footprint_resolver_rejects_unknown_library(tmp_path: Path) -> None:
+    from kicad_mcp.utils.library_tables import resolve_footprint_file
+
+    with pytest.raises(FileNotFoundError, match="fp-lib-table"):
+        resolve_footprint_file(
+            "Missing",
+            "Unknown",
+            configured_root=None,
+            project_dir=tmp_path,
+        )
+
+
+def test_library_and_pcb_resolvers_return_same_project_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from kicad_mcp.tools import library as library_mod
+    from kicad_mcp.tools import pcb as pcb_mod
+
+    project_dir = tmp_path / "project"
+    pretty_dir = project_dir / "footprints" / "Gateway.pretty"
+    pretty_dir.mkdir(parents=True)
+    footprint = pretty_dir / "Custom.kicad_mod"
+    footprint.write_text('(footprint "Custom")\n', encoding="utf-8")
+    project_file = project_dir / "demo.kicad_pro"
+    project_file.write_text("{}\n", encoding="utf-8")
+    (project_dir / "fp-lib-table").write_text(
+        '(fp_lib_table (lib (name "Gateway") (type "KiCad") '
+        '(uri "${KIPRJMOD}/footprints/Gateway.pretty") (options "") (descr "")))\n',
+        encoding="utf-8",
+    )
+    config = SimpleNamespace(
+        project_file=project_file,
+        project_dir=project_dir,
+        footprint_library_dir=None,
+    )
+    monkeypatch.setattr("kicad_mcp.library_resolution.get_config", lambda: config)
+
+    assert library_mod._footprint_file is pcb_mod._footprint_file
+    assert library_mod._footprint_file("Gateway", "Custom") == footprint
+    assert pcb_mod._footprint_file("Gateway", "Custom") == footprint
+
+
+def test_active_project_dir_falls_back_to_project_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from kicad_mcp.library_resolution import active_project_dir
+
+    config = SimpleNamespace(project_file=None, project_dir=tmp_path)
+    monkeypatch.setattr("kicad_mcp.library_resolution.get_config", lambda: config)
+
+    assert active_project_dir() == tmp_path
+
+
+def test_parse_lib_table_skips_entry_without_uri(tmp_path: Path) -> None:
+    table = tmp_path / "fp-lib-table"
+    table.write_text(
+        '(fp_lib_table (lib (name "Broken") (type "KiCad")))\n',
+        encoding="utf-8",
+    )
+
+    assert _parse_lib_table(table, tmp_path) == {}
+
+
+def test_lib_table_paths_discovers_global_kicad_table(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kicad_mcp.utils.library_tables import lib_table_paths
+
+    appdata = tmp_path / "appdata"
+    table = appdata / "kicad" / "10.0" / "fp-lib-table"
+    table.parent.mkdir(parents=True)
+    table.write_text("(fp_lib_table)\n", encoding="utf-8")
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    assert table in lib_table_paths("fp-lib-table", project_dir=None)


### PR DESCRIPTION
## Purpose

Use one project-aware footprint resolver across library tools and schematic-to-PCB synchronization.

Closes #503.
Refs #495.

## Confirmed root cause

Current `main` contained two different `_footprint_file` implementations:

- the library path resolved configured directories plus project/global `fp-lib-table` entries;
- the PCB sync path only checked `cfg.footprint_library_dir`.

A red-first reproduction created a project-local `Gateway.pretty` library registered only through `${KIPRJMOD}/footprints/Gateway.pretty`. With no configured global footprint directory, the library resolver found `Gateway:Custom`, while `pcb_sync_from_schematic` returned `NOT_FOUND`.

## Changes

- add a FastMCP-independent KiCad library-table resolver
- add one active-project resolution facade used by all tool surfaces
- resolve `${KIPRJMOD}` and configured environment variables without erasing unknown variables
- discover project tables before global KiCad tables
- retain configured global `.pretty` directory compatibility
- skip unsupported/non-KiCad, missing, malformed, or unreadable table entries safely
- keep missing-library failures explicit rather than guessing another library
- route both `tools.library` and `tools.pcb` through the same `_footprint_file` function object
- remove all local duplicate `_footprint_file` implementations
- make project-table footprints visible to library list/search/list/info tools
- make project-table footprints usable by `pcb_sync_from_schematic`
- preserve existing tool names, inputs, output formats, and configured-root behavior

## Verification

### Red-first regressions

Before implementation:

- importing the proposed shared resolver failed because no shared module existed;
- `pcb_sync_from_schematic` returned `NOT_FOUND` for a valid project-only footprint;
- the existing library resolver found the same footprint under the same configuration.

After implementation:

- a `${KIPRJMOD}` project table resolves correctly;
- project/global/configured discovery paths are covered;
- library and PCB modules use the same resolver function object;
- project-local footprints appear in library list/search/list/info results;
- schematic-to-PCB sync adds the project-local footprint and transfers named pad nets;
- configured-root fallback and explicit unknown-library failure remain intact.

### Focused and repository checks

- shared active/low-level resolver coverage: **100%**
- related library, contract, and PCB integration package: **65 passed**
- targeted pre-push tests: **46 passed**
- Ruff format/lint: **551 files clean**
- strict mypy: **219 source files, no issues**
- architecture boundary check: passed
- tool-contract lint: passed
- generated tools reference: passed
- staged pre-commit set: passed, including private-key and hardcoded-secret detection

### Clean-worker full suite

Exact commit `8d650b822dfc146c331089baa9a8d974d9218d7c` was checked out on a clean MSI worker with Node 24.11.0, Python 3.13.12, and uv 0.10.8.

The full unit/integration/e2e suite completed with exit code 0. Repository coverage was **87.76%**, above the required **83%** threshold. The only warnings were the existing Windows fallback `AsyncMock` warning and existing MCP experimental-task deprecation warnings.

## Compatibility, risk, and rollback

No public MCP tool contracts or response shapes change. Resolution becomes more complete and consistent, while unknown libraries continue to fail explicitly.

Rollback is a single revert of this PR.
