### PR TITLE
fix(schematic): sheet-pin follow-ups that missed the #626 merge

### DIFF
--- a/docs/evidence/progressive-disclosure-profile-snapshot.json
+++ b/docs/evidence/progressive-disclosure-profile-snapshot.json
@@ -94,10 +94,10 @@
     },
     "expert": {
       "callableTools": 380,
-      "catalogCharacters": 217483,
+      "catalogCharacters": 217445,
       "catalogReductionVsExpertPct": 0.0,
       "declaredTools": 380,
-      "estimatedCatalogTokens": 54371,
+      "estimatedCatalogTokens": 54362,
       "forbiddenToolExposures": 8,
       "goldenCases": 65,
       "goldenCasesCovered": 55,

--- a/docs/evidence/progressive-disclosure-profile-snapshot.json
+++ b/docs/evidence/progressive-disclosure-profile-snapshot.json
@@ -94,10 +94,10 @@
     },
     "expert": {
       "callableTools": 380,
-      "catalogCharacters": 217445,
+      "catalogCharacters": 218874,
       "catalogReductionVsExpertPct": 0.0,
       "declaredTools": 380,
-      "estimatedCatalogTokens": 54362,
+      "estimatedCatalogTokens": 54719,
       "forbiddenToolExposures": 8,
       "goldenCases": 65,
       "goldenCasesCovered": 55,

--- a/docs/superpowers/specs/2026-08-09-schematic-sheet-pin-authoring-design.md
+++ b/docs/superpowers/specs/2026-08-09-schematic-sheet-pin-authoring-design.md
@@ -108,13 +108,13 @@ class SheetBlock:
 class SheetPinPlacement:
     name: str
     pin_type: str
-    edge: str               # left | right (plan_sheet_pins) or all four (placement_on_edge)
     x_mm: float
     y_mm: float
-    rotation: int            # left -> 180, right -> 0 (and 90/270 for top/bottom)
+    rotation: int            # left -> 180, right -> 0 (and 90/270 for top/bottom);
+                             # the edge, via edge_for_rotation -- no separate field
     justify: str
     uuid: str                 # existing UUID, or "" for a new pin the caller must stamp
-    action: str                # "add" | "retype" | "keep"
+    action: str                # "add" | "retype" | "move" | "keep"
 
 @dataclass(frozen=True)
 class SheetPinPlan:
@@ -162,13 +162,14 @@ removes every existing `(pin ...)` block, and inserts the new ones before the
 `tests/integration/test_schematic_connectivity_gate.py` used to reach by hand
 before this feature existed.
 
-The splice itself is guarded by a private `_check_non_overlapping` helper that
-`apply_plan` and `insert_pin` both go through via `_splice`: replaying edits in
-descending order of `start` is only safe if the spans are pairwise
+The splice itself is guarded by two private preconditions that `apply_plan` and
+`insert_pin` both go through. `_check_non_overlapping` (via `_splice`): replaying
+edits in descending order of `start` is only safe if the spans are pairwise
 non-overlapping, and a `(pin ...)` node sharing a physical source line with
-`(instances ...)` or `(size ...)` would violate that. When it happens, the
-module raises a named `ValueError` instead of silently corrupting the
-schematic.
+`(instances ...)` or `(size ...)` would violate that. `_indent_of`: the text
+before the anchor on its line has to be indentation, which it is not when the
+whole `(sheet ...)` block is written on one line. Either way the module raises a
+named `ValueError` instead of silently corrupting the schematic.
 
 ### 3.2 `schematic/hierarchy_authoring.py` (extended)
 
@@ -262,8 +263,8 @@ in the output. The sheet symbol never shrinks and is never moved.
 
 With `grow_sheet=False` the size stays fixed. Pins that then no longer fit
 their edge land in `SheetPinPlan.overflow`; for that sheet **nothing at all**
-is written, and the report names the affected pins and the height that would
-be required. A half-pinned sheet would be worse than an unchanged one.
+is written, and the report names the affected pins. A half-pinned sheet would
+be worse than an unchanged one.
 
 **Grid alignment:** the *absolute* pin position is snapped to the schematic
 grid (`SCHEMATIC_GRID_MM`, default 1.27 mm), and `position_along_edge` is
@@ -288,7 +289,9 @@ stable IDs keep the git diff small and reviewable -- at 81 pins that is the
 difference between a reviewable and an unreviewable commit.
 
 A second run with no changes to the child sheet produces the same plan, does
-not change the file, and reports only "keep".
+not change the file, and reports only "unchanged". A pin whose type matches but
+whose position this layout changes is reported as "moved", not "unchanged" --
+the file is rewritten for it.
 
 `dry_run=True` produces the same report and writes nothing.
 
@@ -315,8 +318,15 @@ measures from the bottom, `right` from the top).
   write
 - Child sheet file missing or unreadable -> that sheet is skipped and listed
   as blocked in the report; the remaining sheets still run
-- Sheet block without an `(instances` node or without `(size` -> sheet is
-  skipped and reported instead of splicing at the wrong place
+- Sheet block without `(size` (or without a name, or with an unparseable
+  number) -> the parser cannot address it, so it is left out and named as
+  unaddressable when it was asked for by name; the remaining sheets still run
+- Sheet block without an `(instances` node -> there is no safe splice anchor,
+  so the **whole transaction** is abandoned and reported: nothing is written
+  for any sheet in the run. Same for a `(sheet ...)` block written on one line,
+  where the pin anchor's line prefix is not indentation. All-or-nothing is the
+  point (see the single-transaction note below); a partially pinned hierarchy
+  is worse than an unchanged one
 - Sheet moved or resized since it was read -> the write-time geometry guard
   (Section 3.2) aborts the transaction and reports old vs. new origin/size
 - Node loss on write -> `transactional_write` rolls back and raises

--- a/scripts/check_tool_contracts.py
+++ b/scripts/check_tool_contracts.py
@@ -7,12 +7,35 @@ import sys
 from typing import Any
 
 from kicad_mcp.capabilities import AccessTier, all_records, metadata_coverage
+from kicad_mcp.operating_modes import OperatingMode
 from kicad_mcp.server import build_server
+from kicad_mcp.tools.router import available_profiles
 
 
 async def _tool_schemas() -> dict[str, dict[str, Any]]:
     server = build_server("full")
     return {tool.name: dict(tool.inputSchema or {}) for tool in await server.list_tools()}
+
+
+async def _declared_tool_schemas() -> dict[str, dict[str, Any]]:
+    """Return every tool schema any declared profile can surface.
+
+    ``build_server("full")`` alone is not enough: its listing is narrowed twice
+    more, by the default read-only operating mode and by the runtime IPC filter,
+    so no mutating tool reaches a schema check on a machine without KiCad
+    running. Both narrowings are lifted here on purpose -- a schema is a static
+    contract, and a host that never sees a tool today will see it the moment the
+    operator switches modes.
+    """
+    schemas: dict[str, dict[str, Any]] = {}
+    for profile in available_profiles():
+        server = build_server(profile)
+        server.operating_mode = OperatingMode.EXPERIMENTAL
+        server.allow_experimental_tools = True
+        server.filter_runtime_tools = False
+        for tool in await server.list_tools():
+            schemas.setdefault(tool.name, dict(tool.inputSchema or {}))
+    return schemas
 
 
 def _schema_properties(schema: dict[str, Any]) -> dict[str, Any]:
@@ -58,7 +81,7 @@ async def lint() -> list[str]:
                 errors.append(f"Read-only profile '{profile}' exposes mutating tool {tool_name}")
 
     schemas = await _tool_schemas()
