### PR TITLE
eval: promote MiniMax to required release gate

### DIFF
--- a/.github/workflows/live-model-release-gate.yml
+++ b/.github/workflows/live-model-release-gate.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-nano-30b-a3b
-          - nvidia-mistral-medium-3-5-128b
+          - nvidia-minimax-m3
           - opencode-cli-nemotron-3-ultra-free
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -154,7 +154,7 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-nano-30b-a3b
-          - nvidia-mistral-medium-3-5-128b
+          - nvidia-minimax-m3
           - opencode-cli-nemotron-3-ultra-free
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/evals/live/baselines.yaml
+++ b/evals/live/baselines.yaml
@@ -9,6 +9,6 @@ evidence:
 minimum_repeats: 3
 required_configurations:
   - nvidia-nemotron-3-nano-30b-a3b
-  - nvidia-mistral-medium-3-5-128b
+  - nvidia-minimax-m3
   - opencode-cli-nemotron-3-ultra-free
 configurations: {}

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -18,12 +18,12 @@ THRESHOLDS = ROOT / "evals/tool_selection/thresholds.yaml"
 
 CONFIG_IDS = (
     "nvidia-nemotron-3-nano-30b-a3b",
-    "nvidia-mistral-medium-3-5-128b",
+    "nvidia-minimax-m3",
     "opencode-cli-nemotron-3-ultra-free",
 )
 MODELS = (
     "nvidia/nemotron-3-nano-30b-a3b",
-    "mistralai/mistral-medium-3.5-128b",
+    "minimaxai/minimax-m3",
     "nemotron-3-ultra-free",
 )
 HOSTS = ("nvidia-nim", "nvidia-nim", "opencode-zen-cli")
@@ -48,7 +48,7 @@ COMMANDS = (
         "--model",
         MODELS[1],
         "--timeout-seconds",
-        "65",
+        "90",
         "--structured-output",
         "none",
     ),
@@ -407,6 +407,7 @@ def test_release_gate_workflow_is_main_only_protected_and_sequential() -> None:
     for config_id in CONFIG_IDS:
         assert config_id in workflow
     for nonblocking_id in (
+        "nvidia-mistral-medium-3-5-128b",
         "nvidia-gemma-4-31b-it",
         "nvidia-llama-3-3-70b-instruct",
         "opencode-deepseek-v4-flash-free",


### PR DESCRIPTION
## Summary

- replace the unavailable Mistral Medium 3.5 entry in both protected release-gate matrices with the already committed MiniMax M3 configuration
- update the unapproved baseline required-configuration list without approving or populating baseline metrics
- update the release-gate contract test for MiniMax's reviewed model id and 90/95-second provider/subprocess budget
- keep Mistral configured as a nonblocking diagnostic candidate

## Promotion evidence

All three independent full-corpus runs used exact revision `703ff82a60341dc24ec5bb39524fd5c3b155ca53` and configuration `nvidia-minimax-m3`:

- `30782216217`: 65/65 passed; evidence SHA-256 `e7fd4983bb1cd289f32c73247b23d2540cfad01dc945106aca682f73e6788307`
- `30783757590`: 65/65 passed; evidence SHA-256 `bcc0d5cc0969860d6eaea289a54dedc3ccb70f600c51bf79430b1d08956cd77b`
- `30785439060`: 65/65 passed; evidence SHA-256 `b317c28b91eec852090dfd1bad3931d95c87f5be20b7fcda18b146ae718a2148`

Across each run: adapter, selection, safety, forbidden-call, call-limit, unnecessary-call, and general violation counters were zero; pipeline and thresholds passed.

## Verification

- TDD RED: updated blocking test contract failed while workflow and baseline still referenced Mistral
- TDD GREEN: release-gate contract tests passed after the three-file promotion change
- live runner and NVIDIA adapter unit suites passed
- Ruff format/lint and workflow validation passed
- commit hooks and targeted pre-push hook passed

## Boundaries

This PR does not approve the baseline, populate metrics, run the blocking 3-repeat release gate, merge the release PR, or publish/deploy a release. Those steps remain gated on post-merge exact-SHA evidence.

Related to #492 and #408.