### PR TITLE
fix(ci): make Sonar source and test scopes disjoint

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -50,10 +50,9 @@ sonar.exclusions=\
   **/fuzz/**,\
   **/performance/**,\
   **/docs/**,\
+  packages/protocol-schemas/test/**,\
+  packages/kicad-fixtures/test/**,\
   **/.codegraph/**
-
-# Tests excluded from main source analysis
-sonar.test.exclusions=tests/**
 
 # Files excluded from coverage computation
 sonar.coverage.exclusions=\

--- a/tests/unit/test_workflow_tooling.py
+++ b/tests/unit/test_workflow_tooling.py
@@ -78,3 +78,20 @@ def test_direct_javascript_actions_use_node24_releases() -> None:
     assert has_sha_pinned_action(workflows, "dorny/paths-filter")
     assert "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36" not in workflows
     assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" not in workflows
+
+
+def test_sonar_source_and_test_scopes_are_disjoint() -> None:
+    raw = (ROOT / "sonar-project.properties").read_text(encoding="utf-8")
+    logical = raw.replace("\\\n", "")
+    properties: dict[str, list[str]] = {}
+    for line in logical.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        properties[key] = [item.strip() for item in value.split(",") if item.strip()]
+
+    exclusions = properties["sonar.exclusions"]
+    assert "packages/protocol-schemas/test/**" in exclusions
+    assert "packages/kicad-fixtures/test/**" in exclusions
+    assert "sonar.test.exclusions" not in properties


### PR DESCRIPTION
## Summary
- exclude package-level test roots from Sonar source analysis
- stop excluding the root `tests/**` tree from Sonar test analysis
- add a regression test for the Sonar scope contract

## Root cause
SonarCloud failed with `sources_tests_overlap` because `sonar.sources` included `packages` while `sonar.tests` also included `packages/protocol-schemas/test` and `packages/kicad-fixtures/test`.

## Verification
- `pytest -q tests/unit/test_workflow_tooling.py tests/unit/test_github_actions_policy.py` -> 13 passed
- `ruff check tests/unit/test_workflow_tooling.py` -> passed
- `ruff format --check tests/unit/test_workflow_tooling.py` -> passed
- `git diff HEAD^ HEAD --check` -> passed

## Baseline note
The full Windows unit baseline has one pre-existing environment-specific failure in `test_dev_bootstrap.py`: Windows `bash.EXE` returns exit 127 when invoked with the repository `.sh` script. This PR does not touch that path.