### PR TITLE
fix(ci): require protected checks in Mergify queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,20 @@ queue_rules:
     merge_method: squash
     branch_protection_injection_mode: queue
     max_checks_retries: 0
+    merge_conditions:
+      - check-success = mcp-server (ubuntu-24.04)
+      - check-success = mcp-server (windows-2025)
+      - check-success = mcp-server (macos-15)
+      - check-success = mcp-npm (ubuntu-24.04)
+      - check-success = mcp-npm (windows-2025)
+      - check-success = mcp-npm (macos-15)
+      - check-success = protocol-schemas
+      - check-success = scan
+      - check-success = analyze (python)
+      - check-success = analyze (javascript-typescript)
+      - check-success = Required PR Gate
+      - check-success = dependency-review
+      - check-success = Live Model Release Policy
     queue_conditions:
       - base = main
       - author = dependabot[bot]

--- a/docs/development/dependency-management.md
+++ b/docs/development/dependency-management.md
@@ -30,10 +30,13 @@ per-ecosystem groups and are never mixed with routine version-update groups.
 Dependabot pull requests are ordinary protected pull requests: required CI and the
 `main` ruleset still apply, and no dependency bot is allowed to bypass those gates.
 Mergify provides a serial, one-PR-at-a-time queue for the routine grouped version
-updates only. Its queue injects the repository's GitHub protection/ruleset conditions,
-uses squash merges, and does not retry failed checks automatically. Human-authored,
-release, security, major, and otherwise ungrouped dependency pull requests remain a
-maintainer decision.
+updates only. The queue explicitly mirrors every required status-check context from
+`.github/rulesets/main.json` as a successful-check merge condition; automatic GitHub
+ruleset discovery is defense-in-depth rather than the enforcement source. The mirror is
+covered by a repository regression test so ruleset/check changes cannot silently drift.
+The queue uses squash merges and does not retry failed checks automatically.
+Human-authored, release, security, major, and otherwise ungrouped dependency pull
+requests remain a maintainer decision.
 
 ## Lockfile maintenance
 

--- a/docs/engineering/ci-cd-policy.md
+++ b/docs/engineering/ci-cd-policy.md
@@ -147,9 +147,11 @@ minor/patch version updates are grouped per ecosystem, while major and runtime-s
 updates remain individually reviewable and security updates use separate groups.
 Required status checks and the active `main` ruleset remain authoritative; neither
 Dependabot nor Mergify bypasses them. Mergify may automatically queue only the explicitly
-allowlisted routine Dependabot groups, one PR at a time, after applying the repository's
-GitHub protection/ruleset conditions. Human, release, security, major, and other
-ungrouped PRs are not auto-queued by repository policy.
+allowlisted routine Dependabot groups, one PR at a time. Its merge conditions explicitly
+mirror the required contexts declared in `.github/rulesets/main.json`; repository tests
+require an exact match, so Mergify does not rely on external ruleset-discovery APIs to
+decide that CI is complete. Human, release, security, major, and other ungrouped PRs are
+not auto-queued by repository policy.
 
 ### SonarQube Cloud scope
 

--- a/tests/unit/test_release_preflight_guard.py
+++ b/tests/unit/test_release_preflight_guard.py
@@ -400,6 +400,27 @@ def test_mergify_only_autoqueues_safe_grouped_dependabot_updates() -> None:
     assert "security" not in head_condition
 
 
+def test_mergify_merge_conditions_mirror_repository_ruleset_required_checks() -> None:
+    ruleset = json.loads((ROOT / ".github" / "rulesets" / "main.json").read_text(encoding="utf-8"))
+    required_contexts = {
+        check["context"]
+        for rule in ruleset["rules"]
+        if rule["type"] == "required_status_checks"
+        for check in rule["parameters"]["required_status_checks"]
+    }
+    assert required_contexts
+
+    mergify = yaml.safe_load((ROOT / ".mergify.yml").read_text(encoding="utf-8"))
+    queue = next(rule for rule in mergify["queue_rules"] if rule["name"] == "safe-dependencies")
+    explicit_check_conditions = {
+        condition.removeprefix("check-success = ")
+        for condition in queue["merge_conditions"]
+        if condition.startswith("check-success = ")
+    }
+
+    assert explicit_check_conditions == required_contexts
+
+
 def test_release_preflight_rejects_missing_tauri_lockfile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- mirror every required status-check context from `.github/rulesets/main.json` into Mergify `merge_conditions`
- keep automatic GitHub ruleset injection as defense-in-depth, not the sole enforcement source
- add a regression test requiring an exact set match so ruleset/check changes cannot silently drift from Mergify
- clarify dependency/CI policy documentation

## Safety context

The merge queue is intentionally paused while this change is reviewed. It will remain paused after merge until a queued Dependabot group demonstrates that all explicit required checks are enforced before scheduling.

## Verification

- TDD RED: existing Mergify queue had no `merge_conditions`
- GREEN: explicit check conditions exactly match all 13 contexts in `.github/rulesets/main.json`
- ruleset + release-preflight policy tests: 27 passed
- full benchmark-excluded unit suite: return code 0, 3 existing skips
- `check:meta`, architecture/compatibility and `git diff --check`: passed
- Mergify CLI 2026.8.7.1: config valid
- Mergify simulation confirms the allowlisted grouped Dependabot branch rule still matches
- staged secret-like scan: 0 findings; pre-commit passed
- pre-push: Ruff + 24 targeted tests passed