-    for tool_name, schema in schemas.items():
+    for tool_name, schema in sorted((await _declared_tool_schemas()).items()):
         for path in _array_schema_paths_missing_items(schema):
             errors.append(
                 f"{tool_name} input schema array at {path} must declare items "

--- a/src/kicad_mcp/schematic/hierarchy_authoring.py
+++ b/src/kicad_mcp/schematic/hierarchy_authoring.py
@@ -16,6 +16,7 @@ from .sheet_pins import (
     insert_pin,
     parse_hierarchical_labels,
     parse_sheet_blocks,
+    parse_skipped_sheet_blocks,
     placement_on_edge,
     plan_sheet_pins,
 )
@@ -188,7 +189,14 @@ class SchematicHierarchyAuthoringService:
         try:
             schematic = self.load_schematic(top_schematic_path)
             if schematic.sheets.get_sheet_by_name(name) is not None:
-                return f"Sheet '{name}' already exists."
+                already = f"Sheet '{name}' already exists."
+                if sheet_pins:
+                    already += (
+                        " Nothing was created and no sheet pins were applied -- this early "
+                        "return does not touch an existing sheet. Use sch_add_sheet_pin or "
+                        "sch_import_sheet_pins to add pins to it."
+                    )
+                return already
             if not child_path.exists():
                 child_schematic = create_schematic(name)
                 child_schematic.save(child_path, preserve_format=True)
@@ -328,29 +336,42 @@ class SchematicHierarchyAuthoringService:
         the same text splice ``import_sheet_pins`` uses: never through
         ``kicad_sch_api.add_sheet()``'s own ``sheet_pins`` argument, whose
         load/save round trip silently drops ``(comment N ...)`` nodes from the
-        schematic's ``title_block``. Never raises -- a failure here is folded
-        into the returned string so the sheet stays reported as created even
-        if its pins could not be written.
+        schematic's ``title_block``.
+
+        Never raises. ``create_sheet`` calls it outside any ``try`` and after
+        the sheet is already on disk, so an ``OSError`` from the re-read or a
+        ``ValueError`` from planning would otherwise surface as a failed
+        ``sch_create_sheet`` for a sheet that was in fact created. Every failure
+        is folded into the returned string instead.
         """
         plan_labels = tuple(sheet_pins)
-        root_text = self.read_text(top_schematic_path)
-        block = next(
-            (candidate for candidate in parse_sheet_blocks(root_text) if candidate.name == name),
-            None,
-        )
-        if block is None:
-            return f"\nSheet '{name}' was created, but its block could not be re-read to add pins."
+        try:
+            root_text = self.read_text(top_schematic_path)
+            block = next(
+                (
+                    candidate
+                    for candidate in parse_sheet_blocks(root_text)
+                    if candidate.name == name
+                ),
+                None,
+            )
+            if block is None:
+                return (
+                    f"\nSheet '{name}' was created, but its block could not be re-read to add pins."
+                )
+            plan = self._stamp_uuids(plan_sheet_pins(plan_labels, block, grid_mm=self.grid_mm()))
+        except Exception as exc:
+            self.warn("schematic_create_sheet_pins_failed", name=name, error=str(exc))
+            return f"\nSheet '{name}' was created, but its pins could not be planned: {exc}"
 
-        plan = self._stamp_uuids(plan_sheet_pins(plan_labels, block, grid_mm=self.grid_mm()))
-
-        def mutator(current: str, _name: str = name, _plan: SheetPinPlan = plan) -> str:
+        def mutator(current: str) -> str:
             target = next(
-                (candidate for candidate in parse_sheet_blocks(current) if candidate.name == _name),
+                (candidate for candidate in parse_sheet_blocks(current) if candidate.name == name),
                 None,
             )
             if target is None:
-                raise ValueError(f"Sheet '{_name}' disappeared before the pin write.")
-            return apply_plan(current, target, _plan)
+                raise ValueError(f"Sheet '{name}' disappeared before the pin write.")
+            return apply_plan(current, target, plan)
 
         try:
             self.transactional_write(mutator, top_schematic_path)
@@ -364,16 +385,27 @@ class SchematicHierarchyAuthoringService:
             pin_detail += (
                 f" Conflicting pin types for {', '.join(plan.conflicts)} (first occurrence wins)."
             )
+        # The same disclosures sch_import_sheet_pins surfaces -- notably that a
+        # widened sheet was widened from an estimated text width. Dropping them
+        # here would let sch_create_sheet resize a sheet and say nothing.
+        pin_detail += "".join(f"\nnote: {note}" for note in plan.notes)
         return pin_detail
 
     @staticmethod
     def _describe(sheet: SheetBlock, plan: SheetPinPlan) -> str:
-        counts = {"add": 0, "retype": 0, "keep": 0}
+        """Summarize what a plan would do to one sheet.
+
+        Only ever appended to a report on a path where that plan was in fact
+        written (or explicitly labelled a preview). ``moved`` is counted apart
+        from ``unchanged`` because a repositioned pin is rewritten in the file,
+        and calling it unchanged would be a false statement about the write.
+        """
+        counts = {"add": 0, "retype": 0, "move": 0, "keep": 0}
         for placement in plan.placements:
             counts[placement.action] += 1
         detail = (
             f"- {sheet.name}: {counts['add']} added, {counts['retype']} retyped, "
-            f"{counts['keep']} unchanged"
+            f"{counts['move']} moved, {counts['keep']} unchanged"
         )
         if plan.size != sheet.size:
             detail += f"; resized to {plan.size[0]} x {plan.size[1]} mm"
@@ -401,6 +433,22 @@ class SchematicHierarchyAuthoringService:
         if sheet is not None:
             blocks = tuple(block for block in blocks if block.name == sheet)
             if not blocks:
+                skipped = next(
+                    (
+                        candidate
+                        for candidate in parse_skipped_sheet_blocks(root_text)
+                        if candidate.name == sheet
+                    ),
+                    None,
+                )
+                if skipped is not None:
+                    # The sheet is in the file; it is the block that is unusable.
+                    # Saying "not found" here would send the user looking for a
+                    # name that is right there.
+                    return (
+                        f"Sheet '{sheet}' is in {root_path.name} but cannot be addressed: "
+                        f"{skipped.reason}. Fix that block in KiCad and retry."
+                    )
                 return f"Sheet '{sheet}' was not found in {root_path.name}."
         if not blocks:
             return f"{root_path.name} has no child sheets, so there is nothing to import."
@@ -445,7 +493,10 @@ class SchematicHierarchyAuthoringService:
                     None,
                 )
                 if block is None:
-                    continue
+                    raise ValueError(
+                        f"Sheet '{name}' disappeared between the read and the write, so its "
+                        "pins were not applied. Re-run sch_import_sheet_pins."
+                    )
                 if block.origin != origin or block.size != size:
                     raise ValueError(
                         f"Sheet '{name}' moved or resized since it was read "
@@ -458,8 +509,12 @@ class SchematicHierarchyAuthoringService:
         try:
             mutated = mutator(root_text)
         except ValueError as exc:
+            # No per-sheet lines here, and none on the write-failure path below.
+            # They describe the *plan*; on a failed path nothing was written, so
+            # printing "1 added" for a sheet the transaction rolled back would
+            # be false. The two failure returns therefore have the same shape.
             self.warn("schematic_import_sheet_pins_failed", error=str(exc))
-            return "\n".join([f"Could not import sheet pins: {exc}", *lines])
+            return f"Could not import sheet pins: {exc}"
 
         if mutated == root_text:
             return "\n".join(["Sheet pins are already up to date; nothing was written.", *lines])
@@ -470,7 +525,7 @@ class SchematicHierarchyAuthoringService:
             self.transactional_write(mutator, root_path)
         except Exception as exc:
             self.warn("schematic_import_sheet_pins_failed", error=str(exc))
-            return f"Could not write sheet pins: {exc}"
+            return f"Could not import sheet pins: {exc}"
 
         result = self.reload_schematic()
         return "\n".join([result, "Imported sheet pins.", *lines])
@@ -493,6 +548,7 @@ class SchematicHierarchyAuthoringService:
         try:
             root_text = self.read_text(root_path)
         except OSError as exc:
+            self.warn("schematic_add_sheet_pin_unreadable", sheet=sheet, error=str(exc))
             return f"Could not read the top-level schematic: {exc}"
 
         block = next(
@@ -500,6 +556,19 @@ class SchematicHierarchyAuthoringService:
             None,
         )
         if block is None:
+            skipped = next(
+                (
+                    candidate
+                    for candidate in parse_skipped_sheet_blocks(root_text)
+                    if candidate.name == sheet
+                ),
+                None,
+            )
+            if skipped is not None:
+                return (
+                    f"Sheet '{sheet}' is in {root_path.name} but cannot be addressed: "
+                    f"{skipped.reason}. Fix that block in KiCad and retry."
+                )
             return f"Sheet '{sheet}' was not found in {root_path.name}."
 
         placement = placement_on_edge(

--- a/src/kicad_mcp/schematic/sheet_pins.py
+++ b/src/kicad_mcp/schematic/sheet_pins.py
@@ -34,12 +34,21 @@ DEFAULT_PITCH_MM: Final = 2.54
 DEFAULT_MARGIN_MM: Final = 2.54
 DEFAULT_TEXT_HEIGHT_MM: Final = 1.27
 
+_FLOAT = r"-?(?:\d+(?:\.\d+)?|\.\d+)"
+"""One decimal number, with *at most one* decimal point.
+
+A looser ``[\\d.]+`` also matches nonsense like ``80.0.1``, which then reaches
+``float()`` and raises out of ``parse_sheet_blocks`` -- contradicting its
+documented contract that an unusable block is skipped. Matching only real
+numbers turns such a block back into a skip.
+"""
+
 _TAG_RE = re.compile(r"\(\s*([A-Za-z_][A-Za-z0-9_]*)")
 _SHEET_RE = re.compile(r"\(sheet(?![A-Za-z0-9_])")
-_TWO_FLOATS_RE = re.compile(r"\(\w+\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\)")
+_TWO_FLOATS_RE = re.compile(rf"\(\w+\s+({_FLOAT})\s+({_FLOAT})\s*\)")
 _PROPERTY_RE = re.compile(r'\(property\s+"((?:[^"\\]|\\.)*)"\s+"((?:[^"\\]|\\.)*)"')
 _PIN_HEAD_RE = re.compile(r'\(pin\s+"((?:[^"\\]|\\.)*)"\s+([A-Za-z_]+)')
-_PIN_AT_RE = re.compile(r"\(at\s+(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s*\)")
+_PIN_AT_RE = re.compile(rf"\(at\s+({_FLOAT})\s+({_FLOAT})\s+({_FLOAT})\s*\)")
 _UUID_RE = re.compile(r'\(uuid\s+"([^"]*)"\s*\)')
 _HIER_LABEL_RE = re.compile(
     r'\(hierarchical_label\s+"((?:[^"\\]|\\.)*)"\s*(?:\(shape\s+([A-Za-z_]+)\s*\))?'
@@ -61,6 +70,22 @@ class SheetPinRecord:
     y_mm: float
     rotation: int
     uuid: str
+
+
+@dataclass(frozen=True)
+class SkippedSheetBlock:
+    """A ``(sheet ...)`` block ``parse_sheet_blocks`` refused to address.
+
+    Kept so a caller can tell "no such sheet" from "that sheet is in the file
+    but is not safely addressable" -- on a degraded file those are very
+    different instructions to the user.
+    """
+
+    name: str
+    """``Sheetname`` if the block had a readable one, otherwise ``""``."""
+    reason: str
+    """Why it was skipped, phrased for a tool report."""
+    start: int
 
 
 @dataclass(frozen=True)
@@ -165,18 +190,18 @@ def parse_hierarchical_labels(text: str) -> tuple[tuple[str, str], ...]:
     return tuple(labels)
 
 
-def parse_sheet_blocks(text: str) -> tuple[SheetBlock, ...]:
-    """Return every ``(sheet ...)`` block of a schematic with its text spans.
-
-    Blocks that lack a name, a position, or a size are skipped: they cannot be
-    addressed or spliced safely.
-    """
-    blocks: list[SheetBlock] = []
+def _scan_sheet_blocks(text: str) -> Iterator[SheetBlock | SkippedSheetBlock]:
+    """Yield one result per ``(sheet ...)`` match: an addressable block or a skip."""
     for match in _SHEET_RE.finditer(text):
         start = match.start()
         try:
             end = _block_end(text, start)
         except ValueError:
+            yield SkippedSheetBlock(
+                name="",
+                reason="its parentheses are unbalanced",
+                start=start,
+            )
             continue
 
         name = ""
@@ -226,23 +251,52 @@ def parse_sheet_blocks(text: str) -> tuple[SheetBlock, ...]:
                 instances_start = child_start
 
         if not name or origin is None or size is None or size_span is None:
+            missing = [
+                label
+                for label, present in (
+                    ('a "Sheetname" property', bool(name)),
+                    ("a readable (at x y) position", origin is not None),
+                    ("a readable (size w h)", size is not None and size_span is not None),
+                )
+                if not present
+            ]
+            yield SkippedSheetBlock(
+                name=name,
+                reason=f"it has no {' and no '.join(missing)}",
+                start=start,
+            )
             continue
 
-        blocks.append(
-            SheetBlock(
-                name=name,
-                filename=filename,
-                origin=origin,
-                size=size,
-                pins=tuple(pins),
-                start=start,
-                end=end,
-                size_span=size_span,
-                pin_spans=tuple(pin_spans),
-                instances_start=instances_start,
-            )
+        yield SheetBlock(
+            name=name,
+            filename=filename,
+            origin=origin,
+            size=size,
+            pins=tuple(pins),
+            start=start,
+            end=end,
+            size_span=size_span,
+            pin_spans=tuple(pin_spans),
+            instances_start=instances_start,
         )
-    return tuple(blocks)
+
+
+def parse_sheet_blocks(text: str) -> tuple[SheetBlock, ...]:
+    """Return every ``(sheet ...)`` block of a schematic with its text spans.
+
+    Blocks that lack a name, a position, or a size are skipped: they cannot be
+    addressed or spliced safely. A malformed number is treated the same way --
+    the block is skipped, never a raised ``ValueError``. Use
+    ``parse_skipped_sheet_blocks`` to report what was skipped and why.
+    """
+    return tuple(block for block in _scan_sheet_blocks(text) if isinstance(block, SheetBlock))
+
+
+def parse_skipped_sheet_blocks(text: str) -> tuple[SkippedSheetBlock, ...]:
+    """Return the ``(sheet ...)`` blocks ``parse_sheet_blocks`` left out, with reasons."""
+    return tuple(
+        block for block in _scan_sheet_blocks(text) if isinstance(block, SkippedSheetBlock)
+    )
 
 
 _TEXT_WIDTH_RATIO: Final = 0.6
@@ -289,11 +343,16 @@ def edge_for_rotation(rotation: int) -> str | None:
 
 @dataclass(frozen=True)
 class SheetPinPlacement:
-    """One sheet pin, resolved to absolute schematic coordinates."""
+    """One sheet pin, resolved to absolute schematic coordinates.
+
+    There is deliberately no ``edge`` field. ``rotation`` already determines the
+    edge exactly -- ``edge_for_rotation`` is the inverse of the table both
+    producers place from -- so a stored ``edge`` would be a second copy of the
+    same fact, free to disagree with the one KiCad actually reads.
+    """
 
     name: str
     pin_type: str
-    edge: str
     x_mm: float
     y_mm: float
     rotation: int
@@ -404,7 +463,6 @@ def placement_on_edge(
     return SheetPinPlacement(
         name=name,
         pin_type=pin_type,
-        edge=edge,
         x_mm=round(x_mm, 4),
         y_mm=round(y_mm, 4),
         rotation=rotation,
@@ -518,7 +576,6 @@ def plan_sheet_pins(
                 SheetPinPlacement(
                     name=name,
                     pin_type=pin_type,
-                    edge=edge,
                     x_mm=x_mm,
                     y_mm=_snap(origin_y + margin_mm + index * pitch_mm, grid_mm),
                     rotation=rotation,
@@ -569,9 +626,36 @@ def _line_start(text: str, index: int) -> int:
     return text.rfind("\n", 0, index) + 1
 
 
-def _indent_of(text: str, index: int) -> str:
+def _indent_of(text: str, sheet: SheetBlock, index: int) -> str:
+    """Return the anchor line's leading whitespace, or refuse if it is not whitespace.
+
+    Every emitted ``(pin ...)`` line is prefixed with this string. On a
+    ``(sheet ...)`` block written on a single line -- a legal S-expression that
+    older KiCad and third-party generators do produce -- the slice before the
+    anchor is the sheet's own text, and using it as an indent would duplicate
+    the whole block once per emitted line and lose the ``(size ...)`` edit.
+
+    The corrupt result never reaches disk (the write seam rejects it on paren
+    balance, and the duplicate UUIDs independently), but the caller would see an
+    opaque "unbalanced parentheses" instead of something it can act on. This is
+    the named error.
+    """
     line_start = _line_start(text, index)
-    return text[line_start:index]
+    if line_start < sheet.start:
+        raise ValueError(
+            f"Sheet '{sheet.name}' shares its first line with earlier content, so a new "
+            "pin cannot be indented safely; refusing to risk corrupting the file. "
+            "Open the file in KiCad and save it once to get one node per line, then retry."
+        )
+    prefix = text[line_start:index]
+    if prefix.strip():
+        raise ValueError(
+            f"Sheet '{sheet.name}' has its pin anchor mid-line, after {prefix.strip()[:40]!r}, "
+            "so a new pin cannot be indented safely; refusing to risk corrupting the file. "
+            "This usually means the whole (sheet ...) block is written on one line -- "
+            "open the file in KiCad and save it once, then retry."
+        )
+    return prefix
 
 
 def _require_anchor(sheet: SheetBlock) -> int:
@@ -584,13 +668,16 @@ def _require_anchor(sheet: SheetBlock) -> int:
 
 
 def _check_non_overlapping(sheet: SheetBlock, edits: list[tuple[int, int, str]]) -> None:
-    """Guard the one precondition ``_splice`` actually depends on.
+    """Guard ``_splice``'s edit-ordering precondition.
 
     Replaying edits in descending order of ``start`` is only safe if the spans
     are pairwise non-overlapping -- see ``_splice``. A ``(pin ...)`` node
     sharing a physical source line with ``(instances ...)`` or ``(size ...)``
     would violate that (their line-widened spans would collide), so this is a
     loud, named ``ValueError`` instead of a silently corrupted schematic.
+
+    This is not the only precondition a safe write has: ``_indent_of`` guards
+    the other, that the anchor line's prefix is really indentation.
     """
     ordered = sorted(edits, key=lambda edit: edit[0])
     for previous, current in zip(ordered, ordered[1:], strict=False):
@@ -630,7 +717,7 @@ def apply_plan(text: str, sheet: SheetBlock, plan: SheetPinPlan) -> str:
         )
     ]
     edits.extend((start, end, "") for start, end in sheet.pin_spans)
