### PR TITLE
security(gui): publish installer release evidence

### DIFF
--- a/.github/actions-policy.json
+++ b/.github/actions-policy.json
@@ -54,7 +54,10 @@
     },
     "gui-release.yml": {
       "create-release": [
-        "contents"
+        "artifact-metadata",
+        "attestations",
+        "contents",
+        "id-token"
       ]
     },
     "publish-mcp-container.yml": {

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, e.g. kicad-mcp-gui-v3.9.1"
+        description: "Existing GUI release tag, e.g. kicad-mcp-gui-v3.30.1"
         required: true
         type: string
 
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
@@ -67,7 +68,7 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # Apple signing secrets are not configured → skip codesigning on macOS
+          # Apple signing secrets are not configured - skip codesigning on macOS.
           TAURI_SKIP_CODESIGNING: ${{ runner.os == 'macOS' && '1' || '' }}
         run: cargo tauri build ${{ matrix.args }} -- --locked
 
@@ -91,12 +92,16 @@ jobs:
     needs: tauri-build
     runs-on: ubuntu-24.04
     permissions:
+      artifact-metadata: write
+      attestations: write
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Download all Tauri bundles
         env:
@@ -104,7 +109,8 @@ jobs:
         run: |
           gh run download ${{ github.run_id }} --repo ${{ github.repository }} --dir artifacts
 
-      - name: Upload installers to GitHub Release
+      - name: Prepare release inventory
+        id: release-context
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
@@ -113,6 +119,7 @@ jobs:
 
           TAG="$RELEASE_TAG"
           REPO="${{ github.repository }}"
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
 
           case "$TAG" in
             kicad-mcp-gui-v*) ;;
@@ -122,16 +129,21 @@ jobs:
               ;;
           esac
 
+          tag_commit="$(git rev-parse "${TAG}^{commit}" 2>/dev/null || true)"
+          if [ -z "$tag_commit" ]; then
+            echo "::error::GUI release tag must already exist: $TAG"
+            exit 1
+          fi
+          if [ "$tag_commit" != "$SOURCE_COMMIT" ]; then
+            echo "::error::Checked-out source commit does not match $TAG"
+            exit 1
+          fi
+
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-            echo "Release $TAG does not exist yet, creating..."
-            gh release create "$TAG" --repo "$REPO" \
-              --title "$TAG" \
-              --target "$GITHUB_SHA" \
-              --generate-notes
+            gh release create "$TAG" --repo "$REPO" --verify-tag --title "$TAG" --generate-notes
           fi
 
           mkdir -p release-assets
-
           mapfile -d '' installers < <(
             find artifacts -type f \( \
               -name '*.deb' -o \
@@ -154,16 +166,69 @@ jobs:
               *linux-tauri*|*linux*) os="linux" ;;
               *windows-tauri*|*windows*) os="windows" ;;
               *macos-tauri*|*macos*|*darwin*) os="macos" ;;
-              *) os="other" ;;
+              *)
+                echo "::error::Could not classify installer platform: $f"
+                exit 1
+                ;;
             esac
 
             base="$(basename "$f" | tr ' ' '-')"
             target="release-assets/${os}_${base}"
