### PR TITLE
fix(eval): classify alternate validation shapes

### DIFF
--- a/src/kicad_mcp/evals/nvidia_nim_adapter.py
+++ b/src/kicad_mcp/evals/nvidia_nim_adapter.py
@@ -506,30 +506,72 @@ def _failure_for_status(status_code: int) -> FailureKind:
     return "provider_request_rejected"
 
 
-def _provider_request_failure_detail(response: httpx.Response) -> FailureDetail | None:
+def _request_field_detail_from_text(value: object) -> FailureDetail | None:
+    if not isinstance(value, str):
+        return None
+    direct = _PROVIDER_REQUEST_FIELD_DETAILS.get(value.strip())
+    if direct is not None:
+        return direct
+    for field, detail in _PROVIDER_REQUEST_FIELD_DETAILS.items():
+        if re.search(rf"(?<![a-zA-Z0-9_]){re.escape(field)}(?![a-zA-Z0-9_])", value):
+            return detail
+    return None
+
+
+def _provider_request_failure_detail(response: httpx.Response) -> FailureDetail:
     """Return only an allowlisted request field from one validation response."""
     try:
         payload = response.json()
     except (TypeError, ValueError, json.JSONDecodeError):
-        return None
+        return "request_unknown"
     if not isinstance(payload, dict):
-        return None
+        return "request_unknown"
+
     detail = payload.get("detail")
     entries = detail if isinstance(detail, list) else [detail]
-    saw_location = False
     for entry in entries:
         if not isinstance(entry, dict):
             continue
         location = entry.get("loc")
-        if not isinstance(location, list | tuple):
-            continue
-        saw_location = True
-        for segment in reversed(location):
-            if isinstance(segment, str):
-                mapped = _PROVIDER_REQUEST_FIELD_DETAILS.get(segment)
+        if isinstance(location, list | tuple):
+            for segment in reversed(location):
+                mapped = _request_field_detail_from_text(segment)
                 if mapped is not None:
                     return mapped
-    return "request_unknown" if saw_location else None
+
+    diagnostic_values: list[object] = [
+        payload.get("param"),
+        payload.get("parameter"),
+        payload.get("field"),
+        payload.get("message"),
+        payload.get("msg"),
+    ]
+    if isinstance(detail, str):
+        diagnostic_values.append(detail)
+    elif isinstance(detail, dict):
+        diagnostic_values.extend(
+            detail.get(key) for key in ("param", "parameter", "field", "message", "msg")
+        )
+    elif isinstance(detail, list):
+        for entry in detail:
+            if isinstance(entry, dict):
+                diagnostic_values.extend(
+                    entry.get(key) for key in ("param", "parameter", "field", "message", "msg")
+                )
+
+    error = payload.get("error")
+    if isinstance(error, dict):
+        diagnostic_values.extend(
+            error.get(key) for key in ("param", "parameter", "field", "message", "msg")
+        )
+    elif isinstance(error, str):
+        diagnostic_values.append(error)
+
+    for value in diagnostic_values:
+        mapped = _request_field_detail_from_text(value)
+        if mapped is not None:
+            return mapped
+    return "request_unknown"
 
 
 def _json_object(content: str) -> dict[str, Any]:

--- a/tests/unit/test_nvidia_nim_eval_adapter.py
+++ b/tests/unit/test_nvidia_nim_eval_adapter.py
@@ -251,6 +251,58 @@ def test_nim_request_sanitizes_unknown_provider_validation_location() -> None:
     assert "sensitive-provider" not in json.dumps(result)
 
 
+def test_nim_request_sanitizes_provider_error_param() -> None:
+    raw_message = "reasoning_effort rejected with secret-provider-context"
+    result = request_nvidia_nim(
+        model="nvidia/test-model",
+        prompt="Private board prompt must not escape.",
+        api_key="test-key",
+        catalog=(),
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                422,
+                json={
+                    "error": {
+                        "param": "reasoning_effort",
+                        "message": raw_message,
+                    }
+                },
+            )
+        ),
+    )
+
+    assert result == {
+        "schema_version": 1,
+        "status": "error",
+        "failure_kind": "provider_request_rejected",
+        "failure_detail": "request_reasoning_effort",
+    }
+    serialized = json.dumps(result)
+    assert raw_message not in serialized
+    assert "Private board prompt" not in serialized
+
+
+def test_nim_request_sanitizes_allowlisted_field_from_provider_detail_text() -> None:
+    raw_detail = "Validation failed for top_p; secret-provider-context must not escape"
+    result = request_nvidia_nim(
+        model="nvidia/test-model",
+        prompt="Inspect.",
+        api_key="test-key",
+        catalog=(),
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(422, json={"detail": raw_detail})
+        ),
+    )
+
+    assert result == {
+        "schema_version": 1,
+        "status": "error",
+        "failure_kind": "provider_request_rejected",
+        "failure_detail": "request_top_p",
+    }
+    assert raw_detail not in json.dumps(result)
+
+
 def test_nim_request_exposes_only_bounded_retry_after_hint() -> None:
     result = request_nvidia_nim(
         model="nvidia/test-model",
@@ -354,6 +406,7 @@ def test_hosted_nim_request_makes_one_http_call_without_structured_fields() -> N
         "schema_version": 1,
         "status": "error",
         "failure_kind": "provider_request_rejected",
+        "failure_detail": "request_unknown",
     }
     assert len(requests) == 1
     assert "guided_json" not in requests[0]


### PR DESCRIPTION
## Summary

- classify sanitized provider validation fields from common 422 shapes beyond FastAPI `detail[].loc`
- support bounded `error.param` / `param` / `field` metadata and allowlisted field tokens in provider diagnostic text
- emit `request_unknown` for unparseable or unrecognized 422 validation responses instead of silently dropping diagnostic detail
- never copy provider messages, request input, prompts, credentials, or arbitrary response content into eval evidence

## Evidence

A controlled live smoke on `main@2c34b03` (run `31288872861`) reproduced 11/11 `provider_request_rejected` observations after #596, but `failure_detail` remained null. That proves the hosted provider's 422 response does not match the previously supported `detail[].loc` shape.

This PR broadens only the sanitizer/classifier. It does not weaken the protected live-model gate or expose raw provider payloads.

## Verification

- TDD: three new/updated validation-shape tests failed before implementation and pass after it
- live-model focused + release-policy suites: 174 passed
- NVIDIA NIM adapter suite: 99 passed
- targeted mypy: clean
- Ruff: clean
- `git diff --check`: clean

Refs #573 and release PR #588.
