### PR TITLE
chore(deps): group routine updates with Mergify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
     open-pull-requests-limit: 4
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      python-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directories:
@@ -30,6 +42,18 @@ updates:
     open-pull-requests-limit: 4
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      npm-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -44,6 +68,14 @@ updates:
     open-pull-requests-limit: 4
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      actions-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -58,6 +90,13 @@ updates:
     open-pull-requests-limit: 4
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      containers-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
 
   - package-ecosystem: "docker-compose"
     directory: "/"
@@ -72,6 +111,14 @@ updates:
     open-pull-requests-limit: 4
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      compose-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "cargo"
     directory: "/src-tauri"
@@ -85,3 +132,15 @@ updates:
     open-pull-requests-limit: 4
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      cargo-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      cargo-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,28 @@
+merge_queue:
+  mode: serial
+  max_parallel_checks: 1
+
+queue_rules:
+  - name: safe-dependencies
+    batch_size: 1
+    merge_method: squash
+    branch_protection_injection_mode: queue
+    max_checks_retries: 0
+    queue_conditions:
+      - base = main
+      - author = dependabot[bot]
+      - -draft
+      - dependabot-update-type != version-update:semver-major
+      - head ~= ^dependabot/.*/(python-minor-patch|npm-minor-patch|actions-minor-patch|containers-patch|compose-minor-patch|cargo-minor-patch)(?:-|$)
+
+pull_request_rules:
+  - name: Queue safe grouped Dependabot updates
+    conditions:
+      - base = main
+      - author = dependabot[bot]
+      - -draft
+      - dependabot-update-type != version-update:semver-major
+      - head ~= ^dependabot/.*/(python-minor-patch|npm-minor-patch|actions-minor-patch|containers-patch|compose-minor-patch|cargo-minor-patch)(?:-|$)
+    actions:
+      queue:
+        name: safe-dependencies

--- a/docs/development/dependency-management.md
+++ b/docs/development/dependency-management.md
@@ -21,8 +21,19 @@ part of the active update path, so the repository does not keep a second bot
 configuration that could create duplicate update pull requests.
 
 Dependabot runs weekly on Monday using the repository's Europe/Istanbul maintenance
-window. Its pull requests are ordinary protected pull requests: required CI and the
+window. Routine minor/patch version updates are grouped per ecosystem to reduce PR and
+CI churn; major updates remain individual pull requests. Docker version automation is
+more conservative: only patch updates are grouped, leaving runtime-sensitive image
+minor/major changes for explicit maintainer review. Security updates use separate
+per-ecosystem groups and are never mixed with routine version-update groups.
+
+Dependabot pull requests are ordinary protected pull requests: required CI and the
 `main` ruleset still apply, and no dependency bot is allowed to bypass those gates.
+Mergify provides a serial, one-PR-at-a-time queue for the routine grouped version
+updates only. Its queue injects the repository's GitHub protection/ruleset conditions,
+uses squash merges, and does not retry failed checks automatically. Human-authored,
+release, security, major, and otherwise ungrouped dependency pull requests remain a
+maintainer decision.
 
 ## Lockfile maintenance
 
@@ -40,11 +51,12 @@ installs and therefore rejects stale or unexpectedly regenerated lockfiles.
 
 ## Update process
 
-1. Dependabot opens a focused dependency pull request from the default branch.
+1. Dependabot opens either a routine ecosystem group or an individual higher-risk dependency pull request from the default branch.
 2. Review the dependency source, package name, version change, release notes, and license impact.
 3. Run the required CI, security checks, tests, and relevant package builds.
 4. Confirm the matching lockfile changed only as expected.
-5. Merge only after required checks pass; major/runtime-sensitive updates receive maintainer review.
+5. Routine grouped minor/patch version updates may enter the Mergify queue automatically; the GitHub ruleset and required checks remain mandatory.
+6. Security, major, runtime-sensitive, release, human-authored, and ungrouped updates require an explicit maintainer merge decision.
 
 ## Vulnerability monitoring
 

--- a/docs/engineering/ci-cd-policy.md
+++ b/docs/engineering/ci-cd-policy.md
@@ -142,9 +142,14 @@ Dependabot security updates own automated vulnerable-dependency remediation. The
 repository intentionally has no active Renovate configuration or Mend Renovate App
 requirement, avoiding two bots opening overlapping update pull requests.
 
-Dependabot update PRs use the same protected-branch path as maintainer PRs. Required
-status checks and the active `main` ruleset remain authoritative; the dependency bot
-does not bypass them.
+Dependabot update PRs use the same protected-branch path as maintainer PRs. Routine
+minor/patch version updates are grouped per ecosystem, while major and runtime-sensitive
+updates remain individually reviewable and security updates use separate groups.
+Required status checks and the active `main` ruleset remain authoritative; neither
+Dependabot nor Mergify bypasses them. Mergify may automatically queue only the explicitly
+allowlisted routine Dependabot groups, one PR at a time, after applying the repository's
+GitHub protection/ruleset conditions. Human, release, security, major, and other
+ungrouped PRs are not auto-queued by repository policy.
 
 ### SonarQube Cloud scope
 

