### PR TITLE
fix(schematic): merge stacked-pin terminals in sch_add_pin_labels

### DIFF
--- a/src/kicad_mcp/schematic/connectivity_authoring.py
+++ b/src/kicad_mcp/schematic/connectivity_authoring.py
@@ -150,6 +150,11 @@ class SchematicConnectivityAuthoringService:
         terminal_blocks: list[str] = []
         power_lib_defs: dict[str, str] = {}
         occupied_terminals: list[tuple[float, float]] = []
+        #: Terminals already emitted for a resolved (pin coordinate, net) pair. Stacked
+        #: pins (several named pins drawn at one coordinate, e.g. the paired GND/VBUS
+        #: pins of a USB-C receptacle) share this key so they reuse the single stub
+        #: instead of being staggered into orphaned symbols.
+        stacked_terminals: dict[tuple[float, float, str], tuple[float, float]] = {}
         dense_terminal_mode = len(connections) >= 12
         terminal_clearance_mm = self.snap_tolerance_mm if dense_terminal_mode else 6.0
         stagger_step_mm = 2.54
@@ -224,6 +229,12 @@ class SchematicConnectivityAuthoringService:
                     results.append(f"{ref}.{pin}: pin not found")
                     continue
             px, py = point
+            stack_key = (round(px, 4), round(py, 4), net)
+            shared_terminal = stacked_terminals.get(stack_key)
+            if shared_terminal is not None:
+                sx, sy = shared_terminal
+                results.append(f"{ref}.{pin} -> {net} (stacked on shared terminal @ ({sx}, {sy}))")
+                continue
             ux, uy = self.pin_label_stub_direction(point, (ox, oy), pin_positions.values())
             length = max(stub_mm, 10.16) if uy else stub_mm
             ex = round(px + ux * length, 4)
@@ -262,6 +273,7 @@ class SchematicConnectivityAuthoringService:
                         root_uuid=root_uuid,
                     )
                 )
+                stacked_terminals[stack_key] = (ex, ey)
                 results.append(f"{ref}.{pin} -> {net} (power) @ ({ex}, {ey}){suffix}")
             else:
                 rotation = self.terminal_rotation_from_vector(ux, uy)
@@ -278,6 +290,7 @@ class SchematicConnectivityAuthoringService:
                         shape=shape,
                     )
                 )
+                stacked_terminals[stack_key] = (ex, ey)
                 results.append(f"{ref}.{pin} -> {net} @ ({ex}, {ey}){suffix}")
 
         if not (wire_blocks or terminal_blocks):

--- a/tests/unit/test_schematic_connectivity_authoring_service.py
+++ b/tests/unit/test_schematic_connectivity_authoring_service.py
@@ -328,6 +328,92 @@ def test_add_pin_labels_skips_missing_power_library_symbol(tmp_path: Path) -> No
     assert harness.writes == []
 
 
