### PR TITLE
fix(ci): skip SonarCloud scan for fork pull requests

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,10 @@ permissions:
 jobs:
   sonarcloud:
     name: SonarCloud Scan
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    if: >
+      (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code

--- a/docs/superpowers/specs/2026-08-14-sonar-fork-pr-secret-safety-design.md
+++ b/docs/superpowers/specs/2026-08-14-sonar-fork-pr-secret-safety-design.md
@@ -1,0 +1,19 @@
+# Sonar Fork PR Secret Safety Design
+
+## Problem
+
+The SonarCloud workflow runs on `pull_request` events and injects `secrets.SONAR_TOKEN` into the scanner step. GitHub intentionally withholds repository secrets from pull requests whose head repository is a fork, so those scans start without `SONAR_TOKEN` and fail with authorization errors.
+
+## Design
+
+Keep the existing `pull_request` trigger and `push` trigger. Do not switch to `pull_request_target`, because running fork-controlled code in a secret-bearing job would expand the trust boundary.
+
+Gate the SonarCloud job so it runs only when:
+- the repository owner is one of the existing allowed owners; and
+- the event is not a pull request, or the pull request head repository is the same repository as the base repository.
+
+This preserves Sonar analysis for `main` pushes and same-repository pull requests while safely skipping fork pull requests that cannot receive the secret.
+
+## Verification
+
+Add a workflow regression test that parses `.github/workflows/sonarcloud.yml` and asserts the job condition includes the same-repository head check. Run the targeted workflow tests, GitHub Actions policy tests, Ruff, workflow checker, and YAML parsing before pushing.

--- a/tests/unit/test_workflow_tooling.py
+++ b/tests/unit/test_workflow_tooling.py
@@ -95,3 +95,14 @@ def test_sonar_source_and_test_scopes_are_disjoint() -> None:
     assert "packages/protocol-schemas/test/**" in exclusions
     assert "packages/kicad-fixtures/test/**" in exclusions
     assert "sonar.test.exclusions" not in properties
+
+
+def test_sonar_skips_fork_pull_requests_before_secret_bearing_steps() -> None:
+    path = ROOT / ".github" / "workflows" / "sonarcloud.yml"
+    raw = path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(raw)
+    condition = workflow["jobs"]["sonarcloud"]["if"]
+
+    assert "pull_request_target" not in raw
+    assert "github.event_name != 'pull_request'" in condition
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in condition


### PR DESCRIPTION
## Summary
- skip the secret-bearing SonarCloud job for pull requests from forks
- keep SonarCloud enabled for `main` pushes and same-repository pull requests
- retain the existing repository-owner allowlist
- explicitly avoid `pull_request_target`
- add a regression test for the fork guard

## Why
GitHub does not pass repository secrets such as `SONAR_TOKEN` to workflows triggered by fork pull requests. PRs #665 and #667 therefore reached the scanner with an empty token and failed authorization even though the repository secret exists.

## Verification
- `pytest tests/unit/test_workflow_tooling.py tests/unit/test_github_actions_policy.py` — 14 passed
- `python scripts/check_workflows.py --actionlint` — 28 workflows parsed
- `python scripts/workflow_security.py --min-severity high` — no findings
- Ruff check/format and `git diff --check` — clean