### PR TITLE
feat(eval): report task outcome KPIs

### DIFF
--- a/scripts/generate_task_outcome_report.py
+++ b/scripts/generate_task_outcome_report.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Generate deterministic PCB task-outcome KPI reports from versioned evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+from kicad_mcp.evals import (
+    aggregate_task_outcomes,
+    parse_attempt_record,
+    parse_benchmark_contract,
+    render_task_outcome_summary_json,
+    render_task_outcome_summary_text,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, required=True)
+    parser.add_argument("--attempt", type=Path, action="append", required=True)
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--text-output", type=Path, required=True)
+    return parser
+
+
+def _load_mapping(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain one JSON object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        contract_path = args.contract.resolve()
+        attempt_paths = [path.resolve() for path in args.attempt]
+        json_output = args.json_output.resolve()
+        text_output = args.text_output.resolve()
+    except OSError as exc:
+        print(f"task outcome report failed: {exc}", file=sys.stderr)
+        return 2
+
+    if json_output == text_output:
+        print("task outcome report failed: output paths must be different", file=sys.stderr)
+        return 2
+    input_paths = {contract_path, *attempt_paths}
+    if json_output in input_paths or text_output in input_paths:
+        print(
+            "task outcome report failed: output paths must not overwrite input evidence",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        contract = parse_benchmark_contract(_load_mapping(contract_path))
+        attempts = [parse_attempt_record(_load_mapping(path)) for path in attempt_paths]
+        summary = aggregate_task_outcomes(contract, attempts)
+        json_report = render_task_outcome_summary_json(summary)
+        text_report = render_task_outcome_summary_text(summary)
+    except (OSError, ValueError) as exc:
+        print(f"task outcome report failed: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        json_output.parent.mkdir(parents=True, exist_ok=True)
+        text_output.parent.mkdir(parents=True, exist_ok=True)
+        json_output.write_text(json_report, encoding="utf-8", newline="\n")
+        text_output.write_text(text_report, encoding="utf-8", newline="\n")
+    except OSError as exc:
+        print(f"task outcome report failed: {exc}", file=sys.stderr)
+        return 2
+    print(f"wrote {args.json_output} and {args.text_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kicad_mcp/evals/__init__.py
+++ b/src/kicad_mcp/evals/__init__.py
@@ -36,6 +36,10 @@ from .live_runner import (
     validate_sanitized_evidence,
     write_evidence,
 )
+from .task_outcome_reporting import (
+    render_task_outcome_summary_json,
+    render_task_outcome_summary_text,
+)
 from .task_outcome_scoring import (
     TASK_OUTCOME_SUMMARY_SCHEMA_VERSION,
     RateKpi,
@@ -101,6 +105,8 @@ __all__ = [
     "parse_benchmark_contract",
     "render_attempt_record",
     "render_benchmark_contract",
+    "render_task_outcome_summary_json",
+    "render_task_outcome_summary_text",
     "ALL_TASK_STAGES",
     "TASK_OUTCOME_SCHEMA_VERSION",
     "TASK_OUTCOME_SUMMARY_SCHEMA_VERSION",

--- a/src/kicad_mcp/evals/evidence_sanitization.py
+++ b/src/kicad_mcp/evals/evidence_sanitization.py
@@ -28,7 +28,7 @@ _FORBIDDEN_EVIDENCE_KEYS = frozenset(
     }
 )
 _SENSITIVE_EVIDENCE_VALUE = re.compile(
-    r"(?i)(?:bearer\s+\S+|sk-[A-Za-z0-9_-]{8,}|"
+    r"(?i)(?:bearer\s+\S+|(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{8,}|"
     r"(?:api[_-]?key|access[_-]?token|secret)\s*[:=]\s*\S+)"
 )
 _PRIVATE_ABSOLUTE_PATH = re.compile(

--- a/src/kicad_mcp/evals/task_outcome_reporting.py
+++ b/src/kicad_mcp/evals/task_outcome_reporting.py
@@ -1,0 +1,66 @@
+"""Deterministic reporting for end-to-end PCB task outcome KPI evidence."""
+
+from __future__ import annotations
+
+import json
+
+from .evidence_sanitization import validate_sanitized_evidence
+from .task_outcome_scoring import RateKpi, TaskOutcomeSummary
+
+
+def _sanitized_payload(summary: TaskOutcomeSummary) -> dict[str, object]:
+    payload = summary.model_dump(mode="json", exclude_none=True)
+    validate_sanitized_evidence(payload)
+    return payload
+
+
+def render_task_outcome_summary_json(summary: TaskOutcomeSummary) -> str:
+    """Render one task-outcome summary as deterministic sanitized JSON."""
+    payload = _sanitized_payload(summary)
+    return json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+
+def _render_rate(label: str, kpi: RateKpi) -> str:
+    rate = "n/a" if kpi.rate is None else f"{kpi.rate * 100:.1f}%"
+    return (
+        f"{label}: {rate} ({kpi.numerator}/{kpi.denominator}; "
+        f"target >={kpi.target * 100:.1f}%; {kpi.status})"
+    )
+
+
+def render_task_outcome_summary_text(summary: TaskOutcomeSummary) -> str:
+    """Render the headline KPI view from the same sanitized aggregate object."""
+    _sanitized_payload(summary)
+    failure_categories = "; ".join(
+        f"{category}={count}" for category, count in sorted(summary.failure_categories.items())
+    )
+    if not failure_categories:
+        failure_categories = "none"
+    lines = [
+        f"PCB Task Outcome — {summary.benchmark_id} {summary.benchmark_version}",
+        (
+            f"Attempts: {summary.attempts_total} total; {summary.valid_attempts} valid; "
+            f"{summary.infrastructure_invalid_attempts} infrastructure-invalid; "
+            f"{summary.successful_attempts} successful; {summary.failed_attempts} failed"
+        ),
+        _render_rate("PCB Design Task Success Rate", summary.task_success),
+        _render_rate("Mutation Recovery", summary.mutation_recovery),
+        (
+            f"File Corruption: {summary.file_corruption_incidents} incidents "
+            f"({summary.file_corruption_status})"
+        ),
+        _render_rate("Required DRC Execution", summary.required_drc_execution),
+        _render_rate("Manufacturing Reproducibility", summary.manufacturing_reproducibility),
+        (
+            f"Integrity: {summary.duplicate_application_incidents} duplicate applications; "
+            f"{summary.state_divergence_incidents} state divergences"
+        ),
+        f"Failure Categories: {failure_categories}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "render_task_outcome_summary_json",
+    "render_task_outcome_summary_text",
+]

--- a/tests/unit/test_evidence_sanitization.py
+++ b/tests/unit/test_evidence_sanitization.py
@@ -1,0 +1,27 @@
+"""Regression tests for publishable evaluation evidence sanitization."""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_mcp.evals.evidence_sanitization import (
+    EvidenceSanitizationError,
+    validate_sanitized_evidence,
+)
+
+
+def test_task_outcome_summary_schema_name_is_not_misclassified_as_secret() -> None:
+    validate_sanitized_evidence({"schema_version": "pcb-task-outcome-summary.v1"})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "sk-" + "x" * 16,
+        "token=" + "sk-" + "x" * 16,
+        "Bearer " + "x" * 16,
+    ],
+)
+def test_real_secret_shapes_remain_rejected(value: str) -> None:
+    with pytest.raises(EvidenceSanitizationError, match="sensitive string"):
+        validate_sanitized_evidence({"value": value})

--- a/tests/unit/test_generate_task_outcome_report.py
+++ b/tests/unit/test_generate_task_outcome_report.py
@@ -1,0 +1,261 @@
+"""CLI integration tests for deterministic task-outcome KPI reports."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import kicad_mcp.evals as evals
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "generate_task_outcome_report.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_task_outcome_report", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _requirements() -> dict[str, str]:
+    requirements = {stage: "not_applicable" for stage in evals.ALL_TASK_STAGES}
+    for stage in ("requirements", "pcb", "drc", "parse_reopen"):
+        requirements[stage] = "required"
+    return requirements
+
+
+def _contract() -> evals.BenchmarkContract:
+    return evals.BenchmarkContract.model_validate(
+        {
+            "schema_version": "pcb-task-outcome.v1",
+            "benchmark_id": "pcb-reference-suite",
+            "benchmark_version": "v1",
+            "tasks": [
+                {
+                    "task_id": "route-usb-board",
+                    "task_class": "pcb-edit",
+                    "version": "v1",
+                    "stage_requirements": _requirements(),
+                }
+            ],
+            "evidence_sufficiency": {
+                "minimum_valid_attempts": 2,
+                "minimum_valid_attempts_by_task_class": {"pcb-edit": 2},
+                "minimum_recovery_required_mutations": 0,
+                "minimum_drc_required_tasks": 2,
+                "minimum_manufacturing_release_tasks": 0,
+            },
+        }
+    )
+
+
+def _attempt_payload(attempt_id: str, *, classification: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": "pcb-task-outcome.v1",
+        "attempt_id": attempt_id,
+        "task_id": "route-usb-board",
+        "task_class": "pcb-edit",
+        "task_contract_version": "v1",
+        "benchmark_id": "pcb-reference-suite",
+        "benchmark_version": "v1",
+        "source_revision": "a" * 40,
+        "kicad_version": "10.0.5",
+        "toolchain_contract": "toolchain-v1",
+        "agent": "fixture-agent",
+        "model": "fixture-model",
+        "provider": "fixture-provider",
+        "mcp_profile": "default",
+        "operating_mode": "write",
+        "starting_state_digest": "sha256:" + "b" * 64,
+        "timing": {
+            "started_at": "2026-08-27T20:00:00+03:00",
+            "ended_at": "2026-08-27T20:01:00+03:00",
+        },
+        "classification": classification,
+        "retry_count": 0,
+        "start_state": "clean",
+        "manual_repair": False,
+        "stages": [
+            {"stage": "requirements", "outcome": "passed"},
+            {"stage": "pcb", "outcome": "passed"},
+            {"stage": "drc", "outcome": "passed"},
+            {"stage": "parse_reopen", "outcome": "passed"},
+        ],
+        "validations": [
+            {
+                "kind": "drc",
+                "required": True,
+                "execution_attempted": True,
+                "execution_completed": True,
+                "result_consumed": True,
+                "disposition": "resolved",
+            }
+        ],
+    }
+    if classification != "success":
+        categories = {
+            "provider_failure": "provider",
+            "infrastructure_invalid": "infrastructure",
+        }
+        payload["failure_category"] = categories[classification]
+        payload["failure_reason_code"] = "fixture_failure"
+    if classification == "infrastructure_invalid":
+        payload["stages"] = []
+        payload["validations"] = []
+        payload["infrastructure_evidence"] = {
+            "reason_code": "fixture_failure",
+            "reviewed": True,
+            "task_execution_started": False,
+        }
+    return payload
+
+
+def _write_attempt(path: Path, attempt_id: str, classification: str) -> evals.AttemptRecord:
+    record = evals.AttemptRecord.model_validate(
+        _attempt_payload(attempt_id, classification=classification)
+    )
+    path.write_text(evals.render_attempt_record(record), encoding="utf-8")
+    return record
+
+
+def test_cli_writes_json_and_text_from_one_aggregate(tmp_path: Path) -> None:
+    module = _load_script()
+    contract = _contract()
+    contract_path = tmp_path / "contract.json"
+    success_path = tmp_path / "success.json"
+    provider_path = tmp_path / "provider.json"
+    invalid_path = tmp_path / "infra.json"
+    json_output = tmp_path / "reports" / "summary.json"
+    text_output = tmp_path / "reports" / "summary.txt"
+
+    contract_path.write_text(evals.render_benchmark_contract(contract), encoding="utf-8")
+    success = _write_attempt(success_path, "attempt-success", "success")
+    provider = _write_attempt(provider_path, "attempt-provider", "provider_failure")
+    invalid = _write_attempt(invalid_path, "attempt-infra", "infrastructure_invalid")
+
+    result = module.main(
+        [
+            "--contract",
+            str(contract_path),
+            "--attempt",
+            str(success_path),
+            "--attempt",
+            str(provider_path),
+            "--attempt",
+            str(invalid_path),
+            "--json-output",
+            str(json_output),
+            "--text-output",
+            str(text_output),
+        ]
+    )
+
+    assert result == 0
+    summary = evals.aggregate_task_outcomes(contract, [success, provider, invalid])
+    assert json_output.read_text(encoding="utf-8") == evals.render_task_outcome_summary_json(
+        summary
+    )
+    assert text_output.read_text(encoding="utf-8") == evals.render_task_outcome_summary_text(
+        summary
+    )
+    assert (
+        json.loads(json_output.read_text(encoding="utf-8"))["infrastructure_invalid_attempts"] == 1
+    )
+
+
+def test_cli_invalid_attempt_fails_closed_before_writing_outputs(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    module = _load_script()
+    contract_path = tmp_path / "contract.json"
+    attempt_path = tmp_path / "invalid-attempt.json"
+    json_output = tmp_path / "summary.json"
+    text_output = tmp_path / "summary.txt"
+    contract_path.write_text(evals.render_benchmark_contract(_contract()), encoding="utf-8")
+    payload = _attempt_payload("attempt-invalid", classification="success")
+    payload["unexpected"] = "field"
+    attempt_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = module.main(
+        [
+            "--contract",
+            str(contract_path),
+            "--attempt",
+            str(attempt_path),
+            "--json-output",
+            str(json_output),
+            "--text-output",
+            str(text_output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result != 0
+    assert "task outcome report failed" in captured.err
+    assert not json_output.exists()
+    assert not text_output.exists()
+
+
+def test_cli_refuses_to_overwrite_input_evidence(tmp_path: Path, capsys) -> None:
+    module = _load_script()
+    contract = _contract()
+    contract_path = tmp_path / "contract.json"
+    attempt_path = tmp_path / "attempt.json"
+    text_output = tmp_path / "summary.txt"
+    contract_path.write_text(evals.render_benchmark_contract(contract), encoding="utf-8")
+    _write_attempt(attempt_path, "attempt-success", "success")
+    original_attempt = attempt_path.read_text(encoding="utf-8")
+
+    result = module.main(
+        [
+            "--contract",
+            str(contract_path),
+            "--attempt",
+            str(attempt_path),
+            "--json-output",
+            str(attempt_path),
+            "--text-output",
+            str(text_output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result != 0
+    assert "must not overwrite input evidence" in captured.err
+    assert attempt_path.read_text(encoding="utf-8") == original_attempt
+    assert not text_output.exists()
+
+
+def test_cli_output_directory_failure_returns_clean_nonzero(tmp_path: Path, capsys) -> None:
+    module = _load_script()
+    contract_path = tmp_path / "contract.json"
+    attempt_path = tmp_path / "attempt.json"
+    blocked_parent = tmp_path / "not-a-directory"
+    blocked_parent.write_text("occupied", encoding="utf-8")
+    contract_path.write_text(evals.render_benchmark_contract(_contract()), encoding="utf-8")
+    _write_attempt(attempt_path, "attempt-success", "success")
+
+    result = module.main(
+        [
+            "--contract",
+            str(contract_path),
+            "--attempt",
+            str(attempt_path),
+            "--json-output",
+            str(blocked_parent / "summary.json"),
+            "--text-output",
+            str(tmp_path / "summary.txt"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result != 0
+    assert "task outcome report failed" in captured.err
+    assert not (tmp_path / "summary.txt").exists()

--- a/tests/unit/test_task_outcome_reporting.py
+++ b/tests/unit/test_task_outcome_reporting.py
@@ -1,0 +1,110 @@
+"""Reporting tests for end-to-end PCB task outcome KPI evidence."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import kicad_mcp.evals as evals
+from kicad_mcp.evals.evidence_sanitization import EvidenceSanitizationError
+from kicad_mcp.evals.task_outcome_reporting import (
+    render_task_outcome_summary_json,
+    render_task_outcome_summary_text,
+)
+
+
+def _rate(*, numerator: int, denominator: int, target: float, status: str) -> dict[str, object]:
+    rate = numerator / denominator if denominator else None
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "rate": rate,
+        "confidence_interval": None,
+        "target": target,
+        "status": status,
+    }
+
+
+def _summary(*, benchmark_id: str = "pcb-reference-suite") -> evals.TaskOutcomeSummary:
+    return evals.TaskOutcomeSummary.model_validate(
+        {
+            "schema_version": "pcb-task-outcome-summary.v1",
+            "benchmark_id": benchmark_id,
+            "benchmark_version": "v1",
+            "attempts_total": 3,
+            "valid_attempts": 2,
+            "infrastructure_invalid_attempts": 1,
+            "successful_attempts": 1,
+            "failed_attempts": 1,
+            "failure_categories": {"provider": 1},
+            "task_success": _rate(numerator=1, denominator=2, target=0.95, status="not_met"),
+            "mutation_attempts": 4,
+            "recovery_required_mutations": 2,
+            "successful_recoveries": 2,
+            "mutation_recovery": _rate(numerator=2, denominator=2, target=0.99, status="met"),
+            "duplicate_application_incidents": 0,
+            "state_divergence_incidents": 0,
+            "file_corruption_incidents": 0,
+            "file_corruption_status": "met",
+            "drc_required_tasks": 2,
+            "drc_executed_and_consumed_tasks": 2,
+            "required_drc_execution": _rate(
+                numerator=2,
+                denominator=2,
+                target=1.0,
+                status="met",
+            ),
+            "manufacturing_release_tasks": 1,
+            "manufacturing_reproducible_tasks": 1,
+            "manufacturing_reproducibility": _rate(
+                numerator=1,
+                denominator=1,
+                target=1.0,
+                status="met",
+            ),
+        }
+    )
+
+
+def test_json_report_is_deterministic_sanitized_summary() -> None:
+    rendered = render_task_outcome_summary_json(_summary())
+
+    assert rendered.endswith("\n")
+    payload = json.loads(rendered)
+    assert payload["schema_version"] == "pcb-task-outcome-summary.v1"
+    assert payload["benchmark_id"] == "pcb-reference-suite"
+    assert payload["attempts_total"] == 3
+    assert payload["task_success"]["rate"] == 0.5
+    assert payload["failure_categories"] == {"provider": 1}
+    assert rendered == render_task_outcome_summary_json(_summary())
+
+
+def test_text_report_uses_same_headline_kpis_and_denominators() -> None:
+    rendered = render_task_outcome_summary_text(_summary())
+
+    assert rendered == (
+        "PCB Task Outcome — pcb-reference-suite v1\n"
+        "Attempts: 3 total; 2 valid; 1 infrastructure-invalid; 1 successful; 1 failed\n"
+        "PCB Design Task Success Rate: 50.0% (1/2; target >=95.0%; not_met)\n"
+        "Mutation Recovery: 100.0% (2/2; target >=99.0%; met)\n"
+        "File Corruption: 0 incidents (met)\n"
+        "Required DRC Execution: 100.0% (2/2; target >=100.0%; met)\n"
+        "Manufacturing Reproducibility: 100.0% (1/1; target >=100.0%; met)\n"
+        "Integrity: 0 duplicate applications; 0 state divergences\n"
+        "Failure Categories: provider=1\n"
+    )
+
+
+def test_eval_package_exports_task_outcome_report_renderers() -> None:
+    assert evals.render_task_outcome_summary_json is render_task_outcome_summary_json
+    assert evals.render_task_outcome_summary_text is render_task_outcome_summary_text
+
+
+@pytest.mark.parametrize(
+    "renderer",
+    [render_task_outcome_summary_json, render_task_outcome_summary_text],
+)
+def test_report_renderers_reject_sensitive_evidence(renderer) -> None:
+    with pytest.raises(EvidenceSanitizationError, match="sensitive string"):
+        renderer(_summary(benchmark_id="/home/private/pcb-reference-suite"))


### PR DESCRIPTION
﻿## Summary
- expose the existing `pcb-task-outcome-summary.v1` aggregate as deterministic sanitized JSON and human-readable headline KPI reports
- add a thin repo eval CLI that consumes the existing `BenchmarkContract` plus repeatable `AttemptRecord` JSON inputs; no new #730 manifest schema
- preserve fail-closed scoring semantics and prevent report outputs from overwriting input evidence
- fix the evidence sanitizer false positive where `task-outcome-summary` was misclassified as an `sk-...` token while preserving real secret detection

## Scope
This is the #729 integration slice only. It does not change task-success scoring thresholds/denominators, does not implement #728 live mutation evidence, and does not claim #730 representative-corpus target attainment.

## Local verification before push
- task-outcome/sanitizer/live-runner focused regression: 115/115 pass
- changed-file Ruff format/lint: pass
- mypy: 302 source files, 0 issues
- Bandit policy: pass, 0 unexpected findings
- uv build + package metadata: pass
- git diff --check: pass
- all 7 pushed file blobs verified byte-for-byte against the locally tested tree

A fresh full Python suite is running on the exact final local tree; GitHub exact-head CI, Codecov patch, Sonar Quality Gate, CodeQL and security checks remain mandatory before merge.

Refs #729
