### PR TITLE
docs(pcm): record Linux and Windows physical evidence

### DIFF
--- a/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
+++ b/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
@@ -58,6 +58,38 @@ verification, the pre-test KiCad configuration hashes were restored, the API was
 disabled again, the PCM package/resources and IPC socket were removed, and the
 temporary package copy was deleted.
 
+## Secondary physical Linux host
+
+A second authorized Linux desktop (`msi`) independently exercised the same merged
+revision and KiCad `10.0.5`. Its final PCM build reproduced the same
+`e3d1016a47bf8c1270c79a13cb07e1084dcf4e18b8a39d0637841778584d87bd`
+artifact hash and `9,511`-byte size. The host already had an older trusted
+`3.33.3` companion candidate installed, so this run exercised the real PCM update
+path rather than a clean first install.
+
+The final candidate replaced the installed companion through PCM and all installed
+plugin/resource hashes matched the final archive. After restart, the companion was
+discovered in PCB Editor. Backend-down guidance failed closed; with the exact merged
+backend, live health reported KiCad IPC and PCB context available. The companion
+returned from the KiCad UI thread in approximately `0.000133 s`, while
+`studio_push_context` completed in `2.483 ms` with HTTP 200. MCP initialize returned
+`serverInfo.version=3.33.3`; initialized, tools/list (`24` tools),
+`kicad://studio/context`, and read-only `kicad_get_version` all succeeded against the
+disposable fixture board. Forced backend incompatibility also failed closed, with an
+approximately `0.000068 s` UI-thread return.
+
+PCM uninstall was committed with **Apply Pending Changes**; plugin/resources were
+removed and a disposable unrelated client-config hash remained unchanged. Rollback
+then reinstalled the host's pre-test trusted PCM artifact with SHA-256
+`08b112d870f412a0e55c0f15f60264726e3cdd4ebc0e30768888d53a8b37a8c6`;
+its installed file hashes matched that archive and restart rediscovered the companion.
+Finally, the captured KiCad config and user-share trees were restored to their exact
+pre-test tree hashes. The user's active repository branch and dirty working tree were
+unchanged by the evidence run.
+
+This is a second independent Linux-host result. It strengthens Linux physical
+confidence but does not change the Windows/macOS platform boundary below.
+
 ## CI and quality evidence
 
 PR #811 was merged as `c25b852d90321754a95199645a450be98b126e76`.

