### PR TITLE
fix(release): sync Sonar project version

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,9 @@
 sonar.organization=oaslananka
 sonar.projectKey=oaslananka_kicad-mcp-pro
 sonar.projectName=KiCad MCP Pro
-sonar.projectVersion=3.31.0
+# x-release-please-start-version
+sonar.projectVersion=3.32.0
+# x-release-please-end
 
 # ── Analysis scope ──────────────────────────────────────────────────────────
 # Primary source: Python MCP server + Rust/Tauri desktop + HTML frontend

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -83,6 +83,8 @@ def test_release_metadata_is_synchronised() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
     security = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    sonar = (ROOT / "sonar-project.properties").read_text(encoding="utf-8")
+    release_config = json.loads((ROOT / "release-please-config.json").read_text(encoding="utf-8"))
 
     assert server_json["$schema"] == REGISTRY_SCHEMA
     assert server_json["version"] == version
@@ -127,6 +129,12 @@ def test_release_metadata_is_synchronised() -> None:
     assert "development/v2-migration.md" in mkdocs
     assert "https://github.com/oaslananka/kicad-mcp-pro/security/advisories/new" in security
     assert "Do not open public issues for active vulnerabilities." in security
+    assert f"sonar.projectVersion={version}" in sonar
+    assert "x-release-please-start-version" in sonar
+    assert "x-release-please-end" in sonar
+    assert {"type": "generic", "path": "sonar-project.properties"} in release_config["packages"][
+        "."
+    ]["extra-files"]
 
 
 def test_kicad_studio_contract_documents_current_http_bridge() -> None:


### PR DESCRIPTION
## Summary

- keep `sonar.projectVersion` aligned with the canonical package version
- add release-please generic updater block markers around the Sonar version
- guard the wiring in release metadata tests

## Why

`release-please-config.json` already lists `sonar-project.properties` as a generic extra file, but the file had no generic updater annotation. The release PR therefore stayed on `sonar.projectVersion=3.31.0` while the package had moved to 3.32.x.

## Verification

- release metadata + preflight tests pass
- Ruff clean
- diff check clean
