### PR TITLE
fix(companion): avoid KiCad UI thread deadlocks

### DIFF
--- a/docs/integration/companion-plugin.md
+++ b/docs/integration/companion-plugin.md
@@ -86,8 +86,8 @@ uses an atomic replace. Existing invalid JSON/TOML fails before mutation. Inspec
 or restore backups with:
 
 ```bash
-kicad-mcp-pro setup-backups cursor --scope project
-kicad-mcp-pro setup-restore cursor --scope project
+kicad-mcp-pro setup-backups cursor --scope project --project-dir /path/to/project
+kicad-mcp-pro setup-restore cursor --scope project --project-dir /path/to/project
 ```
 
 Claude Code, Codex and Cursor use this same reversible transaction boundary. A

--- a/packages/kicad-plugin/kicad_mcp_companion.py
+++ b/packages/kicad-plugin/kicad_mcp_companion.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from types import ModuleType
 
 import pcbnew  # type: ignore[import-not-found]  # provided by KiCad
@@ -76,36 +77,48 @@ class KiCadMcpCompanionPlugin(pcbnew.ActionPlugin):
         info = self._read_board_info(ctx.BoardInfo)
         base_url = os.environ.get("KICAD_MCP_URL", "http://127.0.0.1:3334")
         auth_token = os.environ.get("KICAD_MCP_AUTH_TOKEN", "")
+        threading.Thread(
+            target=self._run_backend_flow,
+            args=(ctx, info, base_url, auth_token, wx),
+            name="kicad-mcp-companion",
+            daemon=True,
+        ).start()
+
+    def _run_backend_flow(
+        self,
+        ctx: ModuleType,
+        info: object,
+        base_url: str,
+        auth_token: str,
+        wx: object,
+    ) -> None:
+        def show(message: str, icon: object) -> None:
+            wx.CallAfter(wx.MessageBox, message, "kicad-mcp companion", icon)
+
         try:
             compatibility = ctx.load_compatibility_contract()
             client = ctx.StudioContextClient(base_url, auth_token=auth_token)
             health = client.health(compatibility)
             if health.state != "ready":
