### PR TITLE
feat(server): audit tools without capability records at startup

### DIFF
--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -651,8 +651,8 @@ def _tools_without_capability_record() -> list[str]:
 
     A tool with no record falls back to ``AccessTier.WRITE`` in
     :func:`_ipc_runtime_allows_tool`, which can silently hide it from
-    ``tools/list`` (e.g. a file-based ``sch_*`` tool disappearing when the
-    KiCad schematic window is closed). Surfacing the gap loudly at startup
+    ``tools/list`` (for example, a ``sch_*`` tool may be treated as requiring
+    "live schematic write" capability at runtime). Surfacing the gap loudly at startup
     keeps the omission discoverable instead of silent.
     """
     from .tools.router import TOOL_CATEGORIES

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -646,6 +646,37 @@ class _StaticTokenVerifier:
         self._expected_token = token
 
 
+def _tools_without_capability_record() -> list[str]:
+    """Return registered router tools that have no capability record.
+
+    A tool with no record falls back to ``AccessTier.WRITE`` in
+    :func:`_ipc_runtime_allows_tool`, which can silently hide it from
+    ``tools/list`` (e.g. a file-based ``sch_*`` tool disappearing when the
+    KiCad schematic window is closed). Surfacing the gap loudly at startup
+    keeps the omission discoverable instead of silent.
+    """
+    from .tools.router import TOOL_CATEGORIES
+
+    routed = {tool_name for info in TOOL_CATEGORIES.values() for tool_name in info["tools"]}
+    return sorted(name for name in routed if get_capability_record(name) is None)
+
+
+def _audit_capability_records() -> list[str]:
+    """Log a single WARNING when registered tools lack a capability record."""
+    missing = _tools_without_capability_record()
+    if missing:
+        logger.warning(
+            "capability_records_missing",
+            message=(
+                "Registered tools have no capability record and fall back to a "
+                "WRITE tier; they may be hidden from tools/list at runtime."
+            ),
+            count=len(missing),
+            tools=missing,
+        )
+    return missing
+
+
 def _tool_requires_ipc(tool_name: str) -> bool:
     record = get_capability_record(tool_name)
     if record is not None and record.runtime is RuntimeRequirement.KICAD_IPC:
@@ -2123,6 +2154,7 @@ def _print_startup_diagnostics(cfg: KiCadMCPConfig, *, probe_runtime: bool = Tru
         gate_mode="release-export-only",
         ipc_status=ipc_status,
     )
+    _audit_capability_records()
     _print_startup_onboarding()
 
 

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -10,8 +10,10 @@ from kicad_mcp.config import get_config
 from kicad_mcp.connection import KiCadConnectionError
 from kicad_mcp.server import (
     KiCadFastMCP,
+    _audit_capability_records,
     _ensure_thread_aware_stdout,
     _print_startup_diagnostics,
+    _tools_without_capability_record,
     build_server,
     main_callback,
 )
@@ -44,6 +46,47 @@ def test_print_startup_diagnostics_logs_expected_fields(
     assert payload["gate_mode"] == "release-export-only"
     assert str(payload["project_dir"]).endswith("project")
     assert str(payload["ipc_status"]).startswith("unavailable")
+
+
+def test_all_registered_tools_have_capability_records() -> None:
+    # Regression guard: every routed tool must carry a capability record so it is
+    # never silently hidden from tools/list via the WRITE-tier fallback.
+    assert _tools_without_capability_record() == []
+
+
+def test_capability_audit_detects_missing_record(monkeypatch) -> None:
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "kicad_mcp.server._tools_without_capability_record",
+        lambda: ["sch_add_hierarchical_label", "sch_create_sheet"],
+    )
+    monkeypatch.setattr(
+        "kicad_mcp.server.logger.warning",
+        lambda event, **kwargs: warnings.append((event, kwargs)),
+    )
+
+    missing = _audit_capability_records()
+
+    assert missing == ["sch_add_hierarchical_label", "sch_create_sheet"]
+    assert len(warnings) == 1
+    event, kwargs = warnings[0]
+    assert event == "capability_records_missing"
+    assert kwargs["count"] == 2
+    assert kwargs["tools"] == ["sch_add_hierarchical_label", "sch_create_sheet"]
+
+
+def test_capability_audit_stays_silent_when_records_complete(monkeypatch) -> None:
+    warnings: list[str] = []
+
+    monkeypatch.setattr("kicad_mcp.server._tools_without_capability_record", list)
+    monkeypatch.setattr(
+        "kicad_mcp.server.logger.warning",
+        lambda event, **_kwargs: warnings.append(event),
+    )
+
+    assert _audit_capability_records() == []
+    assert warnings == []
 
 
 def test_print_startup_diagnostics_warns_when_stdio_uses_auth_token(


### PR DESCRIPTION
## Summary

Tool visibility depends on each registered tool having a capability record. If a
registered tool is ever missing one, it can be filtered out of the advertised tool
list — and that is hard to notice, because another endpoint may still report the
tool as available, so it looks like the tool "doesn't exist" rather than surfacing
an actionable error.

This adds a lightweight startup audit: it computes the set of registered tools that
lack a capability record and, if that set is non-empty, logs a single loud warning
listing them. When every registered tool has a record (the current state), it stays
silent. It is a regression guard so that a future gap surfaces immediately instead
of silently hiding tools.

## Scope

This change only adds the audit and its warning; it does not alter tool gating or
visibility logic.

While working on this I did notice a separate visibility issue whose cause is
unrelated to missing records — certain file-based schematic authoring tools are
gated as if they required a live editor session, so they disappear from the tool
list when the schematic window is closed (the correct workflow for server-side
editing). That is a distinct problem in the runtime classification and deserves its
own discussion and fix, so I'm keeping it out of this PR and will report it
separately with a proposed approach.

## Tests

Added unit tests: a guard asserting every registered tool currently has a record,
plus tests that the audit warns with the offending list when a record is missing
and stays silent when complete. `ruff` and `mypy` are clean.