--- a/tests/unit/test_release_preflight_guard.py
+++ b/tests/unit/test_release_preflight_guard.py
@@ -326,6 +326,80 @@ def test_dependabot_covers_repository_dependency_ecosystems_and_lockfiles() -> N
         assert lockfile in policy
 
 
+def test_dependabot_groups_routine_updates_without_grouping_major_versions() -> None:
+    config = yaml.safe_load((ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8"))
+    updates = {entry["package-ecosystem"]: entry for entry in config["updates"]}
+
+    expected_version_groups = {
+        "uv": ("python-minor-patch", {"minor", "patch"}),
+        "npm": ("npm-minor-patch", {"minor", "patch"}),
+        "github-actions": ("actions-minor-patch", {"minor", "patch"}),
+        "docker": ("containers-patch", {"patch"}),
+        "docker-compose": ("compose-minor-patch", {"minor", "patch"}),
+        "cargo": ("cargo-minor-patch", {"minor", "patch"}),
+    }
+    for ecosystem, (group_name, update_types) in expected_version_groups.items():
+        group = updates[ecosystem]["groups"][group_name]
+        assert group["applies-to"] == "version-updates"
+        assert group["patterns"] == ["*"]
+        assert set(group["update-types"]) == update_types
+        assert "major" not in group["update-types"]
+
+    for ecosystem, group_name in {
+        "uv": "python-security",
+        "npm": "npm-security",
+        "cargo": "cargo-security",
+    }.items():
+        group = updates[ecosystem]["groups"][group_name]
+        assert group["applies-to"] == "security-updates"
+        assert group["patterns"] == ["*"]
+
+
+def test_mergify_only_autoqueues_safe_grouped_dependabot_updates() -> None:
+    config = yaml.safe_load((ROOT / ".mergify.yml").read_text(encoding="utf-8"))
+
+    assert "merge_protections" not in config
+    assert "merge_protections_settings" not in config
+    assert config["merge_queue"] == {"mode": "serial", "max_parallel_checks": 1}
+
+    assert len(config["queue_rules"]) == 1
+    queue = config["queue_rules"][0]
+    assert queue["name"] == "safe-dependencies"
+    assert queue["batch_size"] == 1
+    assert queue["merge_method"] == "squash"
+    assert queue["branch_protection_injection_mode"] == "queue"
+    assert queue["max_checks_retries"] == 0
+
+    required_conditions = {
+        "base = main",
+        "author = dependabot[bot]",
+        "-draft",
+        "dependabot-update-type != version-update:semver-major",
+    }
+    assert required_conditions <= set(queue["queue_conditions"])
+
+    assert len(config["pull_request_rules"]) == 1
+    rule = config["pull_request_rules"][0]
+    assert rule["actions"] == {"queue": {"name": "safe-dependencies"}}
+    assert required_conditions <= set(rule["conditions"])
+
+    head_conditions = [
+        condition for condition in rule["conditions"] if condition.startswith("head ~= ")
+    ]
+    assert len(head_conditions) == 1
+    head_condition = head_conditions[0]
+    for group_name in (
+        "python-minor-patch",
+        "npm-minor-patch",
+        "actions-minor-patch",
+        "containers-patch",
+        "compose-minor-patch",
+        "cargo-minor-patch",
+    ):
+        assert group_name in head_condition
+    assert "security" not in head_condition
+
+
 def test_release_preflight_rejects_missing_tauri_lockfile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- group routine Dependabot version updates per ecosystem while keeping major updates individual
- keep Docker automation conservative by grouping patch updates only
- group supported security updates separately from routine version updates
- add a Mergify serial, single-PR queue for explicitly allowlisted grouped Dependabot version updates
- preserve GitHub ruleset/required-check enforcement with queue condition injection; no bypass or automatic retry
- document which dependency PR classes remain explicit maintainer decisions

## Mergify safety boundary

Automatic queueing is limited to Dependabot-authored grouped version-update branches for the configured routine groups. Human PRs, release PRs, security groups, major updates, runtime-sensitive Docker minor/major updates, and ungrouped dependency PRs are not auto-queued.

## Verification

- TDD RED: missing Dependabot groups and missing `.mergify.yml` produced the expected failures
- GREEN: dependency grouping + Mergify policy regression tests pass
- `tests/unit/test_release_preflight_guard.py`: 23 passed
- full benchmark-excluded unit suite: return code 0, 3 existing skips
- `check:meta`, architecture/compatibility, and `git diff --check`: passed
- Mergify CLI 2026.8.7.1: `config validate` passed
- Mergify `config simulate` against existing individual Dependabot PR #610 and release PR #588: no rules matched / no planned actions
- staged secret-like value scan: 0 findings; pre-commit passed
- pre-push: Ruff + 23 targeted tests passed