--- a/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
+++ b/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
@@ -1,0 +1,79 @@
+# KiCad PCM Physical Linux Evidence
+
+- Date: `2026-08-29`
+- Product version: `3.33.3`
+- Merged source revision: `c25b852d90321754a95199645a450be98b126e76`
+- KiCad: `10.0.5`
+- PCM artifact SHA-256: `e3d1016a47bf8c1270c79a13cb07e1084dcf4e18b8a39d0637841778584d87bd`
+- PCM artifact size: `9,511` bytes
+- Test content: repository fixture board only; no user project was mutated
+
+## Reproducible package
+
+The PCM ZIP was built twice from the final source tree and the two archives were
+byte-for-byte identical. A later build from the merged revision on the authorized
+Windows test host produced the same SHA-256 and size. That Windows result proves
+cross-platform package reproducibility only; it is not recorded as a Windows
+physical PCM installation result.
+
+## Physical KiCad lifecycle
+
+The exact package was installed through **Plugin and Content Manager -> Install
+from File** on a real KiCad 10.0.5 Linux desktop. Installed companion files were
+checked against the archive by hash. After a full KiCad restart, **Tools ->
+External Plugins -> kicad-mcp companion** was discoverable.
+
+The following states were exercised against fixture-safe content:
+
+- backend stopped: fail-closed `backend_unreachable` guidance;
+- compatible backend: live health reported backend `3.33.3`, IPC reachable, and
+  live PCB context;
+- MCP initialize: `serverInfo.version` reported the product version `3.33.3`;
+- MCP lifecycle: initialize, initialized notification, tools/list,
+  `kicad://studio/context`, and read-only `kicad_get_version`;
+- healthy companion push: KiCad UI-thread return was approximately `0.0006 s`,
+  while the backend completed `studio_push_context` successfully over HTTP 200;
+- compatible reinstall/update: the same-version final candidate was reinstalled
+  through PCM and the installed hashes matched the candidate archive;
+- incompatible backend contract: fail-closed recovery guidance was shown and no
+  context push was performed;
+- uninstall: companion package/resources were removed while unrelated disposable
+  client configuration remained unchanged;
+- rollback: a previously trusted PCM artifact was reinstalled, discovered after
+  restart, and then removed as part of host cleanup.
+
+## Guided client transaction
+
+A disposable Cursor project configuration was used to exercise the project-scoped
+onboarding transaction. Preview did not mutate the file; explicit write targeted
+the requested project, preserved unrelated keys/server entries, created a backup,
+and restore returned the original file hash. This evidence is deliberately scoped
+to the disposable Cursor flow and does not claim a physical Claude Code or Codex
+application session.
+
+## Host restoration
+
+The KiCad API setting was enabled only for the live IPC portion of the test. After
+verification, the pre-test KiCad configuration hashes were restored, the API was
+disabled again, the PCM package/resources and IPC socket were removed, and the
+temporary package copy was deleted.
+
+## CI and quality evidence
+
+PR #811 was merged as `c25b852d90321754a95199645a450be98b126e76`.
+Before merge, the exact PR head passed Required PR Gate, full Python coverage, all
+server/npm OS lanes, CodeQL, dependency review, Gitleaks, Semgrep, security,
+SonarQube Cloud, and Codecov patch coverage. Sonar reported `0` new issues,
+`96.8%` new-code coverage, and `0.0%` new-code duplication.
+
+The merge revision then passed the exact-SHA push workflows including CI
+(`33255537706`), SonarCloud (`33255537748`), CodeQL, Gitleaks, Scorecard, Docs,
+Live Model Assurance, Release Please, and Dependency Graph.
+
+## Remaining platform boundary
+
+This evidence promotes only the Linux physical PCM path. Windows physical PCM flow
+is still pending. The authorized Windows host reproduced the exact ZIP hash before
+its remote-control session became unavailable, but no installation claim is made.
+A physical macOS host is not currently available in the authorized device set;
+macOS CI coverage is not treated as a substitute for a real PCM GUI lifecycle.

--- a/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
+++ b/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
@@ -41,14 +41,21 @@ The following states were exercised against fixture-safe content:
 - rollback: a previously trusted PCM artifact was reinstalled, discovered after
   restart, and then removed as part of host cleanup.
 
-## Guided client transaction
+## Guided client transaction and real client connect
 
 A disposable Cursor project configuration was used to exercise the project-scoped
 onboarding transaction. Preview did not mutate the file; explicit write targeted
 the requested project, preserved unrelated keys/server entries, created a backup,
-and restore returned the original file hash. This evidence is deliberately scoped
-to the disposable Cursor flow and does not claim a physical Claude Code or Codex
-application session.
+and restore returned the original file hash.
+
+On the secondary Linux host, Claude Code `2.1.238` was exercised as a real supported
+MCP client while KiCad `10.0.5` and the loopback backend were live. The test used a
+temporary `HOME` and disposable project, added the `kicad` server with Claude's own
+`mcp add --scope local --transport http` command, then ran `claude mcp get kicad`.
+Claude reported `Status: Connected` for `http://127.0.0.1:3334/mcp`; the backend
+recorded the corresponding initialize/session traffic.
+The user Claude configuration was not modified. MCP initialize/list-tools and the read-only `kicad_get_version`
+tool call were independently verified in the physical KiCad lifecycle smoke above.
 
 ## Host restoration
 

--- a/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
+++ b/docs/evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md
@@ -11,10 +11,9 @@
 ## Reproducible package
 
 The PCM ZIP was built twice from the final source tree and the two archives were