-    indent = _indent_of(text, anchor)
+    indent = _indent_of(text, sheet, anchor)
     rendered = "".join(sheet_pin_block(placement, indent) for placement in plan.placements)
     line_start = _line_start(text, anchor)
     edits.append((line_start, line_start, rendered))
@@ -645,6 +732,6 @@ def insert_pin(text: str, sheet: SheetBlock, placement: SheetPinPlacement) -> st
             "Use sch_import_sheet_pins to reconcile it with the child sheet."
         )
     anchor = _require_anchor(sheet)
-    indent = _indent_of(text, anchor)
+    indent = _indent_of(text, sheet, anchor)
     line_start = _line_start(text, anchor)
     return _splice(text, sheet, [(line_start, line_start, sheet_pin_block(placement, indent))])

--- a/src/kicad_mcp/schematic/sheet_pins.py
+++ b/src/kicad_mcp/schematic/sheet_pins.py
@@ -360,7 +360,14 @@ class SheetPinPlacement:
     uuid: str
     """Existing pin's UUID, or ``""`` for a new pin the caller must stamp."""
     action: str
-    """``add``, ``retype`` or ``keep``."""
+    """``add``, ``retype``, ``move`` or ``keep``.
+
+    ``keep`` means the pin is re-emitted byte-identical -- same type, same
+    position, same rotation. A pin the layout relocates is ``move``, never
+    ``keep``: the file *is* rewritten for it, and a report that called that
+    "unchanged" would be false. A pin that is both retyped and relocated
+    reports ``retype``; either way the report says the pin changed.
+    """
 
 
 @dataclass(frozen=True)
@@ -402,6 +409,22 @@ def _is_on_grid(value: float, grid_mm: float) -> bool:
 
 def _sort_key(name: str) -> tuple[str, str]:
     return (name.casefold(), name)
+
+
+def _is_placed_at(record: SheetPinRecord | None, x_mm: float, y_mm: float, rotation: int) -> bool:
+    """Return whether an existing pin already sits exactly where the plan wants it.
+
+    Compared at the emitted precision (4 decimals), because that is what the
+    writer would put in the file -- the question is whether the write is a
+    no-op for this pin, not whether the floats are bit-identical.
+    """
+    if record is None:
+        return False
+    return (
+        round(record.x_mm, 4) == round(x_mm, 4)
+        and round(record.y_mm, 4) == round(y_mm, 4)
+        and record.rotation == rotation
+    )
 
 
 def _edge_extent(count: int, pitch_mm: float, margin_mm: float) -> float:
@@ -506,22 +529,21 @@ def plan_sheet_pins(
             continue
         desired[raw_name] = shape
 
-    existing = {pin.name: (pin.pin_type, pin.uuid) for pin in sheet.pins}
+    existing = {pin.name: pin for pin in sheet.pins}
     orphans = tuple(sorted((name for name in existing if name not in desired), key=_sort_key))
 
-    entries: list[tuple[str, str, str, str]] = []
+    entries: list[tuple[str, str, SheetPinRecord | None, str]] = []
     for name in sorted(set(desired) | set(existing), key=_sort_key):
+        record = existing.get(name)
         if name in desired:
             pin_type = desired[name]
             action = (
-                "add"
-                if name not in existing
-                else ("keep" if existing[name][0] == pin_type else "retype")
+                "add" if record is None else ("keep" if record.pin_type == pin_type else "retype")
             )
         else:
-            pin_type = existing[name][0]
+            pin_type = existing[name].pin_type
             action = "keep"
-        entries.append((name, pin_type, existing.get(name, ("", ""))[1], action))
+        entries.append((name, pin_type, record, action))
 
     left = [entry for entry in entries if entry[1] == "input"]
     right = [entry for entry in entries if entry[1] != "input"]
@@ -571,16 +593,21 @@ def plan_sheet_pins(
     for edge, column in (("left", left), ("right", right)):
         x_mm = origin_x if edge == "left" else round(origin_x + width, 4)
         rotation, justify = _EDGE_GEOMETRY[edge]
-        for index, (name, pin_type, uuid, action) in enumerate(column):
+        for index, (name, pin_type, record, action) in enumerate(column):
+            y_mm = _snap(origin_y + margin_mm + index * pitch_mm, grid_mm)
+            if action == "keep" and not _is_placed_at(record, x_mm, y_mm, rotation):
+                # The type matches, but this layout puts the pin somewhere else.
+                # The file is rewritten for it, so it is not "unchanged".
+                action = "move"
             placements.append(
                 SheetPinPlacement(
                     name=name,
                     pin_type=pin_type,
                     x_mm=x_mm,
-                    y_mm=_snap(origin_y + margin_mm + index * pitch_mm, grid_mm),
+                    y_mm=y_mm,
                     rotation=rotation,
                     justify=justify,
-                    uuid=uuid,
+                    uuid="" if record is None else record.uuid,
                     action=action,
                 )
             )

--- a/src/kicad_mcp/tools/pcb.py
+++ b/src/kicad_mcp/tools/pcb.py
@@ -10,7 +10,7 @@ import uuid
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Protocol, cast
+from typing import Annotated, Any, Protocol, cast
 
 import structlog
 from kipy.board_types import (
@@ -29,6 +29,7 @@ from kipy.proto.board import board_types_pb2
 from kipy.proto.board.board_types_pb2 import BoardLayer, ViaType, ZoneType
 from kipy.proto.common import types as common_types
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from ..config import get_config
 from ..connection import KiCadConnectionError, board_transaction, get_board
@@ -114,6 +115,7 @@ from .metadata import headless_compatible, requires_kicad_running
 from .schematic import _iter_child_sheet_paths, parse_schematic_file
 
 logger = structlog.get_logger(__name__)
+_KeepoutRegion = Annotated[list[float], Field(min_length=4, max_length=4)]
 BOARD_FILE_VERSION = "20250216"
 STRING_PATTERN = r'"((?:\\.|[^"\\])*)"'
 FLOAT_PATTERN = r"-?\d+(?:\.\d+)?"
@@ -4429,7 +4431,7 @@ def _register_advanced_placement_tools(mcp: FastMCP) -> None:
         seed: int = 42,
         grid_mm: float = 0.5,
         max_seconds: float = 0.0,
-        keepout_regions: list[tuple[float, float, float, float]] | None = None,
+        keepout_regions: list[_KeepoutRegion] | None = None,
     ) -> str:
         """Run a force-directed spring-embedder placement algorithm on a set of components.
 
@@ -4459,7 +4461,7 @@ def _register_advanced_placement_tools(mcp: FastMCP) -> None:
                 value caps runtime on pathologically large boards but makes the
                 result depend on host speed (not reproducible).
             keepout_regions: Optional rectangular keepouts as
-                ``[(x_min, y_min, x_max, y_max), ...]`` in mm.
+                ``[[x_min, y_min, x_max, y_max], ...]`` in mm.
 
         Returns:
             JSON string with optimised positions for each component.
@@ -4492,7 +4494,9 @@ def _register_advanced_placement_tools(mcp: FastMCP) -> None:
             seed=seed,
             grid_mm=grid_mm,
             max_seconds=max_seconds,
-            keepout_regions=list(keepout_regions or []),
+            keepout_regions=[
+                (region[0], region[1], region[2], region[3]) for region in keepout_regions or []
+            ],
         )
         stats: dict[str, object] = {}
         result = force_directed_placement(comps, placement_nets, cfg, stats=stats)

--- a/src/kicad_mcp/tools/schematic_hierarchy_authoring.py
+++ b/src/kicad_mcp/tools/schematic_hierarchy_authoring.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from ..models.schematic import (
     CreateSheetInput,
@@ -16,6 +18,14 @@ from ..models.schematic import (
     SheetPinInput,
 )
 from ..schematic.hierarchy_authoring import SchematicHierarchyAuthoringService
+
+_SheetPinPair = Annotated[list[str], Field(min_length=2, max_length=2)]
+"""One ``[name, pin_type]`` pair as a fixed-length array, not a tuple.
+
+A ``tuple[str, str]`` annotation makes FastMCP emit an inner array schema with
+``prefixItems`` and no ``items``, which stricter MCP hosts reject; the adapter
+normalizes back to tuples before the service sees them.
+"""
 
 
 @dataclass(frozen=True)
@@ -36,20 +46,21 @@ def register(mcp: FastMCP, dependencies: SchematicHierarchyAuthoringDependencies
         x_mm: float,
         y_mm: float,
         snap_to_grid: bool = True,
-        sheet_pins: list[tuple[str, str]] | None = None,
+        sheet_pins: list[_SheetPinPair] | None = None,
     ) -> str:
         """Create a child schematic sheet and add it to the active top-level schematic.
 
-        Optional ``sheet_pins`` is a list of ``(name, type)`` pairs laid out by
-        the same rules as ``sch_import_sheet_pins``.
+        Optional ``sheet_pins`` is a list of ``[name, type]`` two-element arrays,
+        laid out by the same rules as ``sch_import_sheet_pins``.
         """
+        normalized_pins = [] if sheet_pins is None else [(pair[0], pair[1]) for pair in sheet_pins]
         payload = CreateSheetInput(
             name=name,
             filename=filename,
             x_mm=x_mm,
             y_mm=y_mm,
             snap_to_grid=snap_to_grid,
-            sheet_pins=sheet_pins or [],
+            sheet_pins=normalized_pins,
         )
         return service.create_sheet(
             payload.name,

--- a/src/kicad_mcp/tools/schematic_hierarchy_authoring.py
+++ b/src/kicad_mcp/tools/schematic_hierarchy_authoring.py
@@ -177,6 +177,18 @@ def register(mcp: FastMCP, dependencies: SchematicHierarchyAuthoringDependencies
         measures from the top, ``bottom`` and ``top`` from the left, and ``left``
         from the bottom. Use ``sch_import_sheet_pins`` to derive every pin from
         the child sheet instead of placing them one by one.
+
+        Limitations, all deliberate:
+
+        - The position is used exactly as given. It is **not** snapped to the
+          schematic grid, so a pin placed off-grid will have no wire snap to it.
+          ``sch_import_sheet_pins`` does snap.
+        - A position past the end of an edge is accepted, which puts the pin
+          off the sheet symbol -- ``position_along_edge=1000.0`` on a 20 mm
+          sheet yields y around -949. Nothing warns.
+        - ``top`` and ``bottom`` pins survive here, but ``sch_import_sheet_pins``
+          only ever places pins on ``left`` and ``right``. A later import
+          relocates a hand-placed top or bottom pin to one of those two edges.
         """
         payload = SheetPinInput.model_validate(
             {
@@ -211,10 +223,23 @@ def register(mcp: FastMCP, dependencies: SchematicHierarchyAuthoringDependencies
 
         Every pin of a touched sheet is re-laid-out, including existing ones,
         because KiCad measures left-edge pins from the bottom -- so a growing
-        sheet would otherwise move them. Existing pins keep their name, type
-        source and UUID; pins without a matching label are reported, never
-        deleted. Sheet width growth uses an estimated text width (heuristic:
-        0.6 x font height per character), not a measured one.
+        sheet would otherwise move them. An existing pin keeps its name and its
+        UUID, and is moved to wherever this layout puts it; its type is changed
+        if the child sheet's label shape now says something else. Pins without a
+        matching label are reported, never deleted. Only the ``left`` and
+        ``right`` edges are used, so a pin hand-placed on ``top`` or ``bottom``
+        with ``sch_add_sheet_pin`` is relocated. The report counts added,
+        retyped, moved and unchanged pins separately.
+
+        ``grow_sheet`` (default on) lets the sheet symbol grow to fit its pins:
+        taller for the fuller edge, and wider if the estimated label text of the
+        two columns would collide. The sheet never shrinks and never moves.
+        Width growth uses an estimated text width (heuristic: 0.6 x font height
+        per character), not a measured one, and says so in the report. Turning
+        ``grow_sheet`` off keeps the size fixed, and any sheet whose pins then do
+        not fit is skipped **entirely** -- reported, with nothing written for it
+        -- rather than partially written. A half-pinned sheet is worse than an
+        unchanged one.
 
         Leave ``sheet`` empty to process every child sheet. Use ``dry_run`` to
         see the report without writing.

--- a/src/kicad_mcp/tools/signal_integrity.py
+++ b/src/kicad_mcp/tools/signal_integrity.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import json
 import math
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Annotated, Protocol, cast
 
 from kipy.proto.board.board_types_pb2 import ViaType
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from ..config import get_config
 from ..connection import get_board
@@ -68,6 +69,7 @@ from ..utils.units import nm_to_mm
 from ..verdicts import three_level_verdict, warn_max_from
 from .design_intent_state import resolve_design_intent
 
+_ViaPosition = Annotated[list[float], Field(min_length=2, max_length=2)]
 _DEFAULT_OUTER_DIELECTRIC_MM = 0.18
 _DEFAULT_BOARD_THICKNESS_MM = 1.6
 
@@ -857,12 +859,15 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool()
     def si_check_via_stub(
         frequency_ghz: float,
-        via_positions: list[tuple[float, float]] | None = None,
+        via_positions: list[_ViaPosition] | None = None,
         er: float = 4.0,
     ) -> str:
-        """Estimate via-stub resonance and risk for selected vias on the active board."""
+        """Estimate via-stub resonance and risk for selected vias on the active board.
+
+        ``via_positions`` are ``[x_mm, y_mm]`` two-element arrays.
+        """
         payload = ViaStubInput(
-            via_positions=via_positions or [],
+            via_positions=[(position[0], position[1]) for position in via_positions or []],
             frequency_ghz=frequency_ghz,
             er=er,
         )

--- a/tests/integration/test_schematic_sheet_pin_import.py
+++ b/tests/integration/test_schematic_sheet_pin_import.py
@@ -162,7 +162,7 @@ async def test_import_creates_one_pin_per_label_and_keeps_the_title_block(
     after = top_file.read_text(encoding="utf-8")
     assert '(pin "VIN" input' in after
     assert '(pin "VOUT" output' in after
-    assert "- child: 2 added, 0 retyped, 0 unchanged" in report
+    assert "- child: 2 added, 0 retyped, 0 moved, 0 unchanged" in report
 
     # The whole reason for the text-splice write path: everything outside the
     # sheet block -- including every (comment N ...) node -- is untouched.

--- a/tests/unit/test_schematic_hierarchy_authoring_registration.py
+++ b/tests/unit/test_schematic_hierarchy_authoring_registration.py
@@ -105,8 +105,8 @@ def test_registration_preserves_names_descriptions_and_defaults() -> None:
     }
     assert tools["sch_create_sheet"].description == (
         "Create a child schematic sheet and add it to the active top-level schematic.\n\n"
-        "Optional ``sheet_pins`` is a list of ``(name, type)`` pairs laid out by\n"
-        "the same rules as ``sch_import_sheet_pins``.\n"
+        "Optional ``sheet_pins`` is a list of ``[name, type]`` two-element arrays,\n"
+        "laid out by the same rules as ``sch_import_sheet_pins``.\n"
     )
     label_description = (
         "Add a {kind} label, preserving the requested shape and rotation.\n\n"
@@ -231,6 +231,22 @@ def test_registration_preserves_missing_label_and_pydantic_validation() -> None:
             y_mm=2.0,
             sheet_pins=[("VIN", "sideways")],
         )
+
+
+def test_create_sheet_normalizes_host_supplied_pin_arrays_to_tuples() -> None:
+    """A host sends ``[[name, type], ...]``; the service must still see tuples."""
+    server, service = _registered()
+    tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+    tools["sch_create_sheet"].fn(
+        name="Power",
+        filename="power",
+        x_mm=1.0,
+        y_mm=2.0,
+        sheet_pins=[["VIN", "input"], ["VOUT", "output"]],
+    )
+
+    assert service.calls[0][1][5] == (("VIN", "input"), ("VOUT", "output"))
 
 
 def test_create_sheet_forwards_sheet_pins_as_a_tuple() -> None:

--- a/tests/unit/test_schematic_hierarchy_authoring_service.py
+++ b/tests/unit/test_schematic_hierarchy_authoring_service.py
@@ -692,3 +692,217 @@ def test_add_sheet_pin_rejects_a_sheet_that_moved_before_the_write(tmp_path: Pat
     assert store.writes == []
     assert "02_mcu" in report
     assert "moved" in report.casefold() or "resized" in report.casefold()
+
+
+ROOT_TEXT_WITH_RIGHT_EDGE_INPUT = """(kicad_sch
+\t(sheet
+\t\t(at 80.01 30.48)
+\t\t(size 30.48 20.32)
+\t\t(property "Sheetname" "02_mcu"
+\t\t\t(at 80.01 29.77 0)
+\t\t)
+\t\t(property "Sheetfile" "child.kicad_sch"
+\t\t\t(at 80.01 51.38 0)
+\t\t)
+\t\t(pin "VIN" input
+\t\t\t(at 110.49 33.02 0)
+\t\t\t(effects
+\t\t\t\t(font
+\t\t\t\t\t(size 1.27 1.27)
+\t\t\t\t)
+\t\t\t\t(justify right)
+\t\t\t)
+\t\t\t(uuid "keep-uuid")
+\t\t)
+\t\t(instances
+\t\t\t(project "main" (path "/1" (page "2")))
+\t\t)
+\t)
+)
+"""
+"""An `input` pin on the right edge -- what ``sch_add_sheet_pin(edge="right")``
+writes. The import layout puts inputs on the left, so this pin is relocated."""
+
+VIN_ONLY_CHILD_TEXT = '(hierarchical_label "VIN"\n\t(shape input)\n\t(at 1 2 0)\n)\n'
+
+
+def test_import_sheet_pins_reports_a_repositioned_pin_as_moved(tmp_path: Path) -> None:
+    store = _TextStore(
+        {"root.kicad_sch": ROOT_TEXT_WITH_RIGHT_EDGE_INPUT, "child.kicad_sch": VIN_ONLY_CHILD_TEXT}
+    )
+    service = _pin_service(store, tmp_path / "root.kicad_sch")
+
+    report = service.import_sheet_pins(None, True, False)
+
+    written = store.files["root.kicad_sch"]
+    assert "(at 80.01 33.02 180)" in written
+    assert "- 02_mcu: 0 added, 0 retyped, 1 moved, 0 unchanged" in report
+    assert "1 unchanged" not in report
+
+
+def test_import_sheet_pins_omits_per_sheet_lines_when_nothing_was_written(
+    tmp_path: Path,
+) -> None:
+    """One sheet lacks ``(instances ...)``, so the whole transaction aborts.
+    Printing "1 added" for the sibling sheet would describe a write that never
+    happened.
+    """
+    root_text = ROOT_TEXT_TWO_SHEETS.replace(
+        '\t\t(instances\n\t\t\t(project "main" (path "/1" (page "3")))\n\t\t)\n', ""
+    )
+    store = _TextStore(
+        {
+            "root.kicad_sch": root_text,
+            "power.kicad_sch": POWER_CHILD_TEXT,
+            "mcu.kicad_sch": CHILD_TEXT,
+        }
+    )
+    service = _pin_service(store, tmp_path / "root.kicad_sch")
+
+    report = service.import_sheet_pins(None, True, False)
+
+    assert store.writes == []
+    assert "added" not in report
+    assert report.startswith("Could not import sheet pins:")
+    assert "02_mcu" in report
+
+
+def test_both_import_failure_paths_have_the_same_shape(tmp_path: Path) -> None:
+    """The replay check and the write seam must report failure identically --
+    one prefix, one line, no planning lines.
+    """
+    replay_store = _TextStore(
+        {"root.kicad_sch": ROOT_TEXT_NO_ANCHOR, "child.kicad_sch": CHILD_TEXT}
+    )
+    replay_report = _pin_service(replay_store, tmp_path / "root.kicad_sch").import_sheet_pins(
+        None, True, False
+    )
+
+    write_store = _GeometryDriftStore(
+        {"root.kicad_sch": ROOT_TEXT, "child.kicad_sch": CHILD_TEXT},
+        drifted_root_text=ROOT_TEXT_MOVED,
+    )
+    write_report = _pin_service(write_store, tmp_path / "root.kicad_sch").import_sheet_pins(
+        None, True, False
+    )
+
+    for report in (replay_report, write_report):
+        assert report.startswith("Could not import sheet pins: ")
+        assert "\n" not in report
+
+
+class _VanishingSheetStore(_TextStore):
+    """The sheet is gone from the text the write seam hands the mutator."""
+
+    def transactional_write(self, mutator, sch_file=None):  # type: ignore[no-untyped-def]
+        name = (sch_file or Path("root.kicad_sch")).name
+        if name == "root.kicad_sch":
+            self.files[name] = "(kicad_sch\n)\n"
+        return super().transactional_write(mutator, sch_file)
+
+
+def test_import_sheet_pins_reports_a_sheet_that_vanished_before_the_write(
+    tmp_path: Path,
+) -> None:
+    """Silently skipping it would still print "Imported sheet pins." and
+    "1 added" for a sheet that was never touched.
+    """
+    store = _VanishingSheetStore({"root.kicad_sch": ROOT_TEXT, "child.kicad_sch": CHILD_TEXT})
+    service = _pin_service(store, tmp_path / "root.kicad_sch")
+
+    report = service.import_sheet_pins(None, True, False)
+
+    assert "Imported sheet pins." not in report
+    assert "added" not in report
+    assert "02_mcu" in report
+    assert "disappeared" in report
+
+
+ROOT_TEXT_DEGRADED_SHEET = ROOT_TEXT.replace("\t\t(size 30.48 20.32)\n", "", 1)
+
+
+def test_import_sheet_pins_distinguishes_an_unusable_sheet_from_a_missing_one(
+    tmp_path: Path,
+) -> None:
+    store = _TextStore({"root.kicad_sch": ROOT_TEXT_DEGRADED_SHEET, "child.kicad_sch": CHILD_TEXT})
+    service = _pin_service(store, tmp_path / "root.kicad_sch")
+
+    degraded = service.import_sheet_pins("02_mcu", True, False)
+    missing = service.import_sheet_pins("nope", True, False)
+
+    assert "not found" not in degraded
+    assert "cannot be addressed" in degraded
+    assert "size" in degraded
+    assert "not found" in missing
+
+
+def test_add_sheet_pin_warns_when_the_schematic_cannot_be_read(tmp_path: Path) -> None:
+    store = _TextStore({})
+    warnings: list[tuple[str, dict[str, Any]]] = []
+    service = replace(
+        _pin_service(store, tmp_path / "root.kicad_sch"),
+        warn=lambda event, **fields: warnings.append((event, fields)),
+    )
+
+    report = service.add_sheet_pin("02_mcu", "MANUAL", "input", "left", 5.08)
+
+    assert "Could not read" in report
+    assert [event for event, _fields in warnings] == ["schematic_add_sheet_pin_unreadable"]
+
+
+def test_create_sheet_says_pins_were_not_applied_to_an_existing_sheet(tmp_path: Path) -> None:
+    root_path = tmp_path / "demo.kicad_sch"
+    service, _root, _child, _tx, _warnings = _service(
+        root_path=root_path,
+        root=_RootSchematic(duplicate=True),
+    )
+
+    report = service.create_sheet("Power", "power", 10.0, 20.0, True, (("VIN", "input"),))
+
+    assert "already exists" in report
+    assert "no sheet pins were applied" in report
+
+
+def test_create_sheet_folds_an_unreadable_root_into_its_report(tmp_path: Path) -> None:
+    """``_apply_sheet_pins`` documents that it never raises. It runs after the
+    sheet is created and saved, outside any ``try`` in ``create_sheet``, so an
+    OSError escaping it would fail a call that in fact created the sheet.
+    """
+    store = _TextStore({"root.kicad_sch": ROOT_TEXT, "child.kicad_sch": CHILD_TEXT})
+    warnings: list[tuple[str, dict[str, Any]]] = []
+
+    def _explode(_path: Path) -> str:
+        raise OSError("root vanished")
+
+    service = replace(
+        _pin_service(store, tmp_path / "root.kicad_sch"),
+        read_text=_explode,
+        warn=lambda event, **fields: warnings.append((event, fields)),
+    )
+
+    report = service.create_sheet(
+        "02_mcu", "child.kicad_sch", 80.01, 30.48, True, (("VIN", "input"),)
+    )
+
+    assert "was created" in report
+    assert "root vanished" in report
+    assert [event for event, _fields in warnings] == ["schematic_create_sheet_pins_failed"]
+
+
+def test_create_sheet_surfaces_the_heuristic_width_note(tmp_path: Path) -> None:
+    """The same disclosure sch_import_sheet_pins makes. Without it the tool can
+    widen a sheet from an estimated text width and say nothing.
+    """
+    store = _TextStore({"root.kicad_sch": ROOT_TEXT, "child.kicad_sch": CHILD_TEXT})
+    service = _pin_service(store, tmp_path / "root.kicad_sch")
+
+    report = service.create_sheet(
+        "02_mcu",
+        "child.kicad_sch",
+        80.01,
+        30.48,
+        True,
+        (("A_VERY_LONG_INPUT_SIGNAL_NAME", "input"), ("A_VERY_LONG_OUTPUT_SIGNAL_NAME", "output")),
+    )
+
+    assert "heuristic" in report

--- a/tests/unit/test_sheet_pins_emission.py
+++ b/tests/unit/test_sheet_pins_emission.py
@@ -94,7 +94,6 @@ def _placement(**overrides: object) -> SheetPinPlacement:
     base = {
         "name": "I2S_BCLK",
         "pin_type": "output",
-        "edge": "right",
         "x_mm": 110.49,
         "y_mm": 33.02,
         "rotation": 0,
@@ -276,3 +275,47 @@ def test_splice_refuses_overlapping_edits() -> None:
             sheet,
             [(sheet.start + 5, sheet.start + 15, "a"), (sheet.start + 10, sheet.start + 20, "b")],
         )
+
+
+SINGLE_LINE_ROOT = (
+    "(kicad_sch (sheet (at 80.01 30.48) (size 30.48 20.32) "
+    '(property "Sheetname" "02_mcu" (at 80.01 29.77 0)) '
+    '(property "Sheetfile" "child.kicad_sch" (at 80.01 51.38 0)) '
+    '(instances (project "main" (path "/1" (page "2"))))))\n'
+)
+"""A ``(sheet ...)`` block on one line -- legal S-expression, and what older
+KiCad and third-party generators emit. Nothing before the pin anchor on that
+line is indentation, so an unguarded ``_indent_of`` would prefix every emitted
+line with the sheet's own text."""
+
+ONE_LINE_SHEET_AT_COLUMN_ZERO = (
+    '(sheet (at 80.01 30.48) (size 30.48 20.32) (property "Sheetname" "02_mcu" '
+    '(at 80.01 29.77 0)) (instances (project "main" (path "/1" (page "2")))))\n'
+)
+"""The same hazard with the sheet starting at column zero: the anchor's line
+start is *not* before ``sheet.start``, so only the non-whitespace prefix check
+catches it."""
+
+
+def test_apply_plan_refuses_a_sheet_written_on_one_line() -> None:
+    sheet = parse_sheet_blocks(SINGLE_LINE_ROOT)[0]
+    plan = _stamp(plan_sheet_pins((("VIN", "input"),), sheet, grid_mm=GRID))
+
+    with pytest.raises(ValueError, match="02_mcu"):
+        apply_plan(SINGLE_LINE_ROOT, sheet, plan)
+
+
+def test_insert_pin_refuses_a_sheet_written_on_one_line() -> None:
+    sheet = parse_sheet_blocks(SINGLE_LINE_ROOT)[0]
+
+    with pytest.raises(ValueError, match="02_mcu"):
+        insert_pin(SINGLE_LINE_ROOT, sheet, _placement(name="MANUAL"))
+
+
+def test_apply_plan_refuses_a_one_line_sheet_starting_at_column_zero() -> None:
+    sheet = parse_sheet_blocks(ONE_LINE_SHEET_AT_COLUMN_ZERO)[0]
+    assert sheet.start == 0
+    plan = _stamp(plan_sheet_pins((("VIN", "input"),), sheet, grid_mm=GRID))
+
+    with pytest.raises(ValueError, match="mid-line"):
+        apply_plan(ONE_LINE_SHEET_AT_COLUMN_ZERO, sheet, plan)

--- a/tests/unit/test_sheet_pins_parsing.py
+++ b/tests/unit/test_sheet_pins_parsing.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import pytest
 
+from kicad_mcp.models.schematic import SheetEdge, SheetPinType
 from kicad_mcp.schematic.sheet_pins import (
+    EDGES,
     PIN_TYPES,
     SheetPinRecord,
     edge_for_rotation,
     parse_hierarchical_labels,
     parse_sheet_blocks,
+    parse_skipped_sheet_blocks,
 )
 
 SHEET_BLOCK = """(kicad_sch
@@ -154,6 +159,18 @@ def test_pin_types_are_the_kicad_vocabulary() -> None:
     assert PIN_TYPES == ("input", "output", "bidirectional", "tri_state", "passive")
 
 
+def test_the_validated_literals_match_the_runtime_tuples() -> None:
+    """The same vocabulary is declared twice -- keep the two copies identical.
+
+    ``models.schematic`` validates the tool arguments against a ``Literal`` and
+    ``sheet_pins`` checks them again at runtime against a tuple. Nothing else
+    ties the two together, so a value added to one and not the other would be
+    accepted at the boundary and rejected inside, or the reverse.
+    """
+    assert get_args(SheetPinType) == PIN_TYPES
+    assert get_args(SheetEdge) == EDGES
+
+
 @pytest.mark.parametrize("text", ["", "(kicad_sch\n)\n"])
 def test_parse_sheet_blocks_tolerates_documents_without_sheets(text: str) -> None:
     assert parse_sheet_blocks(text) == ()
@@ -194,3 +211,60 @@ def test_parse_sheet_blocks_skips_an_unbalanced_block_without_raising() -> None:
 
     assert len(blocks) == 1
     assert blocks[0].name == "05_audio"
+
+
+def test_parse_sheet_blocks_skips_a_block_whose_number_has_two_decimal_points() -> None:
+    # "80.0.1" is not a number. Matching it as one lets float() raise straight
+    # out of parse_sheet_blocks, escaping every tool entry point and breaking
+    # the function's documented contract that an unusable block is skipped.
+    text = SHEET_BLOCK.replace("(at 30.48 90.17)", "(at 80.0.1 90.17)", 1)
+
+    assert parse_sheet_blocks(text) == ()
+
+    skipped = parse_skipped_sheet_blocks(text)
+    assert len(skipped) == 1
+    assert skipped[0].name == "05_audio"
+    assert "position" in skipped[0].reason
+
+
+def test_parse_sheet_blocks_skips_a_pin_position_with_two_decimal_points() -> None:
+    # Same defect one level down: a malformed (at ...) inside a (pin ...) node
+    # must degrade to the zero fallback, not raise.
+    text = SHEET_BLOCK.replace(
+        "\t\t(instances\n",
+        '\t\t(pin "BROKEN" input\n\t\t\t(at 1.2.3 4.0 0)\n\t\t\t(uuid "u")\n\t\t)\n'
+        "\t\t(instances\n",
+        1,
+    )
+
+    blocks = parse_sheet_blocks(text)
+
+    assert len(blocks) == 1
+    assert blocks[0].pins == (
+        SheetPinRecord(name="BROKEN", pin_type="input", x_mm=0.0, y_mm=0.0, rotation=0, uuid="u"),
+    )
+
+
+def test_parse_skipped_sheet_blocks_names_a_sheet_without_a_size() -> None:
+    text = SHEET_BLOCK.replace("\t\t(size 30.48 20.32)\n", "", 1)
+
+    assert parse_sheet_blocks(text) == ()
+
+    skipped = parse_skipped_sheet_blocks(text)
+    assert len(skipped) == 1
+    assert skipped[0].name == "05_audio"
+    assert "size" in skipped[0].reason
+
+
+def test_parse_skipped_sheet_blocks_reports_an_unnamed_block() -> None:
+    text = SHEET_BLOCK.replace('"Sheetname"', '"Sheetnam"', 1)
+
+    skipped = parse_skipped_sheet_blocks(text)
+
+    assert len(skipped) == 1
+    assert skipped[0].name == ""
+    assert "Sheetname" in skipped[0].reason
+
+
+def test_parse_skipped_sheet_blocks_is_empty_for_a_healthy_document() -> None:
+    assert parse_skipped_sheet_blocks(SHEET_BLOCK) == ()

--- a/tests/unit/test_sheet_pins_planning.py
+++ b/tests/unit/test_sheet_pins_planning.py
@@ -11,23 +11,32 @@ from kicad_mcp.schematic.sheet_pins import (
 GRID = 1.27
 
 
+def _record(
+    name: str,
+    pin_type: str,
+    uuid: str,
+    *,
+    x_mm: float = 0.0,
+    y_mm: float = 0.0,
+    rotation: int = 0,
+) -> SheetPinRecord:
+    """One existing pin. Position defaults to the origin, i.e. *not* where the
+    layout would put it -- which is what makes such a pin ``move`` rather than
+    ``keep``. Tests that want ``keep`` must state the planned position.
+    """
+    return SheetPinRecord(
+        name=name, pin_type=pin_type, x_mm=x_mm, y_mm=y_mm, rotation=rotation, uuid=uuid
+    )
+
+
 def _sheet(
     *,
-    pins: tuple[tuple[str, str, str], ...] = (),
+    pins: tuple[SheetPinRecord, ...] = (),
     origin: tuple[float, float] = (80.01, 30.48),
     size: tuple[float, float] = (30.48, 20.32),
 ) -> SheetBlock:
-    """Build a ``SheetBlock`` for planning tests.
-
-    ``pins`` stays the lightweight ``(name, pin_type, uuid)`` shape these
-    tests already use -- only identity and type matter to ``plan_sheet_pins``
-    for *existing* pins, which computes fresh positions for everything it
-    places. Position/rotation are stubbed at the origin.
-    """
-    records = tuple(
-        SheetPinRecord(name=name, pin_type=pin_type, x_mm=0.0, y_mm=0.0, rotation=0, uuid=uuid)
-        for name, pin_type, uuid in pins
-    )
+    """Build a ``SheetBlock`` for planning tests."""
+    records = pins
     return SheetBlock(
         name="02_mcu",
         filename="main_02_mcu.kicad_sch",
@@ -113,7 +122,9 @@ def test_positions_are_snapped_to_the_schematic_grid() -> None:
 
 
 def test_existing_pin_with_the_same_type_is_kept_with_its_uuid() -> None:
-    sheet = _sheet(pins=(("IN", "input", "aaaa-bbbb"),))
+    sheet = _sheet(
+        pins=(_record("IN", "input", "aaaa-bbbb", x_mm=80.01, y_mm=33.02, rotation=180),)
+    )
 
     plan = plan_sheet_pins((("IN", "input"),), sheet, grid_mm=GRID)
 
@@ -122,7 +133,7 @@ def test_existing_pin_with_the_same_type_is_kept_with_its_uuid() -> None:
 
 
 def test_existing_pin_with_a_different_type_is_retyped_to_match_the_child() -> None:
-    sheet = _sheet(pins=(("IN", "input", "aaaa-bbbb"),))
+    sheet = _sheet(pins=(_record("IN", "input", "aaaa-bbbb"),))
 
     plan = plan_sheet_pins((("IN", "output"),), sheet, grid_mm=GRID)
 
@@ -143,7 +154,7 @@ def test_a_new_pin_carries_an_empty_uuid_for_the_caller_to_fill() -> None:
 
 
 def test_a_pin_without_a_matching_label_is_reported_but_never_dropped() -> None:
-    sheet = _sheet(pins=(("STALE", "output", "cccc"),))
+    sheet = _sheet(pins=(_record("STALE", "output", "cccc"),))
 
     plan = plan_sheet_pins((("IN", "input"),), sheet, grid_mm=GRID)
 
@@ -186,7 +197,17 @@ def test_the_plan_is_stable_across_runs() -> None:
     labels = (("B", "input"), ("A", "output"))
     first = plan_sheet_pins(labels, _sheet(), grid_mm=GRID)
     sheet = _sheet(
-        pins=tuple((p.name, p.pin_type, "uuid-" + p.name) for p in first.placements),
+        pins=tuple(
+            _record(
+                p.name,
+                p.pin_type,
+                "uuid-" + p.name,
+                x_mm=p.x_mm,
+                y_mm=p.y_mm,
+                rotation=p.rotation,
+            )
+            for p in first.placements
+        ),
         size=first.size,
     )
 
@@ -210,3 +231,36 @@ def test_placement_on_edge_mirrors_the_library_edge_semantics() -> None:
     assert (bottom.x_mm, bottom.y_mm, bottom.rotation, bottom.justify) == (85.09, 50.8, 270, "left")
     assert (left.x_mm, left.y_mm, left.rotation, left.justify) == (80.01, 45.72, 180, "left")
     assert (top.x_mm, top.y_mm, top.rotation, top.justify) == (85.09, 30.48, 90, "right")
+
+
+def test_an_existing_pin_the_layout_relocates_is_moved_not_kept() -> None:
+    """An `input` pin on the right edge -- exactly what ``sch_add_sheet_pin``
+    with ``edge="right"`` produces -- is relocated to the left column by the
+    import layout. Its type is unchanged, but the file is rewritten for it, so
+    calling it "unchanged" would be a false report of the write.
+    """
+    sheet = _sheet(pins=(_record("VIN", "input", "aaaa", x_mm=110.49, y_mm=33.02, rotation=0),))
+
+    plan = plan_sheet_pins((("VIN", "input"),), sheet, grid_mm=GRID)
+
+    placement = plan.placements[0]
+    assert placement.action == "move"
+    assert (placement.x_mm, placement.y_mm, placement.rotation) == (80.01, 33.02, 180)
+    assert placement.uuid == "aaaa"
+
+
+def test_an_orphan_pin_the_layout_relocates_is_moved_not_kept() -> None:
+    sheet = _sheet(pins=(_record("STALE", "output", "cccc"),))
+
+    plan = plan_sheet_pins((), sheet, grid_mm=GRID)
+
+    assert plan.orphans == ("STALE",)
+    assert plan.placements[0].action == "move"
+
+
+def test_a_retyped_pin_that_also_moves_still_reports_retype() -> None:
+    sheet = _sheet(pins=(_record("IN", "input", "aaaa"),))
+
+    plan = plan_sheet_pins((("IN", "output"),), sheet, grid_mm=GRID)
+
+    assert plan.placements[0].action == "retype"

--- a/tests/unit/test_sheet_pins_planning.py
+++ b/tests/unit/test_sheet_pins_planning.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from kicad_mcp.schematic.sheet_pins import (
     SheetBlock,
     SheetPinRecord,
+    edge_for_rotation,
     placement_on_edge,
     plan_sheet_pins,
 )
@@ -53,8 +54,10 @@ def test_inputs_go_left_and_everything_else_goes_right() -> None:
     plan = plan_sheet_pins(labels, _sheet(), grid_mm=GRID)
 
     by_name = {p.name: p for p in plan.placements}
-    assert by_name["USB_DP"].edge == "left"
-    assert {by_name[n].edge for n in ("I2C1_SDA", "I2S_BCLK", "SENSE", "HIZ")} == {"right"}
+    assert edge_for_rotation(by_name["USB_DP"].rotation) == "left"
+    assert {
+        edge_for_rotation(by_name[n].rotation) for n in ("I2C1_SDA", "I2S_BCLK", "SENSE", "HIZ")
+    } == {"right"}
 
 
 def test_each_edge_is_alphabetical_and_pitched() -> None:
@@ -62,7 +65,7 @@ def test_each_edge_is_alphabetical_and_pitched() -> None:
 
     plan = plan_sheet_pins(labels, _sheet(), grid_mm=GRID)
 
-    left = [p for p in plan.placements if p.edge == "left"]
+    left = [p for p in plan.placements if edge_for_rotation(p.rotation) == "left"]
     assert [p.name for p in left] == ["alpha", "Bravo", "CHARLIE"]
     assert [p.y_mm for p in left] == [33.02, 35.56, 38.1]
 
@@ -70,8 +73,8 @@ def test_each_edge_is_alphabetical_and_pitched() -> None:
 def test_left_pins_sit_on_the_left_border_and_face_inward() -> None:
     plan = plan_sheet_pins((("IN", "input"), ("OUT", "output")), _sheet(), grid_mm=GRID)
 
-    left = next(p for p in plan.placements if p.edge == "left")
-    right = next(p for p in plan.placements if p.edge == "right")
+    left = next(p for p in plan.placements if edge_for_rotation(p.rotation) == "left")
+    right = next(p for p in plan.placements if edge_for_rotation(p.rotation) == "right")
     assert (left.x_mm, left.rotation, left.justify) == (80.01, 180, "left")
     assert (right.x_mm, right.rotation, right.justify) == (110.49, 0, "right")
 
@@ -124,7 +127,11 @@ def test_existing_pin_with_a_different_type_is_retyped_to_match_the_child() -> N
     plan = plan_sheet_pins((("IN", "output"),), sheet, grid_mm=GRID)
 
     placement = plan.placements[0]
-    assert (placement.action, placement.pin_type, placement.edge) == ("retype", "output", "right")
+    assert (
+        placement.action,
+        placement.pin_type,
+        edge_for_rotation(placement.rotation),
+    ) == ("retype", "output", "right")
     assert placement.uuid == "aaaa-bbbb"
 
 
@@ -185,8 +192,8 @@ def test_the_plan_is_stable_across_runs() -> None:
 
     second = plan_sheet_pins(labels, sheet, grid_mm=GRID)
 
-    assert [(p.name, p.edge, p.x_mm, p.y_mm) for p in second.placements] == [
-        (p.name, p.edge, p.x_mm, p.y_mm) for p in first.placements
+    assert [(p.name, p.rotation, p.x_mm, p.y_mm) for p in second.placements] == [
+        (p.name, p.rotation, p.x_mm, p.y_mm) for p in first.placements
     ]
     assert {p.action for p in second.placements} == {"keep"}
 

--- a/tests/unit/test_tool_schema_contract.py
+++ b/tests/unit/test_tool_schema_contract.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from jsonschema import Draft202012Validator
+from mcp.types import Tool
 
+from kicad_mcp.operating_modes import OperatingMode
 from kicad_mcp.server import build_server
 from kicad_mcp.server_info import get_server_info_contract
+from kicad_mcp.tools.router import available_profiles
 
 SCHEMA_ROOT = Path(__file__).resolve().parents[2] / "packages" / "protocol-schemas" / "schemas"
 TOOL_DISCOVERY_SCHEMA = SCHEMA_ROOT / "mcp-tool-discovery.schema.json"
@@ -63,17 +66,54 @@ def test_every_tool_has_valid_input_schema() -> None:
         Draft202012Validator.check_schema(schema)
 
 
+def _declared_tools() -> dict[str, Tool]:
+    """Return every tool any declared profile can surface, keyed by name.
+
+    ``build_server("full")`` on its own is not enough. Its listing is narrowed
+    twice more -- by the default read-only operating mode and by the runtime IPC
+    filter -- so on a machine with no KiCad running it contains no mutating tool
+    at all, and a broken write-tool schema sails straight through. Both
+    narrowings are lifted here deliberately: an input schema is a static
+    contract, and every tool listed by any profile has to satisfy it.
+    """
+    tools: dict[str, Tool] = {}
+    for profile in available_profiles():
+        server = build_server(profile)
+        server.operating_mode = OperatingMode.EXPERIMENTAL
+        server.allow_experimental_tools = True
+        server.filter_runtime_tools = False
+        for tool in server.list_tools_sync():
+            tools.setdefault(tool.name, tool)
+    return tools
+
+
 def test_every_array_schema_declares_items_for_host_compatibility() -> None:
     """Stricter MCP hosts require every array node to declare ``items``."""
-    server = build_server("full")
     violations: list[str] = []
 
-    for tool in server.list_tools_sync():
-        violations.extend(
-            f"{tool.name}:{path}" for path in _array_paths_missing_items(tool.inputSchema)
-        )
+    for name, tool in sorted(_declared_tools().items()):
+        violations.extend(f"{name}:{path}" for path in _array_paths_missing_items(tool.inputSchema))
 
     assert not violations, "array schemas missing items: " + ", ".join(violations)
+
+
+def test_sch_create_sheet_sheet_pins_is_a_host_compatible_array() -> None:
+    """``sheet_pins`` must be a list of two-element string arrays, not tuples.
+
+    Regression guard for the ``list[tuple[str, str]]`` signature, which emits an
+    inner ``prefixItems`` array with no ``items``. The tool is a write tool, so
+    it is invisible to a plain ``build_server("full")`` listing -- which is
+    exactly how the defect reached this branch.
+    """
+    tool = _declared_tools()["sch_create_sheet"]
+    schema = tool.inputSchema["properties"]["sheet_pins"]
+    pair_schema = schema["anyOf"][0]["items"]
+
+    assert pair_schema["type"] == "array"
+    assert pair_schema["minItems"] == 2
+    assert pair_schema["maxItems"] == 2
+    assert pair_schema["items"] == {"type": "string"}
+    assert "prefixItems" not in pair_schema
 
 
 def test_every_tool_input_schema_root_is_object() -> None:


### PR DESCRIPTION
Follow-up to #626. These four commits were pushed to that PR's branch but
arrived after it was merged, so they are not in `main`. Sorry for the split —
they belong with #626 and are only separate because of the timing.

Two of them matter more than the rest.

## 1. `sch_create_sheet` reintroduced the array-schema pattern #618 removed

#626 added `sheet_pins: list[tuple[str, str]]`, which emits an inner
`{"type": "array", "prefixItems": [...]}` with no `items` — the shape #618
fixed in `sch_find_free_placement` because stricter MCP hosts reject it. This
fixes it the same way: `Annotated[list[str], Field(min_length=2, max_length=2)]`
on the tool parameter, normalised to tuples inside the adapter. The service and
the pure module are untouched.

**Why the existing check did not catch it**, which is the more useful half:
`scripts/check_tool_contracts.py` and
`test_every_array_schema_declares_items_for_host_compatibility` each build the
server once, in the default `readonly` operating mode with the IPC runtime
filter on. That lists 131 of 380 registered tools, and none of them mutating.
`sch_find_free_placement` is read-only, so it was visible; `sch_create_sheet` is
not, so it never was. The profile allowlists were not the limiting factor — the
operating mode and the runtime filter were.

So both checks are widened across all three axes. The union of what they now
see is 380, i.e. every registered tool. That turned two pre-existing violations
red, in `pcb_auto_place_force_directed` and `si_check_via_stub`, and both are
fixed here with the same minimal #618 treatment: one alias, one annotation, one
docstring line, tuple normalisation at the adapter boundary. Nothing else in
those modules is touched.

Note that `test_every_tool_has_valid_input_schema` and
`test_every_tool_input_schema_root_is_object` still build the narrow listing and
remain blind to write tools. Widening those two is the obvious next step, but it
changes what they assert about a lot of tools at once, so it is left to you.

## 2. `sch_import_sheet_pins` reported things the write did not do

Two false statements, both reproducible on #626 as merged:

- A pin whose type matched but whose **position** changed was counted `keep` and
  reported "unchanged", while the file was rewritten. `SheetPinPlacement.action`
  gains `move`, and the report counts it separately.
- On the `ValueError` path, the per-sheet planning lines were printed *after* the
  failure, so a root where one sheet lacks `(instances ...)` reported "1 added"
  for sheets where nothing was written. The two error returns also had different
  shapes; they are now identical and neither appends planning lines.

`CONTRIBUTING.md`'s honesty rule is explicit about this, and the report is the
only feedback a tool that rewrites schematics gives.

## The rest

- `_indent_of` assumed the text before the splice anchor was whitespace. For a
  `(sheet ...)` block written on one line — legal, and produced by older KiCad
  and third-party generators — it returned the sheet's own preceding text and
  used it as the emitted pin's indent. `_validate_schematic_text` always caught
  the result on paren balance, so nothing could reach disk, but the caller saw
  "unbalanced parentheses" instead of a named error. Now guarded like
  `_check_non_overlapping`, whose docstring no longer claims to be the only
  precondition.
- `_apply_sheet_pins` documented "Never raises" but had no guard and was called
  outside any `try`, so a read or parse failure escaped `sch_create_sheet` after
  the sheet had been created and saved. Guarded; the failure is folded into the
  returned report.
- `_TWO_FLOATS_RE` and `_PIN_AT_RE` accepted multiple decimal points, so
  `(at 80.0.1 30.48)` raised an uncaught `ValueError` out of
  `parse_sheet_blocks` — escaping all four tool entry points and contradicting
  that function's documented "blocks that lack a position are skipped".
- A sheet that vanished between read and write was silently skipped while the
  run still reported "Imported sheet pins."; it now raises a reported error, as
  `sch_add_sheet_pin` already did for the same race.
- `sch_import_sheet_pins(sheet="X")` said "was not found" when the parser had
  merely skipped a degraded block; the two cases are now distinguished.
- Docstring corrections: `grow_sheet` was undocumented, including that turning it
  off skips an overflowing sheet entirely rather than writing it partially;
  `sch_add_sheet_pin` did not say it performs no grid snapping and accepts
  positions outside the sheet; neither tool said that an import relocates
  hand-placed `top`/`bottom` pins to `left`/`right`; and "keep their name, type
  source and UUID" read as a promise that a retyped pin breaks.
- `SheetPinPlacement.edge` was written but never read in production and is
  removed. `plan.notes` — including the estimated-text-width disclosure — were
  dropped on the `sch_create_sheet` path and are now surfaced there too.

All green against current `main`: unit, integration, mypy, ruff, architecture
boundaries and the widened contract lint. The one unit failure is the
pre-existing `test_cli_init.py::test_default_path_uses_home_dir`, which `rmdir`s
the real `~/.kicad-mcp`.