-                wx.MessageBox(
+                show(
                     f"{health.message}\n\n"
                     "Recovery: start or update the local kicad-mcp-pro backend, then retry.",
-                    "kicad-mcp companion",
                     wx.ICON_ERROR,
                 )
                 return
             client.push(ctx.build_studio_context(info))
-            wx.MessageBox(
-                f"Pushed context for {info.file_name or 'active board'} to {base_url}.",
-                "kicad-mcp companion",
+            file_name = getattr(info, "file_name", "")
+            show(
+                f"Pushed context for {file_name or 'active board'} to {base_url}.",
                 wx.ICON_INFORMATION,
             )
         except ValueError as exc:
-            wx.MessageBox(
-                f"Companion setup/compatibility error:\n{exc}",
-                "kicad-mcp companion",
-                wx.ICON_ERROR,
-            )
+            show(f"Companion setup/compatibility error:\n{exc}", wx.ICON_ERROR)
         except Exception as exc:  # noqa: BLE001 - network/server errors are user-facing
-            wx.MessageBox(
+            show(
                 f"Could not reach kicad-mcp at {base_url}:\n{exc}\n\n"
                 "Start an HTTP-mode server, e.g.:\n"
                 "kicad-mcp-pro --transport streamable-http --port 3334 --mode write",
-                "kicad-mcp companion",
                 wx.ICON_ERROR,
             )
 

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -705,6 +705,8 @@ def _filter_ipc_runtime_tools(
     tools: list[mcp_types.Tool],
     state: KiCadIpcCapabilityState | None = None,
 ) -> list[mcp_types.Tool]:
+    if not any(_tool_requires_ipc(tool.name) for tool in tools):
+        return tools
     state = state or get_ipc_capability_state()
     return [tool for tool in tools if _ipc_runtime_allows_tool(tool.name, state)]
 
@@ -1970,6 +1972,9 @@ def build_server(profile: str | None = None, *, defer_registration: bool = False
         auth=auth,
         token_verifier=token_verifier,
     )
+    # The legacy mcp.server.fastmcp wrapper otherwise advertises the MCP SDK
+    # package version during initialize instead of this product's release version.
+    server._mcp_server.version = __version__
     server.operating_mode = operating_mode
     server.allow_experimental_tools = operating_mode is OperatingMode.EXPERIMENTAL
     server.allowed_tool_names = set(tools_for_profile(selected_profile))
@@ -2684,11 +2689,16 @@ def bridge(
 def setup_restore(
     agent: str = typer.Argument(..., help=option_help("Agent to restore config for.")),
     scope: str = typer.Option("project", "--scope", help=option_help("Config scope to restore.")),
+    project_dir: str | None = typer.Option(
+        None,
+        "--project-dir",
+        help=option_help("Project directory for project-scoped config."),
+    ),
 ) -> None:
     """Restore the most recent backup of an agent configuration."""
     from .setup import restore_config
 
-    result = restore_config(agent, scope)
+    result = restore_config(agent, scope, project_dir=project_dir)
     typer.echo(result)
 
 
@@ -2696,11 +2706,16 @@ def setup_restore(
 def setup_backups(
     agent: str = typer.Argument(..., help=option_help("Agent to list backups for.")),
     scope: str = typer.Option("project", "--scope", help=option_help("Config scope to list.")),
+    project_dir: str | None = typer.Option(
+        None,
+        "--project-dir",
+        help=option_help("Project directory for project-scoped config."),
+    ),
 ) -> None:
     """List available backups for an agent configuration."""
     from .setup import list_config_backups
 
-    result = list_config_backups(agent, scope)
+    result = list_config_backups(agent, scope, project_dir=project_dir)
     typer.echo(result)
 
 

--- a/src/kicad_mcp/setup.py
+++ b/src/kicad_mcp/setup.py
@@ -200,7 +200,7 @@ def _claude_desktop_path() -> Path:
     return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
 
 
-def resolve_path(agent_key: str, scope: str) -> Path:
+def resolve_path(agent_key: str, scope: str, project_dir: str | Path | None = None) -> Path:
     """Resolve the config file path for an agent and scope.
 
     Respects platform (Windows/macOS/Linux) differences.
@@ -226,7 +226,10 @@ def resolve_path(agent_key: str, scope: str) -> Path:
     # On Windows, rewrite Unix-style paths
     if sys.platform == "win32":
         raw = raw.replace("~", os.environ.get("USERPROFILE", "~"))
-    return Path(raw).expanduser().resolve()
+    path = Path(raw).expanduser()
+    if scope == "project" and project_dir is not None and not path.is_absolute():
+        path = Path(project_dir).expanduser() / path
+    return path.resolve()
 
 
 def resolve_all_paths(agent_key: str) -> dict[Scope, Path]:
@@ -480,10 +483,16 @@ def backup_config(path: Path) -> Path | None:
     return bak
 
 
-def list_backups(agent_key: str, scope: str) -> list[Path]:
+def list_backups(
+    agent_key: str, scope: str, *, project_dir: str | Path | None = None
+) -> list[Path]:
     """List all backup files for a given agent config."""
     try:
-        path = resolve_path(agent_key, str(scope))
+        path = (
+            resolve_path(agent_key, str(scope), project_dir)
+            if project_dir is not None
+            else resolve_path(agent_key, str(scope))
+        )
     except ValueError:
         return []
     parent = path.parent
@@ -493,14 +502,18 @@ def list_backups(agent_key: str, scope: str) -> list[Path]:
     return sorted(parent.glob(pattern), reverse=True)
 
 
-def restore_backup(agent_key: str, scope: str) -> str:
+def restore_backup(agent_key: str, scope: str, *, project_dir: str | Path | None = None) -> str:
     """Restore the most recent backup for an agent config."""
-    backups = list_backups(agent_key, scope)
+    backups = list_backups(agent_key, scope, project_dir=project_dir)
     if not backups:
         return f"No backups found for {agent_key} ({scope})."
     latest = backups[0]
     try:
-        path = resolve_path(agent_key, scope)
+        path = (
+            resolve_path(agent_key, scope, project_dir)
+            if project_dir is not None
+            else resolve_path(agent_key, scope)
+        )
         shutil.copy2(latest, path)
         return f"Restored {path} from {latest}"
     except (OSError, ValueError) as exc:
@@ -675,6 +688,7 @@ def write_config(
     scope: str = "project",
     *,
     backup: bool = True,
+    project_dir: str | Path | None = None,
 ) -> WriteResult:
     """Merge and atomically write one client config. Returns ``(path, success)``."""
     info = AGENTS.get(agent_key)
@@ -687,7 +701,11 @@ def write_config(
         return f"Agent '{agent_key}' does not support scope '{scope}'. Valid: {valid}", False
 
     try:
-        path = resolve_path(agent_key, scope)
+        path = (
+            resolve_path(agent_key, scope, project_dir)
+            if project_dir is not None
+            else resolve_path(agent_key, scope)
+        )
         existing = path.read_text(encoding="utf-8") if path.exists() else ""
         merged = _merged_config(existing, config_str, agent_key, info.format)
         issues = validate_config(merged, agent_key, info.format)
@@ -932,7 +950,9 @@ def setup_agent(
                 f"Valid scopes: {valid}\n\nConfig snippet:\n{config_str}"
             )
 
-        path_str, ok = write_config(agent, config_str, scope)
+        path_str, ok = write_config(
+            agent, config_str, scope, project_dir=project if scope == "project" else None
+        )
         if ok:
             # Validate after writing
             issues = validate_config(config_str, agent, fmt)
@@ -973,18 +993,22 @@ def setup_wizard() -> str:
     return "\n".join(lines)
 
 
-def restore_config(agent: str, scope: str = "project") -> str:
+def restore_config(
+    agent: str, scope: str = "project", *, project_dir: str | Path | None = None
+) -> str:
     """Restore the most recent backup for an agent config."""
     if agent not in AGENTS:
         return f"Unknown agent: {agent}"
-    return restore_backup(agent, str(scope))
+    return restore_backup(agent, str(scope), project_dir=project_dir)
 
 
-def list_config_backups(agent: str, scope: str = "project") -> str:
+def list_config_backups(
+    agent: str, scope: str = "project", *, project_dir: str | Path | None = None
+) -> str:
     """List available backups for an agent config."""
     if agent not in AGENTS:
         return f"Unknown agent: {agent}"
-    backups = list_backups(agent, str(scope))
+    backups = list_backups(agent, str(scope), project_dir=project_dir)
     if not backups:
         return f"No backups found for {agent} ({scope})."
     lines = [f"Backups for {agent} ({scope}):"]

--- a/tests/unit/test_companion_context.py
+++ b/tests/unit/test_companion_context.py
@@ -455,6 +455,99 @@ def test_health_invalid_json_is_backend_unhealthy() -> None:
     assert "decoded" in status.message
 
 
+def _run_companion_worker_inline(monkeypatch: pytest.MonkeyPatch, module: object) -> None:
+    class _ImmediateThread:
+        def __init__(
+            self,
+            *,
+            target: object,
+            args: tuple[object, ...] = (),
+            kwargs: dict[str, object] | None = None,
+            **_: object,
+        ) -> None:
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+
+        def start(self) -> None:
+            assert callable(self._target)
+            self._target(*self._args, **self._kwargs)
+
+    monkeypatch.setattr(
+        module,
+        "threading",
+        __import__("types").SimpleNamespace(Thread=_ImmediateThread),
+        raising=False,
+    )
+
+
+def test_action_plugin_defers_backend_io_off_ui_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path
+
+    plugin_dir = Path(__file__).resolve().parents[2] / "packages" / "kicad-plugin"
+    health_calls: list[bool] = []
+    scheduled: list[object] = []
+
+    class _ActionPlugin:
+        pass
+
+    class _Client:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def health(self, _: dict[str, object]) -> object:
+            health_calls.append(True)
+            return types.SimpleNamespace(state="ready", message="ready")
+
+        def push(self, _payload: object) -> None:
+            pass
+
+    class _DeferredThread:
+        def __init__(self, *, target: object, **_: object) -> None:
+            scheduled.append(target)
+
+        def start(self) -> None:
+            pass
+
+    fake_ctx = types.SimpleNamespace(
+        BoardInfo=object,
+        StudioContextClient=_Client,
+        build_studio_context=lambda info: {"active_file": str(info)},
+        load_compatibility_contract=lambda: _compat_contract(),
+    )
+    fake_wx = types.SimpleNamespace(
+        ICON_ERROR=1,
+        ICON_INFORMATION=2,
+        MessageBox=lambda *_args: None,
+        CallAfter=lambda func, *args: func(*args),
+    )
+    monkeypatch.setitem(sys.modules, "pcbnew", types.SimpleNamespace(ActionPlugin=_ActionPlugin))
+    monkeypatch.setitem(sys.modules, "wx", fake_wx)
+
+    spec = importlib.util.spec_from_file_location(
+        "kicad_mcp_companion_async_test", plugin_dir / "kicad_mcp_companion.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "_load_context", lambda: fake_ctx)
+    monkeypatch.setattr(
+        module, "threading", types.SimpleNamespace(Thread=_DeferredThread), raising=False
+    )
+    plugin = module.KiCadMcpCompanionPlugin()
+    monkeypatch.setattr(plugin, "_read_board_info", lambda _: "fixture-board")
+
+    plugin.Run()
+
+    assert health_calls == []
+    assert len(scheduled) == 1
+
+
 def test_action_plugin_does_not_push_context_when_backend_is_not_ready(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -495,6 +588,7 @@ def test_action_plugin_does_not_push_context_when_backend_is_not_ready(
         ICON_WARNING=4,
         YES_NO=8,
         YES=16,
+        CallAfter=lambda func, *args: func(*args),
         MessageBox=lambda message, *_args: messages.append(str(message)),
     )
     monkeypatch.setitem(sys.modules, "pcbnew", types.SimpleNamespace(ActionPlugin=_ActionPlugin))
@@ -510,6 +604,7 @@ def test_action_plugin_does_not_push_context_when_backend_is_not_ready(
     spec.loader.exec_module(module)
     monkeypatch.setattr(module, "_load_context", lambda: fake_ctx)
 
+    _run_companion_worker_inline(monkeypatch, module)
     plugin = module.KiCadMcpCompanionPlugin()
     monkeypatch.setattr(plugin, "_read_board_info", lambda _: "fixture-board")
     plugin.Run()
@@ -547,6 +642,7 @@ def test_action_plugin_surfaces_compatibility_contract_error(
         ICON_WARNING=4,
         YES_NO=8,
         YES=16,
+        CallAfter=lambda func, *args: func(*args),
         MessageBox=lambda message, *_args: messages.append(str(message)),
     )
     monkeypatch.setitem(sys.modules, "pcbnew", types.SimpleNamespace(ActionPlugin=_ActionPlugin))
@@ -562,6 +658,7 @@ def test_action_plugin_surfaces_compatibility_contract_error(
     spec.loader.exec_module(module)
     monkeypatch.setattr(module, "_load_context", lambda: fake_ctx)
 
+    _run_companion_worker_inline(monkeypatch, module)
     plugin = module.KiCadMcpCompanionPlugin()
     monkeypatch.setattr(plugin, "_read_board_info", lambda _: "fixture-board")
     plugin.Run()
@@ -605,6 +702,7 @@ def test_action_plugin_pushes_only_after_ready_health(monkeypatch: pytest.Monkey
         ICON_WARNING=4,
         YES_NO=8,
         YES=16,
+        CallAfter=lambda func, *args: func(*args),
         MessageBox=lambda *_args: None,
     )
     monkeypatch.setitem(sys.modules, "pcbnew", types.SimpleNamespace(ActionPlugin=_ActionPlugin))
@@ -620,6 +718,7 @@ def test_action_plugin_pushes_only_after_ready_health(monkeypatch: pytest.Monkey
     spec.loader.exec_module(module)
     monkeypatch.setattr(module, "_load_context", lambda: fake_ctx)
 
+    _run_companion_worker_inline(monkeypatch, module)
     plugin = module.KiCadMcpCompanionPlugin()
     monkeypatch.setattr(plugin, "_read_board_info", lambda _: "fixture-board")
     plugin.Run()

--- a/tests/unit/test_companion_context.py
+++ b/tests/unit/test_companion_context.py
@@ -532,7 +532,8 @@ def test_action_plugin_defers_backend_io_off_ui_thread(
     spec = importlib.util.spec_from_file_location(
         "kicad_mcp_companion_async_test", plugin_dir / "kicad_mcp_companion.py"
     )
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     monkeypatch.setattr(module, "_load_context", lambda: fake_ctx)

--- a/tests/unit/test_issue_731_onboarding.py
+++ b/tests/unit/test_issue_731_onboarding.py
@@ -269,3 +269,40 @@ def test_atomic_replace_failure_keeps_original_and_cleans_temp(
     assert "replace failed" in message
     assert path.read_bytes() == original
     assert list(tmp_path.glob(".mcp.json.*.tmp")) == []
+
+
+def test_setup_agent_write_targets_explicit_project_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kicad_mcp.setup import setup_agent
+
+    project = tmp_path / "project"
+    cwd = tmp_path / "cwd"
+    project.mkdir()
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    result = setup_agent("cursor", project_dir=str(project), write=True, scope="project")
+
+    target = project / ".cursor" / "mcp.json"
+    assert "Config written" in result
+    assert target.exists()
+    assert not (cwd / ".cursor" / "mcp.json").exists()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["kicad"]["env"]["KICAD_MCP_PROJECT_DIR"] == str(project)
+
+
+def test_project_backup_restore_honors_explicit_project_dir(tmp_path: Path) -> None:
+    from kicad_mcp.setup import restore_config, setup_agent
+
+    project = tmp_path / "project"
+    target = project / ".cursor" / "mcp.json"
+    target.parent.mkdir(parents=True)
+    original = {"theme": "dark", "mcpServers": {"other": {"command": "safe"}}}
+    target.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+    setup_agent("cursor", project_dir=str(project), write=True, scope="project")
+    restored = restore_config("cursor", "project", project_dir=str(project))
+
+    assert "Restored" in restored
+    assert json.loads(target.read_text(encoding="utf-8")) == original

--- a/tests/unit/test_mcp_protocol_contract.py
+++ b/tests/unit/test_mcp_protocol_contract.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
+from kicad_mcp import __version__
 from kicad_mcp.compatibility import MCP_PROTOCOL_VERSION
 from kicad_mcp.config import get_config
 from kicad_mcp.server import _StreamableHttpContractMiddleware, build_server
@@ -68,6 +69,20 @@ def _assert_json_rpc_error(
     assert payload["id"] == request_id
     assert payload["error"]["code"] == code
     assert payload["error"]["message"] == message
+
+
+def test_initialize_advertises_product_version(sample_project: Path) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.stateful_http = False
+    server = build_server("default")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        initialized = client.post("/mcp", headers=_headers(), json=_initialize_request())
+
+    assert initialized.status_code == 200
+    assert initialized.json()["result"]["serverInfo"]["version"] == __version__
 
 
 def test_oaslana_71_chatgpt_connector_stateless_tools_list_does_not_require_session_header(

--- a/tests/unit/test_schematic_runtime_discovery.py
+++ b/tests/unit/test_schematic_runtime_discovery.py
@@ -46,3 +46,15 @@ def test_file_backed_schematic_tools_remain_visible_when_editor_is_closed() -> N
         "variant_create",
     }.issubset(visible)
     assert "sch_reload" not in visible
+
+
+def test_non_ipc_tool_filter_does_not_probe_runtime(monkeypatch) -> None:
+    import kicad_mcp.server as server_module
+
+    def unexpected_probe() -> object:
+        raise AssertionError("non-IPC discovery must not probe KiCad runtime")
+
+    monkeypatch.setattr(server_module, "get_ipc_capability_state", unexpected_probe)
+    tools = [Tool(name="studio_push_context", inputSchema={})]
+
+    assert _filter_ipc_runtime_tools(tools) == tools

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -341,6 +341,31 @@ class TestCliSetup:
         result = CliRunner().invoke(app, ["setup-backups", "claude-code"])
         assert result.exit_code == 0, result.output
 
+    def test_setup_backup_commands_forward_project_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        observed: list[tuple[str, str | None]] = []
+        monkeypatch.setattr(
+            "kicad_mcp.setup.restore_config",
+            lambda _agent, _scope, *, project_dir=None: (
+                observed.append(("restore", project_dir)) or "ok"
+            ),
+        )
+        monkeypatch.setattr(
+            "kicad_mcp.setup.list_config_backups",
+            lambda _agent, _scope, *, project_dir=None: (
+                observed.append(("backups", project_dir)) or "ok"
+            ),
+        )
+
+        project = str(tmp_path / "project")
+        restored = CliRunner().invoke(app, ["setup-restore", "cursor", "--project-dir", project])
+        listed = CliRunner().invoke(app, ["setup-backups", "cursor", "--project-dir", project])
+
+        assert restored.exit_code == 0, restored.output
+        assert listed.exit_code == 0, listed.output
+        assert observed == [("restore", project), ("backups", project)]
+
 
 # ---------------------------------------------------------------------------
 # Doctor integration


### PR DESCRIPTION
## Summary
- move companion backend health/context HTTP I/O off the KiCad UI thread and marshal dialogs back through `wx.CallAfter`
- skip KiCad IPC runtime probing when the discovered tool set contains no IPC-dependent tools
- make project-scoped setup/backup/restore honor explicit `--project-dir`
- advertise the KiCad MCP Pro product version in MCP `initialize.serverInfo`
- document explicit project-dir backup/restore commands

## Root cause
Real KiCad 10.0.5 PCM testing exposed a UI-thread deadlock: the companion synchronously waited for backend HTTP while backend health/tool discovery could synchronously probe KiCad IPC. Moving backend I/O off the UI thread removes that circular wait while preserving live runtime health semantics.

The same physical onboarding pass found project-scoped writes resolving relative config paths against the process CWD instead of the requested project directory, and MCP initialize advertising the SDK version instead of the product version.

## Verification
- Ruff check + format: pass
- mypy: pass
- focused regression/security suites: pass
- full suite: 3787 tests, 0 failures, 0 errors, 28 skipped
- total coverage: 89.80% (required 83%)
- `git diff --check`: clean
- no generated/untracked coverage artifacts left in the worktree

### Real KiCad 10.0.5 Linux evidence
- deterministic PCM artifact produced twice with identical SHA256 `e3d1016a47bf8c1270c79a13cb07e1084dcf4e18b8a39d0637841778584d87bd`
- installed through KiCad Plugin and Content Manager
- live health reported `ipcReachable=true` and `livePcbContext=true`
- MCP initialize advertised `kicad-mcp-pro` version `3.33.3`
- companion activation returned from the UI thread in ~0.0006s and successfully pushed fixture-safe board context
- backend logged `studio_push_context` success and HTTP 200
- incompatible-version fail-closed, uninstall/config retention, rollback/reinstall, and disposable Cursor preview/write/backup/restore flows were physically exercised during the issue validation pass
- test host was restored to the captured pre-test KiCad state afterward

## Scope note
Issue #731 also requires maintained cross-platform physical evidence. This PR strengthens the Linux evidence and fixes bugs found by it, but intentionally does not auto-close the issue until the remaining platform matrix is objectively verified.

Refs #731