-byte-for-byte identical. A later build from the merged revision on the authorized
-Windows test host produced the same SHA-256 and size. That Windows result proves
-cross-platform package reproducibility only; it is not recorded as a Windows
-physical PCM installation result.
+byte-for-byte identical. A later physical Windows run from the same merged revision
+reproduced the same SHA-256 and size and completed the PCM lifecycle; see
+[Windows physical evidence](windows-kicad-10.0.5.md).
 
 ## Physical KiCad lifecycle
 
@@ -104,8 +103,7 @@ Live Model Assurance, Release Please, and Dependency Graph.
 
 ## Remaining platform boundary
 
-This evidence promotes only the Linux physical PCM path. Windows physical PCM flow
-is still pending. The authorized Windows host reproduced the exact ZIP hash before
-its remote-control session became unavailable, but no installation claim is made.
+This file records the Linux physical PCM path. Windows physical PCM lifecycle is now
+separately verified in [Windows physical evidence](windows-kicad-10.0.5.md).
 A physical macOS host is not currently available in the authorized device set;
 macOS CI coverage is not treated as a substitute for a real PCM GUI lifecycle.

--- a/docs/evidence/kicad-pcm/2026-08-29/windows-kicad-10.0.5.md
+++ b/docs/evidence/kicad-pcm/2026-08-29/windows-kicad-10.0.5.md
@@ -1,0 +1,76 @@
+# KiCad PCM Physical Windows Evidence
+
+- Date: `2026-08-29`
+- Product version: `3.33.3`
+- Merged source revision: `c25b852d90321754a95199645a450be98b126e76`
+- KiCad: `10.0.5`
+- Platform: authorized Windows desktop
+- Final PCM SHA-256: `e3d1016a47bf8c1270c79a13cb07e1084dcf4e18b8a39d0637841778584d87bd`
+- Final PCM size: `9,511` bytes
+- Test content: repository fixture board only; no user project was mutated
+
+## Clean install and restart
+
+The host started with no `com_github_oaslananka_kicad-mcp-pro` PCM package and
+with the KiCad API disabled. The final merged artifact was installed through the
+real KiCad **Plugin and Content Manager -> Install from File** flow. KiCad stored
+the package below the user `Documents/KiCad/10.0/3rdparty` tree.
+
+All installed companion/resource files matched the final ZIP entries by SHA-256.
+After a full KiCad restart, PCB Editor exposed **External Plugins -> kicad-mcp
+companion** for the disposable fixture board.
+
+## Backend and MCP lifecycle
+
+With port `3334` stopped, invoking the real companion showed fail-closed backend
+recovery guidance. The KiCad API was then enabled only for the live IPC portion
+of the test, and the exact merged backend was started on loopback.
+Live health reported backend `3.33.3`, `available=true`, `ipcReachable=true`, and
+`livePcbContext=true` against KiCad `10.0.5`. A synchronous native invocation of
+the companion returned from the KiCad UI thread in approximately `0.0277 s`, and
+the real KiCad dialog confirmed a successful context push for the fixture board.
+
+Protocol-level smoke then verified:
+
+- initialize: HTTP `200`, `serverInfo.version=3.33.3`;
+- initialized notification: HTTP `202`;
+- tools/list: HTTP `200`, `24` tools;
+- `kicad://studio/context`: returned the disposable fixture path;
+- read-only `kicad_get_version`: `isError=false`, CLI/IPC both `10.0.5`.
+
+A forced incompatible companion contract was also exercised. The native companion
+invocation returned in approximately `0.0258 s`, displayed the expected backend
+version incompatibility/recovery guidance, and did not push context. The temporary
+compatibility fixture was then restored from the final artifact by hash.
+
+## Uninstall and rollback
+
+A disposable unrelated client configuration was hashed before uninstall. PCM
+**Remove -> Apply Pending Changes** removed both plugin and resource directories;
+the client configuration SHA-256 remained unchanged.
+Rollback used the previously trusted `c5346b2fcec340e36c9fdfab543378837cb6d04b`
+artifact, independently rebuilt on Windows with SHA-256
+`d19e0e994707304912cd584f31283a138e85106d6f6f0b521d9f9a5a8148e717`.
+All rollback-installed files matched that archive by hash, and a full PCB Editor
+restart rediscovered the companion. The rollback package was then removed through
+PCM again as part of host cleanup.
+
+## Host restoration
+
+The disposable board was closed without saving and retained its original SHA-256
+`5004a7d46fdc0c2aba6b1bad83983cb3171b603f17eea05821a51f871167eae2`.
+The pre-test `kicad_common.json` snapshot was restored byte-for-byte to SHA-256
+`7ef9ef20558346f2a8d1998e21ee7916c1a99dbdace28fcc05d4f69f95ed049f`,
+which restored `api.enable_server=false`.
+
+Final cleanup verification showed no companion plugin/resources, no KiCad or
+PCB Editor process, no listener on port `3334`, and no test-owned temporary
+clone/artifact/fixture directories remaining.
+
+## Platform boundary
+
+This is real Windows PCM GUI lifecycle evidence, not a CI substitute. Together
+with the independent Linux-host runs, physical PCM install/restart/health/MCP/
+incompatible/uninstall/rollback behavior is verified on Linux and Windows.
+A physical macOS host is still unavailable in the authorized device set, so macOS
+CI remains explicitly CI-only rather than physical PCM evidence.

