### PR TITLE
fix(ci): allow safe GitHub Action SHA rotations

### DIFF
--- a/scripts/check_docker_metadata.py
+++ b/scripts/check_docker_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 import tomllib
 from pathlib import Path
@@ -11,6 +12,13 @@ REPO_ROOT = PACKAGE_ROOT
 MCP_SERVER_NAME = "io.github.oaslananka/kicad-mcp-pro"
 GHCR_IMAGE = "ghcr.io/oaslananka/kicad-mcp-pro"
 OLD_GHCR_IMAGE = "ghcr.io/oaslananka/kicad-mcp-pro/kicad-mcp-pro"
+
+
+def _has_sha_pinned_action(workflow_text: str, action_path: str) -> bool:
+    pattern = re.compile(
+        rf"(?m)^\s*(?:-\s*)?uses:\s*{re.escape(action_path)}@[0-9a-fA-F]{{40}}(?:\s+#.*)?\s*$"
+    )
+    return pattern.search(workflow_text) is not None
 
 
 def _read(path: str) -> str:
@@ -98,34 +106,13 @@ def main() -> int:
         "outputs: type=cacheonly": "container workflow must verify multi-arch builds on PRs",
         "packages: write": "container workflow must have GHCR package write permission",
         "id-token: write": "container workflow must have OIDC permission for signing",
-        "docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a": (
-            "container workflow must pin setup-qemu-action"
-        ),
         "tonistiigi/binfmt:qemu-v10.0.4@sha256:": (
             "container workflow must pin the QEMU binfmt image by digest"
-        ),
-        "docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5": (
-            "container workflow must pin setup-buildx-action"
         ),
         "moby/buildkit:v0.26.2@sha256:": (
             "container workflow must pin the BuildKit driver image by digest"
         ),
-        "docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee": (
-            "container workflow must pin docker/login-action"
-        ),
-        "docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9": (
-            "container workflow must pin docker/metadata-action"
-        ),
-        "docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf": (
-            "container workflow must pin docker/build-push-action"
-        ),
-        "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25": (
-            "container workflow must pin trivy-action"
-        ),
         "version: v0.70.0": "container workflow must pin Trivy CLI",
-        "sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6": (
-            "container workflow must pin cosign-installer"
-        ),
         "cosign-release: v3.0.6": "container workflow must pin cosign CLI",
         "cosign sign --yes": "container workflow must sign the image digest",
         "sbom: true": "container workflow must attach a BuildKit SBOM",
@@ -133,6 +120,19 @@ def main() -> int:
     }
     for marker, message in workflow_markers.items():
         if marker not in container_workflow:
+            errors.append(message)
+
+    required_actions = {
+        "docker/setup-qemu-action": "container workflow must pin setup-qemu-action",
+        "docker/setup-buildx-action": "container workflow must pin setup-buildx-action",
+        "docker/login-action": "container workflow must pin docker/login-action",
+        "docker/metadata-action": "container workflow must pin docker/metadata-action",
+        "docker/build-push-action": "container workflow must pin docker/build-push-action",
+        "aquasecurity/trivy-action": "container workflow must pin trivy-action",
+        "sigstore/cosign-installer": "container workflow must pin cosign-installer",
+    }
+    for action_path, message in required_actions.items():
+        if not _has_sha_pinned_action(container_workflow, action_path):
             errors.append(message)
 
     docs_to_scan = [

--- a/scripts/check_github_actions_policy.py
+++ b/scripts/check_github_actions_policy.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import re
 from pathlib import Path
+from typing import cast
 
 import yaml
 
@@ -41,6 +42,15 @@ def _iter_uses(value: object) -> list[str]:
     return found
 
 
+def has_sha_pinned_action(workflow_text: str, action_path: str) -> bool:
+    """Return whether workflow text uses an Action path at an immutable SHA."""
+    pattern = re.compile(
+        rf"(?m)^\s*(?:-\s*)?uses:\s*['\"]?{re.escape(action_path)}@"
+        rf"[0-9a-fA-F]{{40}}['\"]?(?:\s+#.*)?\s*$"
+    )
+    return pattern.search(workflow_text) is not None
+
+
 def _permission_writes(value: object, context: str, errors: list[str]) -> set[str]:
     if value is None:
         return set()
@@ -71,9 +81,11 @@ def validate_repository(root: Path, policy: dict[str, object]) -> list[str]:
     if settings != expected_settings:
         errors.append("actions-policy.json: repository_settings do not match the hardened baseline")
 
-    github_owned = set(policy.get("github_owned_action_owners", []))
-    allowed_repositories = set(policy.get("allowed_action_repositories", []))
-    allowed_transitive_repositories = set(policy.get("allowed_transitive_action_repositories", []))
+    github_owned = set(cast(list[str], policy.get("github_owned_action_owners", [])))
+    allowed_repositories = set(cast(list[str], policy.get("allowed_action_repositories", [])))
+    allowed_transitive_repositories = set(
+        cast(list[str], policy.get("allowed_transitive_action_repositories", []))
+    )
     overlapping_repositories = sorted(allowed_repositories & allowed_transitive_repositories)
     if overlapping_repositories:
         errors.append(
@@ -180,7 +192,7 @@ def validate_repository(root: Path, policy: dict[str, object]) -> list[str]:
         for line in codeowners_path.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     }
-    required_rules = set(policy.get("required_codeowner_rules", []))
+    required_rules = set(cast(list[str], policy.get("required_codeowner_rules", [])))
     missing_rules = sorted(required_rules - codeowners)
     if missing_rules:
         errors.append(f"CODEOWNERS is missing protected rules: {missing_rules!r}")

--- a/tests/unit/test_docker_image.py
+++ b/tests/unit/test_docker_image.py
@@ -9,7 +9,18 @@ from pathlib import Path
 
 import pytest
 
+from scripts import check_docker_metadata
+
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_docker_metadata_action_pin_contract_accepts_sha_rotation() -> None:
+    action = "docker/setup-qemu-action"
+    workflow = f"uses: {action}@{'a' * 40}"
+
+    assert check_docker_metadata._has_sha_pinned_action(workflow, action)
+    assert not check_docker_metadata._has_sha_pinned_action(f"uses: {action}@v3", action)
+    assert not check_docker_metadata._has_sha_pinned_action(workflow, "docker/setup-buildx-action")
 
 
 def _docker() -> str:

--- a/tests/unit/test_github_actions_policy.py
+++ b/tests/unit/test_github_actions_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import scripts.check_github_actions_policy as actions_policy
 from scripts.check_github_actions_policy import load_policy, validate_repository
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -75,6 +76,44 @@ jobs:
     errors = validate_repository(tmp_path, _baseline_policy())
 
     assert any("not pinned to a 40-character SHA" in error for error in errors)
+
+
+def test_sha_pinned_action_check_accepts_revision_changes_and_rejects_tags() -> None:
+    first_sha = "a" * 40
+    second_sha = "b" * 40
+    workflow = f"""jobs:
+  attest:
+    steps:
+      - uses: actions/attest@{first_sha}
+      - name: second
+        uses: actions/attest@{second_sha}
+"""
+
+    assert actions_policy.has_sha_pinned_action(workflow, "actions/attest")
+    assert not actions_policy.has_sha_pinned_action(
+        workflow.replace(f"actions/attest@{first_sha}", "actions/attest@v4").replace(
+            f"actions/attest@{second_sha}", "actions/attest@main"
+        ),
+        "actions/attest",
+    )
+    assert not actions_policy.has_sha_pinned_action(workflow, "actions/attestation")
+
+
+def test_sha_pinned_action_check_scans_concatenated_workflow_text() -> None:
+    sha = "c" * 40
+    workflows = f"""name: first
+jobs:
+  one:
+    steps:
+      - uses: dorny/paths-filter@{sha}
+name: second
+jobs:
+  two:
+    steps:
+      - run: echo done
+"""
+
+    assert actions_policy.has_sha_pinned_action(workflows, "dorny/paths-filter")
 
 
 def test_policy_rejects_unexpected_job_write_scope(tmp_path: Path) -> None:

--- a/tests/unit/test_gui_release_evidence.py
+++ b/tests/unit/test_gui_release_evidence.py
@@ -8,6 +8,8 @@ from types import ModuleType
 
 import pytest
 
+from scripts.check_github_actions_policy import has_sha_pinned_action
+
 ROOT = Path(__file__).resolve().parents[2]
 CHECKSUM_NAME = "kicad-mcp-pro-gui-SHA256SUMS.txt"
 SBOM_NAME = "kicad-mcp-pro-gui-sbom.cdx.json"
@@ -187,7 +189,7 @@ def test_gui_release_workflow_attests_and_verifies_published_installer_inventory
     assert "scripts/generate_gui_release_evidence.py generate" in workflow
     assert "scripts/generate_gui_release_evidence.py verify-local" in workflow
     assert "scripts/generate_gui_release_evidence.py verify-published" in workflow
-    assert "actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26" in workflow
+    assert has_sha_pinned_action(workflow, "actions/attest")
     assert f"subject-checksums: release-evidence/gui/{CHECKSUM_NAME}" in workflow
     assert f"sbom-path: release-evidence/gui/{SBOM_NAME}" in workflow
     assert "attestations: write" in workflow

--- a/tests/unit/test_release_hardening.py
+++ b/tests/unit/test_release_hardening.py
@@ -16,6 +16,7 @@ from kicad_mcp.compatibility import MCP_PROTOCOL_VERSION
 from kicad_mcp.config import get_config, reset_config
 from kicad_mcp.discovery import CliCapabilities
 from kicad_mcp.server import CLI_FAILURE_TOOL_NAMES, HEAVY_TOOL_NAMES, build_server
+from scripts.check_github_actions_policy import has_sha_pinned_action
 from tests.conftest import call_tool_text
 
 EXPOSED_HOST = "0." + "0.0.0"
@@ -641,10 +642,7 @@ def test_release_and_publish_workflows_are_monorepo_ready() -> None:
     publish_extension = _workflow("publish-extension.yml")
     publish_mcp = _workflow("publish-mcp-registry.yml")
 
-    assert (
-        "googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7"
-        in release_please
-    )
+    assert has_sha_pinned_action(release_please, "googleapis/release-please-action")
     assert "config-file: release-please-config.json" in release_please
     assert "manifest-file: .release-please-manifest.json" in release_please
     assert "set -euo pipefail" in release_please
@@ -656,7 +654,7 @@ def test_release_and_publish_workflows_are_monorepo_ready() -> None:
     assert "--head release-please--branches--main" not in release_please
 
     assert "id-token: write" in publish_python
-    assert "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in publish_python
+    assert has_sha_pinned_action(publish_python, "pypa/gh-action-pypi-publish")
     assert "PYPI_TOKEN" not in publish_python
     assert "TEST_PYPI_TOKEN" not in publish_python
 
@@ -689,7 +687,7 @@ def test_security_and_publish_workflows_emit_supply_chain_evidence() -> None:
     publish_python = _workflow("publish-python.yml")
     publish_extension = _workflow("publish-extension.yml")
 
-    assert "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294" in security
+    assert has_sha_pinned_action(security, "actions/dependency-review-action")
     assert "fail-on-severity: high" in security
     assert "show-patched-versions: true" in security
 
@@ -731,7 +729,7 @@ def test_mcpb_release_workflow_attaches_attested_versioned_bundle() -> None:
     assert 'SOURCE_COMMIT="$(git rev-parse HEAD)"' in workflow
     assert '"sourceCommit": os.environ["SOURCE_COMMIT"]' in workflow
     assert '"sourceCommit": os.environ["GITHUB_SHA"]' not in workflow
-    assert "actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26" in workflow
+    assert has_sha_pinned_action(workflow, "actions/attest")
     assert "subject-checksums: release-assets/mcpb/kicad-mcp-pro-mcpb-SHA256SUMS.txt" in workflow
     assert 'gh release upload "$release_tag" release-assets/mcpb/* --clobber' in workflow
     assert "attestations: write" in workflow
@@ -803,22 +801,16 @@ def test_docker_metadata_contains_mcp_oci_label_and_release_image_contract() -> 
     assert "ghcr.io/oaslananka/kicad-mcp-pro:latest" in container_workflow
     assert "packages: write" in container_workflow
     assert "id-token: write" in container_workflow
-    assert "docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a" in container_workflow
+    assert has_sha_pinned_action(container_workflow, "docker/setup-qemu-action")
     assert "tonistiigi/binfmt:qemu-v10.0.4@sha256:" in container_workflow
-    assert (
-        "docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5" in container_workflow
-    )
+    assert has_sha_pinned_action(container_workflow, "docker/setup-buildx-action")
     assert "moby/buildkit:v0.26.2@sha256:" in container_workflow
-    assert "docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee" in container_workflow
-    assert "docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9" in container_workflow
-    assert "docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf" in container_workflow
-    assert (
-        "sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6" in container_workflow
-    )
+    assert has_sha_pinned_action(container_workflow, "docker/login-action")
+    assert has_sha_pinned_action(container_workflow, "docker/metadata-action")
+    assert has_sha_pinned_action(container_workflow, "docker/build-push-action")
+    assert has_sha_pinned_action(container_workflow, "sigstore/cosign-installer")
     assert "cosign-release: v3.0.6" in container_workflow
-    assert (
-        "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" in container_workflow
-    )
+    assert has_sha_pinned_action(container_workflow, "aquasecurity/trivy-action")
     assert "version: v0.70.0" in container_workflow
     assert "sbom: true" in container_workflow
     assert "provenance: mode=max" in container_workflow
@@ -834,9 +826,9 @@ def test_scorecard_workflow_uses_pinned_actions_without_artifact_storage() -> No
     assert "checks: read" in workflow
     assert "pull-requests: read" in workflow
     assert "statuses: read" in workflow
-    assert "ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46" in workflow
+    assert has_sha_pinned_action(workflow, "ossf/scorecard-action")
     assert "results_format: sarif" in workflow
-    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
+    assert has_sha_pinned_action(workflow, "actions/upload-artifact")
 
 
 def test_scorecard_ci_tests_false_positive_has_auditable_evidence() -> None:
@@ -1343,8 +1335,8 @@ def test_development_bootstrap_workflow_proves_clean_host_and_kicad_canary() -> 
     assert "uv 0.10.8" in workflow
     assert "v24.11.0" in workflow
     assert "11.5.0" in workflow
-    assert "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow
-    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
+    assert has_sha_pinned_action(workflow, "actions/checkout")
+    assert has_sha_pinned_action(workflow, "actions/upload-artifact")
     assert "kicad-canary:" in workflow
     assert "ppa:kicad/kicad-10.0-releases" in workflow
     assert 'test "$(kicad-cli version)" = "10.0.5"' in workflow

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from scripts.check_github_actions_policy import has_sha_pinned_action
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -67,7 +69,7 @@ def test_python_token_fallback_is_manual_approved_and_tokenized() -> None:
     assert "Validate emergency authorization" in workflow
     assert "pypi-token" in workflow
     assert "testpypi-token" in workflow
-    assert "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in workflow
+    assert has_sha_pinned_action(workflow, "pypa/gh-action-pypi-publish")
     assert "id-token: write" not in workflow
 
 

--- a/tests/unit/test_workflow_tooling.py
+++ b/tests/unit/test_workflow_tooling.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import yaml
 
+from scripts.check_github_actions_policy import has_sha_pinned_action
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -73,6 +75,6 @@ def test_direct_javascript_actions_use_node24_releases() -> None:
         for path in sorted((ROOT / ".github" / "workflows").glob("*.yml"))
     )
 
-    assert "dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d" in workflows
+    assert has_sha_pinned_action(workflows, "dorny/paths-filter")
     assert "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36" not in workflows
     assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" not in workflows


### PR DESCRIPTION
$## Summary\n- remove duplicate exact GitHub Action revision assertions from release/container tests\n- keep repository allowlisting and immutable 40-character SHA enforcement as the security contract\n- make Docker metadata validation require the Action repository at an immutable SHA without freezing a second revision copy\n\n## Root cause\nDependabot grouped Actions PR #629 rotates valid immutable Action SHAs. The central Actions policy accepts those rotations, but several tests duplicated the previous SHA values and failed even when the workflow remained allowlisted and SHA-pinned.\n\n## Verification\n- TDD regression coverage for SHA rotation and concatenated workflow text\n- affected policy/release tests pass\n- GitHub Actions policy passes for all 27 workflows\n- Docker metadata validation passes\n- Ruff + mypy clean\n- check:meta passes\n- full non-benchmark unit suite passes (3 existing skips)\n- repo pre-push targeted tests, actionlint, and zizmor pass\n- the fix was also applied diagnostically to PR #629 head and its previously failing policy/release regression set passed\n\nRefs #629