### PR TITLE
feat(validation): add ERC summary counts and a flat violations list

### DIFF
--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -241,6 +241,8 @@ def _erc_severity_summary(violations: list[dict[str, object]]) -> dict[str, int]
     counts: dict[str, int] = {}
     for violation in violations:
         severity = str(violation.get("severity") or "error").casefold()
+        if severity in {"warning", "warn", "marginal"}:
+            severity = "warning"
         counts[severity] = counts.get(severity, 0) + 1
     return counts
 

--- a/src/kicad_mcp/tools/validation.py
+++ b/src/kicad_mcp/tools/validation.py
@@ -231,6 +231,20 @@ def _erc_violations(
     return violations
 
 
+def _erc_severity_summary(violations: list[dict[str, object]]) -> dict[str, int]:
+    """Return violation counts keyed by severity (e.g. ``{"error": 2, "warning": 1}``).
+
+    Preserves whatever severity strings the report carries (so severities beyond
+    error/warning still surface), defaulting to ``"error"`` when a violation omits one —
+    matching the conservative default used when turning violations into findings.
+    """
+    counts: dict[str, int] = {}
+    for violation in violations:
+        severity = str(violation.get("severity") or "error").casefold()
+        counts[severity] = counts.get(severity, 0) + 1
+    return counts
+
+
 def _type_breakdown(entries: list[dict[str, object]]) -> str:
     counts: dict[str, int] = {}
     for entry in entries:
@@ -587,6 +601,7 @@ def _erc_report_payload(
         )
 
     violations = _erc_violations(report)
+    severity_summary = _erc_severity_summary(violations)
     lines = ["ERC summary:", f"- Violations: {len(violations)}"]
     if violations:
         lines.append(_format_violations("Violations", violations))
@@ -617,7 +632,14 @@ def _erc_report_payload(
         metadata={
             "report_path": str(path),
             "available": True,
-            "violations": len(violations),
+            # ``violations`` is the aggregated flat list across all sheets (each entry
+            # retains its ``sheet_path`` plus existing fields); ``violation_count`` keeps
+            # the previous scalar so nothing that read it silently breaks. ``summary``
+            # gives counts by severity so a consumer sees a non-clean schematic at a
+            # glance instead of missing per-sheet violations.
+            "violation_count": len(violations),
+            "violations": violations,
+            "summary": severity_summary,
         },
     )
 
@@ -2791,7 +2813,7 @@ def _build_project_release_readiness_payload(
             else "[ ]"
         )
         + " Review DRC evidence and confirm zero blocking findings.",
-        ("[x]" if erc.available and int(erc.metadata.get("violations", 0)) == 0 else "[ ]")
+        ("[x]" if erc.available and int(erc.metadata.get("violation_count", 0)) == 0 else "[ ]")
         + " Review ERC evidence and confirm zero blocking findings.",
         ("[x]" if manufacturing.status == "PASS" else "[ ]")
         + " Confirm the selected manufacturing profile and DFM checks.",

--- a/tests/unit/test_erc_metadata.py
+++ b/tests/unit/test_erc_metadata.py
@@ -1,8 +1,15 @@
-from kicad_mcp.tools.validation import _erc_violations, _report_entry_finding
+from pathlib import Path
+
+from kicad_mcp.tools.validation import (
+    _erc_report_payload,
+    _erc_severity_summary,
+    _erc_violations,
+    _report_entry_finding,
+)
 
 
 def test_finding_metadata_extraction() -> None:
-    entry = {
+    entry: dict[str, object] = {
         "type": "err_type",
         "description": "an error",
         "severity": "error",
@@ -23,7 +30,7 @@ def test_finding_metadata_extraction() -> None:
 
 
 def test_erc_violations_preserves_sheet_path() -> None:
-    report = {
+    report: dict[str, object] = {
         "sheets": [
             {
                 "path": "/Subsheet/",
@@ -38,7 +45,7 @@ def test_erc_violations_preserves_sheet_path() -> None:
     assert violations[0]["sheet_path"] == "/Subsheet/"
 
     # Check that name is used as fallback if path is absent
-    report2 = {
+    report2: dict[str, object] = {
         "sheets": [
             {
                 "name": "AnotherSheet",
@@ -53,3 +60,62 @@ def test_erc_violations_preserves_sheet_path() -> None:
     violations2 = _erc_violations(report2)
     assert len(violations2) == 1
     assert violations2[0]["sheet_path"] == "AnotherSheet"
+
+
+def test_erc_severity_summary_counts_by_severity() -> None:
+    violations: list[dict[str, object]] = [
+        {"severity": "error", "description": "a"},
+        {"severity": "warning", "description": "b"},
+        {"severity": "error", "description": "c"},
+        {"severity": "exclusion", "description": "d"},  # other severities surface too
+        {"description": "e"},  # missing severity defaults to error
+    ]
+
+    summary = _erc_severity_summary(violations)
+
+    assert summary == {"error": 3, "warning": 1, "exclusion": 1}
+
+
+def test_erc_payload_aggregates_flat_violations_and_summary() -> None:
+    report: dict[str, object] = {
+        "sheets": [
+            {
+                "path": "/",
+                "violations": [
+                    {"type": "t1", "severity": "error", "description": "root err"},
+                ],
+            },
+            {
+                "path": "/Sub/",
+                "violations": [
+                    {"type": "t2", "severity": "warning", "description": "sub warn"},
+                    {"type": "t3", "severity": "error", "description": "sub err"},
+                ],
+            },
+        ]
+    }
+
+    payload = _erc_report_payload(Path("erc_report.json"), report, None, save_report=False)
+
+    # Flat top-level violations list aggregates across every sheet, retaining sheet identity.
+    flat: list[dict[str, object]] = payload.metadata["violations"]
+    assert isinstance(flat, list)
+    assert len(flat) == 3
+    assert {v["sheet_path"] for v in flat} == {"/", "/Sub/"}
+    assert {v["description"] for v in flat} == {"root err", "sub warn", "sub err"}
+
+    # Summary counts by severity; existing scalar preserved under violation_count.
+    assert payload.metadata["summary"] == {"error": 2, "warning": 1}
+    assert payload.metadata["violation_count"] == 3
+    assert payload.verdict == "FAIL"
+
+
+def test_erc_payload_clean_schematic_has_empty_violations_and_summary() -> None:
+    report: dict[str, object] = {"sheets": [{"path": "/", "violations": []}]}
+
+    payload = _erc_report_payload(Path("erc_report.json"), report, None, save_report=False)
+
+    assert payload.metadata["violations"] == []
+    assert payload.metadata["summary"] == {}
+    assert payload.metadata["violation_count"] == 0
+    assert payload.verdict == "PASS"


### PR DESCRIPTION
## Summary

The ERC result exposed violations only under `sheets[].violations`. There was no
aggregated list and no counts, so a caller that reasonably read a top-level
`violations` field got nothing back and could conclude the schematic was clean
while per-sheet violations actually existed — a silent false pass.

This enriches the ERC payload with two additive fields:

- a flat, top-level `violations` list aggregating violations across all sheets,
  where each entry keeps its sheet path alongside its existing fields, and
- a `summary` object with counts per severity, e.g. `{"error": 2, "warning": 1}`,
  so a non-clean schematic is obvious at a glance.

## Compatibility note

The result metadata previously exposed a field named `violations` that held a
scalar count. That count is preserved under the clearer name `violation_count`,
and `violations` now holds the aggregated list described above. The single
internal consumer was updated accordingly. This renaming is intentional — it makes
the field name match its intuitive meaning — but it is a change to an existing
field, so I'm calling it out explicitly for reviewers.

ERC coordinate values are left untouched.

## Tests

Added unit tests for the severity summary and the aggregated list (including the
clean-schematic case), and ran the surrounding validation/release-gate suites as
a regression check. `ruff` and `mypy` are clean.