--- a/docs/status/distribution-readiness.md
+++ b/docs/status/distribution-readiness.md
@@ -11,7 +11,7 @@ A file existing in the repository is not enough to mark a surface verified.
 | MCPB | Existing release surface | `.github/workflows/publish-mcpb.yml`, `tests/unit/test_release_hardening.py` | Attested/versioned release asset contract. |
 | Docker / GHCR | Existing release surface | `.github/workflows/publish-mcp-container.yml`, container tests | No change from PCM work. |
 | Desktop | Existing release surface | GUI CI/release workflows and desktop/backend compatibility tests | Exact-release backend compatibility remains independent of PCM. |
-| **KiCad PCM** | **Physical Linux verified; cross-platform physical matrix pending** | [Linux physical evidence](../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md), `tests/unit/test_kicad_pcm_packaging.py`, `tests/unit/test_companion_context.py`, `.github/workflows/publish-kicad-pcm.yml` | Linux install/restart/health/MCP/update/incompatible/uninstall/rollback is physically verified. Windows physical PCM flow pending; macOS physical host unavailable, so CI is not presented as physical evidence. |
+| **KiCad PCM** | **Physical Linux verified; cross-platform physical matrix pending** | [Linux physical evidence](../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md), `tests/unit/test_kicad_pcm_packaging.py`, `tests/unit/test_companion_context.py`, `.github/workflows/publish-kicad-pcm.yml` | Linux install/restart/health/MCP/update/incompatible/uninstall/rollback is physically verified on two independent Linux hosts. Windows physical PCM flow pending; macOS physical host unavailable, so CI is not presented as physical evidence. |
 | Claude Code guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | Preview is side-effect-free; explicit write is merge-safe/backed up/reversible. |
 | Codex guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | Owned TOML sections are replaced without replacing unrelated text/tables. |
 | Cursor guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | JSON server-map merge preserves unrelated configuration. |
@@ -21,9 +21,10 @@ A file existing in the repository is not enough to mark a surface verified.
 ## Promotion rule
 
 The PCM surface may be described as **physically verified on Linux** because the
-maintained real KiCad installation demonstrates the same versioned artifact through
-install, restart/discovery, backend health, MCP lifecycle/read-only smoke, compatible
-update, incompatible-version fail-closed behavior, uninstall, and rollback. Full
+maintained real KiCad installations on two independent Linux hosts demonstrate the same
+versioned artifact through install/update, restart/discovery, backend health, MCP
+lifecycle/read-only smoke, incompatible-version fail-closed behavior, uninstall, and
+rollback. Full
 cross-platform **Verified** status remains blocked until the maintained platform
 boundary is complete: Windows physical PCM flow pending; macOS physical host unavailable
 and therefore explicitly documented as CI-only rather than physical evidence.