+            if [ -e "$target" ]; then
+              echo "::error::Duplicate normalized installer name: $target"
+              exit 1
+            fi
             cp "$f" "$target"
             echo "Prepared ($os): $target"
           done
 
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "source_commit=$SOURCE_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GUI release evidence
+        run: |
+          python3 scripts/generate_gui_release_evidence.py generate \
+            --artifact-dir release-assets \
+            --output-dir release-evidence/gui \
+            --cargo-lock src-tauri/Cargo.lock \
+            --source-commit "${{ steps.release-context.outputs.source_commit }}" \
+            --release-tag "${{ steps.release-context.outputs.tag }}"
+
+      - name: Verify GUI release evidence before publication
+        run: |
+          python3 scripts/generate_gui_release_evidence.py verify-local \
+            --artifact-dir release-assets \
+            --evidence-dir release-evidence/gui
+
+      - name: Attest GUI installers
+        id: attest-gui
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-checksums: release-evidence/gui/kicad-mcp-pro-gui-SHA256SUMS.txt
+          sbom-path: release-evidence/gui/kicad-mcp-pro-gui-sbom.cdx.json
+
+      - name: Upload installers and evidence to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release-context.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cp release-evidence/gui/* release-assets/
           ls -lh release-assets
           gh release upload "$TAG" release-assets/* --repo "$REPO" --clobber
 
-          echo "::notice::Installers uploaded to $REPO/releases/tag/$TAG"
+      - name: Verify published GUI release inventory
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release-context.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          rm -rf published-assets
+          mkdir -p published-assets
+          gh release download "$TAG" --repo "$REPO" --dir published-assets --clobber
+          python3 scripts/generate_gui_release_evidence.py verify-published \
+            --published-dir published-assets \
+            --evidence published-assets/kicad-mcp-pro-gui-release-evidence.json
+          echo "::notice::GUI release inventory verified for $REPO/releases/tag/$TAG"

--- a/docs/security/release-integrity.md
+++ b/docs/security/release-integrity.md
@@ -106,6 +106,27 @@ cosign verify \
 The Docker workflow publishes BuildKit provenance and SBOM attestations only
 when the image is pushed.
 
+## GUI installer integrity
+
+The Tauri GUI release workflow builds the Linux, Windows, and macOS installers from the exact `kicad-mcp-gui-v*` tag commit and publishes three evidence files with the installers:
+
+```text
+kicad-mcp-pro-gui-SHA256SUMS.txt
+kicad-mcp-pro-gui-sbom.cdx.json
+kicad-mcp-pro-gui-release-evidence.json
+```
+
+The evidence JSON records the source commit, release tag, normalized installer inventory, platform classification, size, SHA-256 digest, and the actual platform-signing status. The CycloneDX 1.6 SBOM is generated deterministically from the committed `src-tauri/Cargo.lock`. Before publication the workflow verifies the installer directory against the generated evidence; after upload it downloads the GitHub Release assets and requires the published inventory and installer digests to match exactly.
+
+Verify a downloaded GUI installer with the published checksum file and GitHub attestation:
+
+```bash
+sha256sum --check kicad-mcp-pro-gui-SHA256SUMS.txt
+gh attestation verify <installer-file> --repo oaslananka/kicad-mcp-pro
+```
+
+The GitHub attestation proves CI/source provenance for the installer digest; it is not a substitute for platform code signing. Windows Authenticode, Apple code signing/notarization, and Linux package signing remain separately reported and must not be inferred from the GitHub attestation.
+
 ## PyPI Trusted Publishing
 
 The Python workflow uses short-lived GitHub OIDC credentials and PyPI Trusted

--- a/docs/security/release-security.md
+++ b/docs/security/release-security.md
@@ -30,7 +30,7 @@ The normal release path is documented in [`../release-process.md`](../release-pr
 | npm wrapper `kicad-mcp-pro` | `.github/workflows/publish-npm.yml` | npm tarball, SHA256 checksums, SBOM, provenance, post-publish digest verification |
 | Protocol schemas npm package | `.github/workflows/publish-protocol-schemas.yml` | npm tarball, SHA256 checksums, SBOM, provenance, post-publish digest verification |
 | Docker image | `.github/workflows/publish-mcp-container.yml` | multi-arch image, labels, SBOM/provenance from buildx, Trivy scan, GHCR digest |
-| Tauri GUI installers | `.github/workflows/gui-release.yml` | platform installer bundles attached to the matching GUI release |
+| Tauri GUI installers | `.github/workflows/gui-release.yml` | Linux/Windows/macOS installer inventory, SHA256 checksums, Cargo-lock CycloneDX SBOM, GitHub artifact attestation, and exact post-publish asset verification |
 | MCP Registry manifest | `.github/workflows/publish-mcp-registry.yml` | manifest validation, package availability verification, registry publish step |
 
 ## Required controls

--- a/docs/security/release-signing.md
+++ b/docs/security/release-signing.md
@@ -17,7 +17,9 @@ KiCad MCP Pro uses artifact-specific release verification instead of relying on 
 | npm wrapper | npm provenance, SHA256 checksums, SBOM, GitHub artifact attestations |
 | Protocol schemas package | npm provenance, SHA256 checksums, SBOM, GitHub artifact attestations |
 | Docker image | digest-pinned image references, BuildKit provenance/SBOM, Trivy scan, and keyless cosign signature for GHCR image digests |
-| GUI bundles | release workflow evidence and platform-specific release notes; platform code signing may be unavailable unless vendor credentials are configured |
+| GUI bundles | SHA256 checksums, Cargo-lock CycloneDX SBOM, GitHub artifact attestation, exact published-asset verification, and explicit platform-signing status |
+
+GitHub artifact attestations bind GUI installer digests and the SBOM to the canonical workflow identity. They do **not** replace Authenticode, Apple code signing/notarization, or Linux package-repository signing. Until vendor signing credentials are configured, the GUI evidence records those platform-signing states as unsigned/unnotarized rather than implying a stronger guarantee.
 
 ## Maintainer checklist
 

--- a/scripts/generate_gui_release_evidence.py
+++ b/scripts/generate_gui_release_evidence.py
@@ -1,0 +1,368 @@
+"""Generate and verify integrity evidence for Tauri GUI release installers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tomllib
+import uuid
+from pathlib import Path
+from typing import Any, cast
+
+CHECKSUM_NAME = "kicad-mcp-pro-gui-SHA256SUMS.txt"
+SBOM_NAME = "kicad-mcp-pro-gui-sbom.cdx.json"
+EVIDENCE_NAME = "kicad-mcp-pro-gui-release-evidence.json"
+REQUIRED_PLATFORMS = ("linux", "windows", "macos")
+PLATFORM_SIGNING: dict[str, dict[str, str]] = {
+    "linux": {"packageSigning": "unsigned"},
+    "windows": {"authenticode": "unsigned"},
+    "macos": {"codeSigning": "unsigned", "notarization": "not-notarized"},
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _platform_for(path: Path) -> str | None:
+    suffix = path.suffix.lower()
+    if suffix in {".deb", ".rpm", ".appimage"}:
+        return "linux"
+    if suffix in {".msi", ".exe"}:
+        return "windows"
+    if suffix == ".dmg":
+        return "macos"
+    return None
+
+
+def _installer_inventory(artifact_dir: Path) -> list[tuple[Path, str]]:
+    files = sorted(
+        (path for path in artifact_dir.iterdir() if path.is_file()),
+        key=lambda item: item.name.lower(),
+    )
+    inventory: list[tuple[Path, str]] = []
+    for path in files:
+        platform = _platform_for(path)
+        if platform is None:
+            raise SystemExit(f"unsupported installer artifact: {path.name}")
+        inventory.append((path, platform))
+    if not inventory:
+        raise SystemExit(f"No supported GUI installers found in {artifact_dir}.")
+    for artifact, _platform in inventory:
+        if artifact.stat().st_size == 0:
+            raise SystemExit(f"installer is empty: {artifact.name}")
+    present = {platform for _path, platform in inventory}
+    for platform in REQUIRED_PLATFORMS:
+        if platform not in present:
+            raise SystemExit(f"missing required installer platform: {platform}")
+    return inventory
+
+
+def _read_cargo_lock(cargo_lock: Path) -> dict[str, Any]:
+    with cargo_lock.open("rb") as handle:
+        return cast(dict[str, Any], tomllib.load(handle))
+
+
+def _bom_ref(package: dict[str, Any]) -> str:
+    return f"pkg:cargo/{package['name']}@{package['version']}"
+
+
+def _dependency_ref(
+    dependency: str,
+    packages_by_name: dict[str, list[dict[str, Any]]],
+) -> str:
+    parts = dependency.split()
+    name = parts[0]
+    candidates = packages_by_name.get(name, [])
+    if len(parts) >= 2:
+        version = parts[1]
+        candidates = [package for package in candidates if str(package.get("version")) == version]
+    if len(candidates) != 1:
+        raise SystemExit(f"Could not resolve Cargo.lock dependency entry: {dependency}")
+    return _bom_ref(candidates[0])
+
+
+def _cargo_dependency_graph(packages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    packages_by_name: dict[str, list[dict[str, Any]]] = {}
+    for package in packages:
+        packages_by_name.setdefault(str(package["name"]), []).append(package)
+
+    graph: list[dict[str, Any]] = []
+    for package in sorted(packages, key=lambda item: _bom_ref(item)):
+        dependencies = package.get("dependencies", [])
+        if not isinstance(dependencies, list):
+            raise SystemExit(f"Invalid Cargo.lock dependency list for {_bom_ref(package)}")
+        graph.append(
+            {
+                "ref": _bom_ref(package),
+                "dependsOn": sorted(
+                    {
+                        _dependency_ref(str(dependency), packages_by_name)
+                        for dependency in dependencies
+                    }
+                ),
+            }
+        )
+    return graph
+
+
+def _cargo_sbom(cargo_lock: Path, inventory: list[tuple[Path, str]]) -> dict[str, Any]:
+    payload = _read_cargo_lock(cargo_lock)
+    packages = [package for package in payload.get("package", []) if isinstance(package, dict)]
+    root = next(
+        (
+            package
+            for package in packages
+            if package.get("name") == "kicad-mcp-pro" and package.get("source") is None
+        ),
+        None,
+    )
+    if root is None:
+        raise SystemExit(f"Cargo.lock has no kicad-mcp-pro root package: {cargo_lock}")
+
+    components: list[dict[str, Any]] = []
+    for package in sorted(
+        (package for package in packages if package is not root),
+        key=lambda item: (str(item.get("name", "")), str(item.get("version", ""))),
+    ):
+        name = str(package["name"])
+        version = str(package["version"])
+        component: dict[str, Any] = {
+            "type": "library",
+            "name": name,
+            "version": version,
+            "purl": _bom_ref(package),
+            "bom-ref": _bom_ref(package),
+        }
+        checksum = package.get("checksum")
+        if isinstance(checksum, str) and checksum:
+            component["hashes"] = [{"alg": "SHA-256", "content": checksum}]
+        components.append(component)
+
+    artifact_subject = "|".join(f"{path.name}:{_sha256(path)}" for path, _ in inventory)
+    lock_digest = _sha256(cargo_lock)
+    serial = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"kicad-mcp-pro-gui:{root['version']}:{lock_digest}:{artifact_subject}",
+    )
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "serialNumber": f"urn:uuid:{serial}",
+        "version": 1,
+        "metadata": {
+            "component": {
+                "type": "application",
+                "name": str(root["name"]),
+                "version": str(root["version"]),
+                "bom-ref": _bom_ref(root),
+            }
+        },
+        "components": components,
+        "dependencies": _cargo_dependency_graph(packages),
+    }
+
+
+def _write_checksums(inventory: list[tuple[Path, str]], output_dir: Path) -> Path:
+    path = output_dir / CHECKSUM_NAME
+    lines = [f"{_sha256(artifact)}  {artifact.name}" for artifact, _platform in inventory]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def generate(
+    *,
+    artifact_dir: Path,
+    output_dir: Path,
+    cargo_lock: Path,
+    source_commit: str,
+    release_tag: str,
+) -> None:
+    """Generate checksums, Cargo SBOM, and machine-readable GUI release evidence."""
+    inventory = _installer_inventory(artifact_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_checksums(inventory, output_dir)
+    sbom = _cargo_sbom(cargo_lock, inventory)
+    (output_dir / SBOM_NAME).write_text(json.dumps(sbom, indent=2) + "\n", encoding="utf-8")
+    evidence = {
+        "schemaVersion": 1,
+        "product": "kicad-mcp-pro",
+        "surface": "desktop",
+        "releaseTag": release_tag,
+        "sourceCommit": source_commit,
+        "checksums": CHECKSUM_NAME,
+        "sbom": SBOM_NAME,
+        "signing": PLATFORM_SIGNING,
+        "artifacts": [
+            {
+                "name": path.name,
+                "platform": platform,
+                "sha256": _sha256(path),
+                "size": path.stat().st_size,
+            }
+            for path, platform in inventory
+        ],
+    }
+    (output_dir / EVIDENCE_NAME).write_text(
+        json.dumps(evidence, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"Expected JSON object: {path}")
+    return cast(dict[str, Any], payload)
+
+
+def _artifact_digests(evidence: dict[str, Any]) -> dict[str, str]:
+    artifacts = evidence.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise SystemExit("GUI release evidence has no artifact inventory.")
+    digests: dict[str, str] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise SystemExit("GUI release evidence contains an invalid artifact entry.")
+        name = artifact.get("name")
+        digest = artifact.get("sha256")
+        if not isinstance(name, str) or not isinstance(digest, str):
+            raise SystemExit("GUI release evidence artifact is missing name or sha256.")
+        digests[name] = digest
+    return digests
+
+
+def _read_checksums(path: Path) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, filename = line.split(maxsplit=1)
+        checksums[filename.strip()] = digest.strip()
+    return checksums
+
+
+def verify_local(artifact_dir: Path, evidence_dir: Path) -> None:
+    """Verify generated GUI evidence still matches the local installer inventory."""
+    evidence_path = evidence_dir / EVIDENCE_NAME
+    evidence = _read_json_object(evidence_path)
+    digests = _artifact_digests(evidence)
+    checksum_name = evidence.get("checksums")
+    sbom_name = evidence.get("sbom")
+    if not isinstance(checksum_name, str) or not isinstance(sbom_name, str):
+        raise SystemExit("GUI release evidence is missing checksum or SBOM filenames.")
+
+    actual_assets = {
+        path.name
+        for path in artifact_dir.iterdir()
+        if path.is_file() and _platform_for(path) is not None
+    }
+    expected_assets = set(digests)
+    missing = sorted(expected_assets - actual_assets)
+    if missing:
+        raise SystemExit(
+            "GUI local inventory verification failed:\n- missing local asset: " + missing[0]
+        )
+    unexpected = sorted(actual_assets - expected_assets)
+    if unexpected:
+        raise SystemExit(
+            "GUI local inventory verification failed:\n- unexpected local asset: " + unexpected[0]
+        )
+
+    checksums = _read_checksums(evidence_dir / checksum_name)
+    if checksums != digests:
+        raise SystemExit("GUI local checksum manifest does not match release evidence.")
+
+    for filename, expected in digests.items():
+        actual = _sha256(artifact_dir / filename)
+        if actual != expected:
+            raise SystemExit(
+                f"GUI local inventory verification failed:\n- sha256 mismatch: {filename}"
+            )
+
+    _read_json_object(evidence_dir / sbom_name)
+
+
+def verify_published(published_dir: Path, evidence_path: Path) -> None:
+    """Verify the exact GitHub Release asset inventory and installer digests."""
+    evidence = _read_json_object(evidence_path)
+    digests = _artifact_digests(evidence)
+    checksum_name = evidence.get("checksums")
+    sbom_name = evidence.get("sbom")
+    if not isinstance(checksum_name, str) or not isinstance(sbom_name, str):
+        raise SystemExit("GUI release evidence is missing checksum or SBOM filenames.")
+
+    expected_assets = set(digests) | {checksum_name, sbom_name, evidence_path.name}
+    actual_assets = {path.name for path in published_dir.iterdir() if path.is_file()}
+    missing = sorted(expected_assets - actual_assets)
+    if missing:
+        raise SystemExit(
+            "GUI published inventory verification failed:\n- missing published asset: " + missing[0]
+        )
+    unexpected = sorted(actual_assets - expected_assets)
+    if unexpected:
+        raise SystemExit(
+            "GUI published inventory verification failed:\n- unexpected published asset: "
+            + unexpected[0]
+        )
+
+    checksums = _read_checksums(published_dir / checksum_name)
+    if checksums != digests:
+        raise SystemExit("GUI published checksum manifest does not match release evidence.")
+
+    for filename, expected in digests.items():
+        actual = _sha256(published_dir / filename)
+        if actual != expected:
+            raise SystemExit(
+                f"GUI published inventory verification failed:\n- sha256 mismatch: {filename}"
+            )
+
+    _read_json_object(published_dir / sbom_name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate")
+    generate_parser.add_argument("--artifact-dir", type=Path, required=True)
+    generate_parser.add_argument("--output-dir", type=Path, required=True)
+    generate_parser.add_argument("--cargo-lock", type=Path, required=True)
+    generate_parser.add_argument("--source-commit", required=True)
+    generate_parser.add_argument("--release-tag", required=True)
+
+    verify_local_parser = subparsers.add_parser("verify-local")
+    verify_local_parser.add_argument("--artifact-dir", type=Path, required=True)
+    verify_local_parser.add_argument("--evidence-dir", type=Path, required=True)
+
+    verify_published_parser = subparsers.add_parser("verify-published")
+    verify_published_parser.add_argument("--published-dir", type=Path, required=True)
+    verify_published_parser.add_argument("--evidence", type=Path, required=True)
+
+    args = parser.parse_args()
+
+    if args.command == "generate":
+        generate(
+            artifact_dir=args.artifact_dir,
+            output_dir=args.output_dir,
+            cargo_lock=args.cargo_lock,
+            source_commit=args.source_commit,
+            release_tag=args.release_tag,
+        )
+        return 0
+    if args.command == "verify-local":
+        verify_local(args.artifact_dir, args.evidence_dir)
+        return 0
+    if args.command == "verify-published":
+        verify_published(args.published_dir, args.evidence)
+        return 0
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_gui_release_evidence.py
+++ b/tests/unit/test_gui_release_evidence.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKSUM_NAME = "kicad-mcp-pro-gui-SHA256SUMS.txt"
+SBOM_NAME = "kicad-mcp-pro-gui-sbom.cdx.json"
+EVIDENCE_NAME = "kicad-mcp-pro-gui-release-evidence.json"
+
+
+def _load_script() -> ModuleType:
+    path = ROOT / "scripts" / "generate_gui_release_evidence.py"
+    assert path.is_file(), "GUI release evidence script must exist"
+    spec = importlib.util.spec_from_file_location("generate_gui_release_evidence", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_cargo_lock(path: Path) -> None:
+    path.write_text(
+        """
+version = 3
+
+[[package]]
+name = "kicad-mcp-pro"
+version = "1.2.3"
+dependencies = [
+ "serde 1.0.0",
+ "tauri 2.11.5",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+[[package]]
+name = "tauri"
+version = "2.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+dependencies = ["serde 1.0.0"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_installers(artifact_dir: Path) -> list[Path]:
+    artifact_dir.mkdir(parents=True)
+    artifacts = [
+        artifact_dir / "linux_kicad-mcp-pro_1.2.3_amd64.deb",
+        artifact_dir / "windows_kicad-mcp-pro_1.2.3_x64.msi",
+        artifact_dir / "macos_kicad-mcp-pro_1.2.3_aarch64.dmg",
+    ]
+    for index, artifact in enumerate(artifacts, start=1):
+        artifact.write_bytes(f"installer-{index}".encode())
+    return artifacts
+
+
+def _generate_fixture(tmp_path: Path):
+    module = _load_script()
+    artifact_dir = tmp_path / "release-assets"
+    output_dir = tmp_path / "release-evidence"
+    cargo_lock = tmp_path / "Cargo.lock"
+    installers = _write_installers(artifact_dir)
+    _write_cargo_lock(cargo_lock)
+    module.generate(
+        artifact_dir=artifact_dir,
+        output_dir=output_dir,
+        cargo_lock=cargo_lock,
+        source_commit="a" * 40,
+        release_tag="kicad-mcp-gui-v1.2.3",
+    )
+    return module, artifact_dir, output_dir, installers
+
+
+def test_generate_gui_release_evidence_writes_exact_inventory_checksums_and_cargo_sbom(
+    tmp_path: Path,
+) -> None:
+    _module, _artifact_dir, output_dir, installers = _generate_fixture(tmp_path)
+
+    checksums = (output_dir / CHECKSUM_NAME).read_text(encoding="utf-8").splitlines()
+    evidence = json.loads((output_dir / EVIDENCE_NAME).read_text(encoding="utf-8"))
+    sbom = json.loads((output_dir / SBOM_NAME).read_text(encoding="utf-8"))
+
+    assert len(checksums) == len(installers)
+    assert {line.split(maxsplit=1)[1].strip() for line in checksums} == {
+        path.name for path in installers
+    }
+    assert evidence["schemaVersion"] == 1
+    assert evidence["surface"] == "desktop"
+    assert evidence["releaseTag"] == "kicad-mcp-gui-v1.2.3"
+    assert evidence["sourceCommit"] == "a" * 40
+    assert {artifact["platform"] for artifact in evidence["artifacts"]} == {
+        "linux",
+        "windows",
+        "macos",
+    }
+    assert all(len(artifact["sha256"]) == 64 for artifact in evidence["artifacts"])
+    assert evidence["signing"] == {
+        "linux": {"packageSigning": "unsigned"},
+        "windows": {"authenticode": "unsigned"},
+        "macos": {"codeSigning": "unsigned", "notarization": "not-notarized"},
+    }
+    assert sbom["bomFormat"] == "CycloneDX"
+    assert sbom["specVersion"] == "1.6"
+    assert sbom["metadata"]["component"]["name"] == "kicad-mcp-pro"
+    assert {component["name"] for component in sbom["components"]} == {"serde", "tauri"}
+    dependency_graph = {entry["ref"]: set(entry["dependsOn"]) for entry in sbom["dependencies"]}
+    assert dependency_graph["pkg:cargo/kicad-mcp-pro@1.2.3"] == {
+        "pkg:cargo/serde@1.0.0",
+        "pkg:cargo/tauri@2.11.5",
+    }
+    assert dependency_graph["pkg:cargo/tauri@2.11.5"] == {"pkg:cargo/serde@1.0.0"}
+
+
+def test_generate_gui_release_evidence_rejects_missing_platform(tmp_path: Path) -> None:
+    module = _load_script()
+    artifact_dir = tmp_path / "release-assets"
+    output_dir = tmp_path / "release-evidence"
+    cargo_lock = tmp_path / "Cargo.lock"
+    artifact_dir.mkdir()
+    (artifact_dir / "linux_app.deb").write_bytes(b"linux")
+    (artifact_dir / "windows_app.msi").write_bytes(b"windows")
+    _write_cargo_lock(cargo_lock)
+
+    with pytest.raises(SystemExit, match="missing required installer platform: macos"):
+        module.generate(
+            artifact_dir=artifact_dir,
+            output_dir=output_dir,
+            cargo_lock=cargo_lock,
+            source_commit="b" * 40,
+            release_tag="kicad-mcp-gui-v1.2.3",
+        )
+
+
+def test_verify_published_rejects_tampered_installer(tmp_path: Path) -> None:
+    module, artifact_dir, output_dir, installers = _generate_fixture(tmp_path)
+    published = tmp_path / "published"
+    published.mkdir()
+    for path in installers:
+        shutil.copy2(path, published / path.name)
+    for name in (CHECKSUM_NAME, SBOM_NAME, EVIDENCE_NAME):
+        shutil.copy2(output_dir / name, published / name)
+    (published / installers[0].name).write_bytes(b"tampered")
+
+    with pytest.raises(SystemExit, match="sha256 mismatch"):
+        module.verify_published(published, published / EVIDENCE_NAME)
+
+
+def test_verify_published_rejects_missing_and_extra_assets(tmp_path: Path) -> None:
+    module, artifact_dir, output_dir, installers = _generate_fixture(tmp_path)
+    published = tmp_path / "published"
+    published.mkdir()
+    for path in installers:
+        shutil.copy2(path, published / path.name)
+    for name in (CHECKSUM_NAME, SBOM_NAME, EVIDENCE_NAME):
+        shutil.copy2(output_dir / name, published / name)
+
+    module.verify_published(published, published / EVIDENCE_NAME)
+
+    (published / "unexpected.txt").write_text("unexpected", encoding="utf-8")
+    with pytest.raises(SystemExit, match="unexpected published asset"):
+        module.verify_published(published, published / EVIDENCE_NAME)
+    (published / "unexpected.txt").unlink()
+
+    (published / installers[-1].name).unlink()
+    with pytest.raises(SystemExit, match="missing published asset"):
+        module.verify_published(published, published / EVIDENCE_NAME)
+
+
+def test_gui_release_workflow_attests_and_verifies_published_installer_inventory() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "gui-release.yml").read_text(encoding="utf-8")
+    policy = json.loads((ROOT / ".github" / "actions-policy.json").read_text(encoding="utf-8"))
+
+    assert "scripts/generate_gui_release_evidence.py generate" in workflow
+    assert "scripts/generate_gui_release_evidence.py verify-local" in workflow
+    assert "scripts/generate_gui_release_evidence.py verify-published" in workflow
+    assert "actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26" in workflow
+    assert f"subject-checksums: release-evidence/gui/{CHECKSUM_NAME}" in workflow
+    assert f"sbom-path: release-evidence/gui/{SBOM_NAME}" in workflow
+    assert "attestations: write" in workflow
+    assert "artifact-metadata: write" in workflow
+    assert "id-token: write" in workflow
+    assert 'SOURCE_COMMIT="$(git rev-parse HEAD)"' in workflow
+    assert 'gh release download "$TAG"' in workflow
+    assert (
+        "ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}"
+        in workflow
+    )
+    assert policy["workflow_write_permissions"]["gui-release.yml"]["create-release"] == [
+        "artifact-metadata",
+        "attestations",
+        "contents",
+        "id-token",
+    ]
+
+
+def test_verify_local_accepts_generated_inventory_and_rejects_tamper(tmp_path: Path) -> None:
+    module, artifact_dir, output_dir, installers = _generate_fixture(tmp_path)
+
+    module.verify_local(artifact_dir, output_dir)
+
+    installers[1].write_bytes(b"tampered-after-evidence")
+    with pytest.raises(SystemExit, match="sha256 mismatch"):
+        module.verify_local(artifact_dir, output_dir)
+
+
+def test_cli_verify_local_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    module, artifact_dir, output_dir, _installers = _generate_fixture(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_gui_release_evidence.py",
+            "verify-local",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--evidence-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert module.main() == 0
+
+
+def test_cli_verify_published_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+
+    module, artifact_dir, output_dir, installers = _generate_fixture(tmp_path)
+    published = tmp_path / "published"
+    published.mkdir()
+    for path in installers:
+        shutil.copy2(path, published / path.name)
+    for name in (CHECKSUM_NAME, SBOM_NAME, EVIDENCE_NAME):
+        shutil.copy2(output_dir / name, published / name)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_gui_release_evidence.py",
+            "verify-published",
+            "--published-dir",
+            str(published),
+            "--evidence",
+            str(published / EVIDENCE_NAME),
+        ],
+    )
+
+    assert module.main() == 0
+
+
+def test_generate_gui_release_evidence_rejects_empty_installer(tmp_path: Path) -> None:
+    module = _load_script()
+    artifact_dir = tmp_path / "release-assets"
+    output_dir = tmp_path / "release-evidence"
+    cargo_lock = tmp_path / "Cargo.lock"
+    installers = _write_installers(artifact_dir)
+    installers[0].write_bytes(b"")
+    _write_cargo_lock(cargo_lock)
+
+    with pytest.raises(SystemExit, match="installer is empty"):
+        module.generate(
+            artifact_dir=artifact_dir,
+            output_dir=output_dir,
+            cargo_lock=cargo_lock,
+            source_commit="c" * 40,
+            release_tag="kicad-mcp-gui-v1.2.3",
+        )
+
+
+def test_generate_gui_release_evidence_rejects_unsupported_artifact(tmp_path: Path) -> None:
+    module = _load_script()
+    artifact_dir = tmp_path / "release-assets"
+    output_dir = tmp_path / "release-evidence"
+    cargo_lock = tmp_path / "Cargo.lock"
+    _write_installers(artifact_dir)
+    (artifact_dir / "internal-bundle.zip").write_bytes(b"not-a-public-installer")
+    _write_cargo_lock(cargo_lock)
+
+    with pytest.raises(SystemExit, match="unsupported installer artifact"):
+        module.generate(
+            artifact_dir=artifact_dir,
+            output_dir=output_dir,
+            cargo_lock=cargo_lock,
+            source_commit="d" * 40,
+            release_tag="kicad-mcp-gui-v1.2.3",
+        )


### PR DESCRIPTION
## Summary

<!-- What changed and why? Keep the scope focused. -->

## Type of change

- [ ] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Tests / fixtures
- [ ] Refactor / maintenance
- [ ] Release / packaging / supply chain

## Validation

- [ ] `corepack pnpm run format:check`
- [ ] `corepack pnpm run lint`
- [ ] `corepack pnpm run typecheck`
- [ ] `corepack pnpm run test:unit`
- [ ] `corepack pnpm run metadata:check`
- [ ] `task verify` or `task ci` when the change crosses tool, package, workflow, or release boundaries

## Safety and compatibility

- [ ] Public tool contracts, generated docs, metadata, and compatibility matrices are updated when needed.
- [ ] Destructive or KiCad-driving behavior is explicit, test-covered, and documented.
- [ ] Logs, fixtures, screenshots, and generated artifacts do not contain secrets or private board data.
- [ ] Approximate / heuristic behavior is described honestly in docs and verdicts.

## Release notes

<!-- User-visible behavior change, migration note, or "None". -->