+def test_add_pin_labels_merges_stacked_power_pins_into_one_terminal(tmp_path: Path) -> None:
+    # A USB-C receptacle stacks its four GND pins on a single coordinate; all four
+    # connections must share ONE power symbol and stub, not spawn orphans.
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [_symbol()], "power_symbols": []},
+        pin_positions={
+            ("Device", "R"): {
+                "A1": (12.0, 20.0),
+                "A12": (12.0, 20.0),
+                "B1": (12.0, 20.0),
+                "B12": (12.0, 20.0),
+            }
+        },
+    )
+
+    result = harness.service.add_pin_labels(
+        [
+            {"reference": "U1", "pin": "A1", "net": "GND"},
+            {"reference": "U1", "pin": "A12", "net": "GND"},
+            {"reference": "U1", "pin": "B1", "net": "GND"},
+            {"reference": "U1", "pin": "B12", "net": "GND"},
+        ]
+    )
+
+    # Exactly one wire stub and one power symbol are emitted.
+    assert sum(name == "wire_block" for name, _ in harness.calls) == 1
+    assert sum(name == "place_symbol_block" for name, _ in harness.calls) == 1
+    content = harness.writes[0][1]
+    assert content.count("POWER(GND,17.08,20.0)") == 1
+    assert content.count("WIRE(12.0,20.0->17.08,20.0)") == 1
+    # The co-connected pins are still reported, never staggered.
+    assert "U1.A1 -> GND (power) @ (17.08, 20.0)" in result
+    assert "U1.A12 -> GND (stacked on shared terminal @ (17.08, 20.0))" in result
+    assert "U1.B1 -> GND (stacked on shared terminal @ (17.08, 20.0))" in result
+    assert "U1.B12 -> GND (stacked on shared terminal @ (17.08, 20.0))" in result
+    assert "staggered" not in result
+    assert "Added 1 pin terminal(s) with stubs" in result
+
+
+def test_add_pin_labels_merges_stacked_signal_pins_into_one_label(tmp_path: Path) -> None:
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [_symbol()], "power_symbols": []},
+        pin_positions={("Device", "R"): {"1": (12.0, 20.0), "2": (12.0, 20.0)}},
+        power_net=lambda name: False,
+    )
+
+    result = harness.service.add_pin_labels(
+        [
+            {"reference": "U1", "pin": "1", "net": "SIG"},
+            {"reference": "U1", "pin": "2", "net": "SIG"},
+        ]
+    )
+
+    assert sum(name == "wire_block" for name, _ in harness.calls) == 1
+    assert sum(name == "label_block" for name, _ in harness.calls) == 1
+    assert "U1.1 -> SIG @ (17.08, 20.0)" in result
+    assert "U1.2 -> SIG (stacked on shared terminal @ (17.08, 20.0))" in result
+    assert "staggered" not in result
+
+
+def test_add_pin_labels_still_staggers_distinct_colliding_coordinates(tmp_path: Path) -> None:
+    # Genuinely distinct pin coordinates whose terminal endpoints collide must
+    # still be staggered apart -- unchanged behavior.
+    harness = _harness(
+        tmp_path,
+        parsed={"uuid": "root", "symbols": [_symbol()], "power_symbols": []},
+        pin_positions={("Device", "R"): {"1": (12.0, 20.0), "2": (13.0, 20.0)}},
+        power_net=lambda name: False,
+    )
+
+    result = harness.service.add_pin_labels(
+        [
+            {"reference": "U1", "pin": "1", "net": "A"},
+            {"reference": "U1", "pin": "2", "net": "B"},
+        ]
+    )
+
+    assert sum(name == "wire_block" for name, _ in harness.calls) == 2
+    assert sum(name == "label_block" for name, _ in harness.calls) == 2
+    assert "U1.1 -> A @ (17.08, 20.0)" in result
+    assert "U1.2 -> B @ (23.16, 20.0); staggered 2 step(s)" in result
+    assert "stacked on shared terminal" not in result
+
+
 def test_route_wire_between_pins_reports_missing_reference_and_pin(tmp_path: Path) -> None:
     missing_ref = _harness(
         tmp_path,


### PR DESCRIPTION
## Summary

`sch_add_pin_labels` mishandles symbols that draw several pins at the *same*
coordinate (stacked pins). A common example is a USB-C receptacle, which stacks
its four GND pins and its four VBUS pins onto one coordinate each. When all of
those pins are listed in `connections`, the tool emitted a separate terminal for
each, staggered them apart to avoid the coordinate collision, and drew a single
stub — leaving the extra power symbols/labels orphaned in space. The netlist
stayed correct (the pins are joined through the shared coordinate), but ERC then
reported a `pin_not_connected` for each orphan.

## Fix

Connections whose resolved pin coordinate *and* net are identical now share one
terminal: the first emits the stub and power symbol/label as before, and the
rest reuse it and are reported as `stacked on shared terminal @ (x, y)`. The
terminal is registered only after a successful emission, so the existing
"symbol not found" fallback paths are unchanged. Genuinely distinct coordinates
keep their own terminals and stagger exactly as before.

## Tests

- Four stacked power pins → exactly one stub and one power symbol, with the
  co-connected pins reported.
- The same for a signal net (one label).
- Regression: distinct coordinates whose *endpoints* would collide still stagger
  as before.

`ruff` and `mypy` are clean; the tool schema is unchanged.