--- a/docs/status/distribution-readiness.md
+++ b/docs/status/distribution-readiness.md
@@ -11,7 +11,7 @@ A file existing in the repository is not enough to mark a surface verified.
 | MCPB | Existing release surface | `.github/workflows/publish-mcpb.yml`, `tests/unit/test_release_hardening.py` | Attested/versioned release asset contract. |
 | Docker / GHCR | Existing release surface | `.github/workflows/publish-mcp-container.yml`, container tests | No change from PCM work. |
 | Desktop | Existing release surface | GUI CI/release workflows and desktop/backend compatibility tests | Exact-release backend compatibility remains independent of PCM. |
-| **KiCad PCM** | **Physical Linux verified; cross-platform physical matrix pending** | [Linux physical evidence](../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md), `tests/unit/test_kicad_pcm_packaging.py`, `tests/unit/test_companion_context.py`, `.github/workflows/publish-kicad-pcm.yml` | Linux install/restart/health/MCP/update/incompatible/uninstall/rollback is physically verified on two independent Linux hosts. Windows physical PCM flow pending; macOS physical host unavailable, so CI is not presented as physical evidence. |
+| **KiCad PCM** | **Physical Linux + Windows verified; macOS physical host pending** | [Linux physical evidence](../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md), [Windows physical evidence](../evidence/kicad-pcm/2026-08-29/windows-kicad-10.0.5.md), `tests/unit/test_kicad_pcm_packaging.py`, `tests/unit/test_companion_context.py`, `.github/workflows/publish-kicad-pcm.yml` | Linux install/restart/health/MCP/update/incompatible/uninstall/rollback is physically verified on two independent Linux hosts. Windows physical PCM flow verified for install/restart/health/MCP/incompatible/uninstall/rollback. macOS physical host unavailable, so CI is not presented as physical evidence. |
 | Claude Code guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | Preview is side-effect-free; explicit write is merge-safe/backed up/reversible. |
 | Codex guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | Owned TOML sections are replaced without replacing unrelated text/tables. |
 | Cursor guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | JSON server-map merge preserves unrelated configuration. |
@@ -20,14 +20,13 @@ A file existing in the repository is not enough to mark a surface verified.
 
 ## Promotion rule
 
-The PCM surface may be described as **physically verified on Linux** because the
-maintained real KiCad installations on two independent Linux hosts demonstrate the same
-versioned artifact through install/update, restart/discovery, backend health, MCP
+The PCM surface may be described as **physically verified on Linux and Windows**.
+Two independent Linux hosts and one Windows host demonstrate the versioned artifact
+through install/update or clean install, restart/discovery, backend health, MCP
 lifecycle/read-only smoke, incompatible-version fail-closed behavior, uninstall, and
-rollback. Full
-cross-platform **Verified** status remains blocked until the maintained platform
-boundary is complete: Windows physical PCM flow pending; macOS physical host unavailable
-and therefore explicitly documented as CI-only rather than physical evidence.
+rollback. Full cross-platform **Verified** status remains blocked only because the
+macOS physical host unavailable boundary is explicitly documented as CI-only rather
+than physical evidence.
 
 Physical evidence must identify the exact source revision and artifact SHA256 without
 exposing local credentials, private paths, or unrelated desktop content.

--- a/docs/status/distribution-readiness.md
+++ b/docs/status/distribution-readiness.md
@@ -11,7 +11,7 @@ A file existing in the repository is not enough to mark a surface verified.
 | MCPB | Existing release surface | `.github/workflows/publish-mcpb.yml`, `tests/unit/test_release_hardening.py` | Attested/versioned release asset contract. |
 | Docker / GHCR | Existing release surface | `.github/workflows/publish-mcp-container.yml`, container tests | No change from PCM work. |
 | Desktop | Existing release surface | GUI CI/release workflows and desktop/backend compatibility tests | Exact-release backend compatibility remains independent of PCM. |
