### PR TITLE
test(bridge): avoid leaked coroutine mock

### DIFF
--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -133,7 +133,7 @@ def test_bridge_stop_process_not_found(
 
 
 @patch("kicad_mcp.bridge._bridge_pid_path")
-@patch("kicad_mcp.bridge._bridge_server")
+@patch("kicad_mcp.bridge._bridge_server", new_callable=MagicMock)
 def test_start_daemon_unix(
     mock_bridge_server: MagicMock,
     mock_pid_path: MagicMock,
@@ -166,7 +166,8 @@ def test_start_daemon_unix(
         with patch.object(sys.stdin, "close", mock_close), patch("asyncio.run") as mock_asyncio_run:
             _start_daemon(state)
             mock_close.assert_called_once()
-            mock_asyncio_run.assert_called_once()
+            mock_bridge_server.assert_called_once_with(state)
+            mock_asyncio_run.assert_called_once_with(mock_bridge_server.return_value)
     finally:
         # Restore or remove temporary attribute
         if fork_fn is not None:


### PR DESCRIPTION
## Summary

- patch the async `_bridge_server` dependency with a synchronous `MagicMock` in the Unix daemon unit test
- assert that the child path passes the mock result into `asyncio.run`
- prevent the coroutine object from leaking into later tests and pytest shutdown

## Reproduction before the fix

```bash
uv run pytest \
  tests/unit/test_bridge.py::test_start_daemon_unix \
  tests/unit/test_bridge.py::test_start_daemon_windows_fallback \
  -W error::RuntimeWarning \
  -W error::pytest.PytestUnraisableExceptionWarning
```

The tests appeared to pass, but pytest exited with code 1 during teardown because the `AsyncMock` coroutine was never awaited.

## Validation

- focused two-test reproduction with `RuntimeWarning` and `PytestUnraisableExceptionWarning` treated as errors
- all 15 tests in `tests/unit/test_bridge.py` with the same warnings-as-errors policy
- Ruff format check for the modified test file
- Ruff lint for the modified test file
- `git diff --check`

## Scope

This is a test-fixture correction only. It does not change the production bridge daemon lifecycle.

Closes #575