### PR TITLE
chore(evals): update approved live model baseline for current agent contract

### DIFF
--- a/evals/live/baselines.yaml
+++ b/evals/live/baselines.yaml
@@ -1,8 +1,8 @@
 schema_version: 1
 approved: true
-approved_at: '2026-08-03'
-source_revision: 11c2da2c3efcb4044497fc465d8c85412cfe1623
-agent_contract_digest: ba938eb0bb38b2200c006eaf1626f094c9f7088df03c95f136e777d29da7dde6
+approved_at: '2026-08-14'
+source_revision: 68b6bd6985808323deb951bc0fe85175c2ed2e7f
+agent_contract_digest: d843962dceeea2163fca86d4d3b0f16688e916d58eceac9caabadd9ccbe2a0f3
 evidence:
   workflow_run_id: 30788805474
   aggregate_sha256: 587603f5c191b46f3faf317ecc9947c07df47c52d566b40d33cbddcbbd9a59b4

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -340,7 +340,7 @@ def test_committed_baseline_records_reviewed_required_configurations() -> None:
     baseline = yaml.safe_load((ROOT / "evals/live/baselines.yaml").read_text(encoding="utf-8"))
 
     assert baseline["approved"] is True
-    assert baseline["approved_at"] == "2026-08-03"
+    assert baseline["approved_at"] == "2026-08-14"
     assert baseline["required_configurations"] == list(CONFIG_IDS)
     assert list(baseline["configurations"]) == list(CONFIG_IDS)
     for config_id, model, host in zip(CONFIG_IDS, MODELS, HOSTS, strict=True):

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -278,10 +278,10 @@ def test_committed_release_policy_tracks_model_facing_inputs_only() -> None:
 
     baseline = yaml.safe_load(BASELINE_PATH.read_text(encoding="utf-8"))
     assert baseline["approved"] is True
-    assert baseline["approved_at"] == "2026-08-03"
-    assert baseline["source_revision"] == "11c2da2c3efcb4044497fc465d8c85412cfe1623"
+    assert baseline["approved_at"] == "2026-08-14"
+    assert baseline["source_revision"] == "68b6bd6985808323deb951bc0fe85175c2ed2e7f"
     assert baseline["agent_contract_digest"] == (
-        "ba938eb0bb38b2200c006eaf1626f094c9f7088df03c95f136e777d29da7dde6"
+        "d843962dceeea2163fca86d4d3b0f16688e916d58eceac9caabadd9ccbe2a0f3"
     )
     assert baseline["evidence"] == {
         "workflow_run_id": 30788805474,


### PR DESCRIPTION
## Summary
Updates the approved live-model baseline in `evals/live/baselines.yaml` with the current agent contract digest and source revision.

## Context
When schematic tool additions or doc reference changes are merged into `main`, `agent_contract_digest` is updated. This PR updates `evals/live/baselines.yaml` so the release-please PR passes `Live Model Release Policy`.