-| **KiCad PCM** | **Candidate — physical verification pending** | `tests/unit/test_kicad_pcm_packaging.py`, `tests/unit/test_companion_context.py`, `.github/workflows/publish-kicad-pcm.yml` | Deterministic package/health/release contracts exist; real install/update/uninstall/rollback evidence is required before “verified”. |
+| **KiCad PCM** | **Physical Linux verified; cross-platform physical matrix pending** | [Linux physical evidence](../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md), `tests/unit/test_kicad_pcm_packaging.py`, `tests/unit/test_companion_context.py`, `.github/workflows/publish-kicad-pcm.yml` | Linux install/restart/health/MCP/update/incompatible/uninstall/rollback is physically verified. Windows physical PCM flow pending; macOS physical host unavailable, so CI is not presented as physical evidence. |
 | Claude Code guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | Preview is side-effect-free; explicit write is merge-safe/backed up/reversible. |
 | Codex guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | Owned TOML sections are replaced without replacing unrelated text/tables. |
 | Cursor guided config | Transaction contract verified; physical flow pending | `tests/unit/test_issue_731_onboarding.py` | JSON server-map merge preserves unrelated configuration. |
@@ -20,13 +20,16 @@ A file existing in the repository is not enough to mark a surface verified.
 
 ## Promotion rule
 
-KiCad PCM moves from **Candidate — physical verification pending** to **Verified**
-only after a maintained real KiCad installation demonstrates the same versioned
-artifact through install, restart/discovery, backend health, MCP lifecycle/read-only
-smoke, compatible update, incompatible-version fail-closed behavior, uninstall,
-and rollback. The evidence must identify the exact source revision and artifact
-SHA256 without exposing local credentials, private paths, or unrelated desktop
-content.
+The PCM surface may be described as **physically verified on Linux** because the
+maintained real KiCad installation demonstrates the same versioned artifact through
+install, restart/discovery, backend health, MCP lifecycle/read-only smoke, compatible
+update, incompatible-version fail-closed behavior, uninstall, and rollback. Full
+cross-platform **Verified** status remains blocked until the maintained platform
+boundary is complete: Windows physical PCM flow pending; macOS physical host unavailable
+and therefore explicitly documented as CI-only rather than physical evidence.
+
+Physical evidence must identify the exact source revision and artifact SHA256 without
+exposing local credentials, private paths, or unrelated desktop content.
 
 Client rows similarly distinguish unit-level transaction safety from a real
 installed-client flow. A successful config unit test does not prove the external

--- a/tests/unit/test_issue_731_docs.py
+++ b/tests/unit/test_issue_731_docs.py
@@ -55,3 +55,14 @@ def test_pcm_submission_doc_is_explicitly_pre_submission() -> None:
     assert "install_size" in doc
     assert "packages/com.github.oaslananka.kicad-mcp-pro" in doc
     assert "Do not submit" in doc
+
+
+def test_linux_evidence_records_real_supported_client_connect() -> None:
+    doc = (
+        ROOT / "docs" / "evidence" / "kicad-pcm" / "2026-08-29" / "linux-kicad-10.0.5.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Claude Code `2.1.238`" in doc
+    assert "Status: Connected" in doc
+    assert "temporary `HOME`" in doc
+    assert "user Claude configuration was not modified" in doc

--- a/tests/unit/test_issue_731_docs.py
+++ b/tests/unit/test_issue_731_docs.py
@@ -23,13 +23,15 @@ def test_companion_docs_cover_pcm_lifecycle_health_and_uvx_fallback() -> None:
     assert "modern KiCad plugin API" in doc
 
 
-def test_distribution_readiness_records_linux_pcm_evidence_without_cross_platform_overclaim(
-) -> None:
+def test_distribution_readiness_records_linux_pcm_evidence_without_cross_platform_overclaim() -> (
+    None
+):
     doc = (ROOT / "docs" / "status" / "distribution-readiness.md").read_text(encoding="utf-8")
 
     assert "KiCad PCM" in doc
     assert "Physical Linux verified; cross-platform physical matrix pending" in doc
     assert "../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md" in doc
+    assert "two independent Linux hosts" in doc
     assert "Windows physical PCM flow pending" in doc
     assert "macOS physical host unavailable" in doc
     assert "**KiCad PCM** | **Verified**" not in doc

--- a/tests/unit/test_issue_731_docs.py
+++ b/tests/unit/test_issue_731_docs.py
@@ -23,11 +23,16 @@ def test_companion_docs_cover_pcm_lifecycle_health_and_uvx_fallback() -> None:
     assert "modern KiCad plugin API" in doc
 
 
-def test_distribution_readiness_keeps_pcm_pending_until_physical_evidence_exists() -> None:
+def test_distribution_readiness_records_linux_pcm_evidence_without_cross_platform_overclaim(
+) -> None:
     doc = (ROOT / "docs" / "status" / "distribution-readiness.md").read_text(encoding="utf-8")
 
     assert "KiCad PCM" in doc
-    assert "Candidate — physical verification pending" in doc
+    assert "Physical Linux verified; cross-platform physical matrix pending" in doc
+    assert "../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md" in doc
+    assert "Windows physical PCM flow pending" in doc
+    assert "macOS physical host unavailable" in doc
+    assert "**KiCad PCM** | **Verified**" not in doc
     assert "Claude Code" in doc
     assert "Codex" in doc
     assert "Cursor" in doc

--- a/tests/unit/test_issue_731_docs.py
+++ b/tests/unit/test_issue_731_docs.py
@@ -23,16 +23,15 @@ def test_companion_docs_cover_pcm_lifecycle_health_and_uvx_fallback() -> None:
     assert "modern KiCad plugin API" in doc
 
 
-def test_distribution_readiness_records_linux_pcm_evidence_without_cross_platform_overclaim() -> (
-    None
-):
+def test_distribution_readiness_records_linux_and_windows_pcm_evidence() -> None:
     doc = (ROOT / "docs" / "status" / "distribution-readiness.md").read_text(encoding="utf-8")
 
     assert "KiCad PCM" in doc
-    assert "Physical Linux verified; cross-platform physical matrix pending" in doc
+    assert "Physical Linux + Windows verified; macOS physical host pending" in doc
     assert "../evidence/kicad-pcm/2026-08-29/linux-kicad-10.0.5.md" in doc
+    assert "../evidence/kicad-pcm/2026-08-29/windows-kicad-10.0.5.md" in doc
     assert "two independent Linux hosts" in doc
-    assert "Windows physical PCM flow pending" in doc
+    assert "Windows physical PCM flow verified" in doc
     assert "macOS physical host unavailable" in doc
     assert "**KiCad PCM** | **Verified**" not in doc
     assert "Claude Code" in doc


### PR DESCRIPTION
## Summary
- record real KiCad 10.0.5 PCM lifecycle evidence for issue #731 on two independent Linux hosts and one Windows host
- document deterministic final artifact SHA-256 `e3d1016a47bf8c1270c79a13cb07e1084dcf4e18b8a39d0637841778584d87bd`
- document Windows clean install, restart/discovery, backend-down and healthy paths, MCP lifecycle, incompatible fail-closed behavior, uninstall/config retention, trusted rollback, and exact host restoration
- record a real supported-client connect flow with Claude Code `2.1.238`: isolated temporary HOME/project, Claude-native `mcp add`, and `mcp get` reporting `Status: Connected` against the live loopback backend
- keep full cross-platform physical status pending because no authorized physical macOS host is currently available; macOS CI is not presented as physical evidence
- keep the docs contract preventing platform overclaim

## Local verification
- RED/GREEN direct execution of the updated distribution-readiness and supported-client docs contracts
- direct execution of all `tests/unit/test_issue_731_docs.py` test functions: pass
- `python3 -m py_compile tests/unit/test_issue_731_docs.py`: pass
- `git diff --check`: pass
- new Python/evidence lines checked for excessive line length: clean
- sensitive device-id/private-path/token scan of committed evidence: no matches
- MSI KiCad config/share trees restored to their pre-test hashes; disposable client/backend/fixture temp files removed

The evidence worktree cannot execute the repository pytest/Ruff environment because the available shared toolchain is owned by `exec-agent`; remote CI is the canonical pytest/Ruff/policy verification for the latest head.

Refs #731
