### PR TITLE
fix(mcp): honor negotiated protocol versions

### DIFF
--- a/docs/mcp/transport.md
+++ b/docs/mcp/transport.md
@@ -20,8 +20,11 @@ HTTP `POST` request to the configured endpoint. Every Streamable HTTP request
 must include `Accept: application/json, text/event-stream` and JSON requests
 must include `Content-Type: application/json`.
 
-After `initialize`, clients must include `MCP-Protocol-Version: 2025-11-25` on
-follow-up requests. Stateful deployments also return `MCP-Session-Id` from
+After `initialize`, clients must echo the negotiated protocol version in the
+`MCP-Protocol-Version` header on follow-up requests. The public stable baseline
+remains `2025-11-25`; the pinned MCP SDK also negotiates its supported earlier
+protocol versions for backward-compatible clients such as Codex. Stateful
+deployments also return `MCP-Session-Id` from
 `initialize`; clients must echo that value on `notifications/initialized`,
 `tools/list`, `tools/call`, and later requests. Missing stateful session IDs
 return HTTP 400 with a structured JSON-RPC error, and unknown session IDs return

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -48,6 +48,7 @@ from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.lowlevel.helper_types import ReadResourceContents
+from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
 from mcp.types import (
     CancelTaskRequest,
     CancelTaskResult,
@@ -1268,12 +1269,12 @@ class _StreamableHttpContractMiddleware:
             return
 
         protocol_version = headers.get("mcp-protocol-version")
-        if protocol_version and protocol_version != MCP_PROTOCOL_VERSION:
+        if protocol_version and protocol_version not in SUPPORTED_PROTOCOL_VERSIONS:
             await _streamable_http_error_response(
                 code=-32002,
                 message=(
                     f"Unsupported MCP-Protocol-Version: {protocol_version}. "
-                    f"Expected {MCP_PROTOCOL_VERSION}."
+                    f"Supported versions: {', '.join(SUPPORTED_PROTOCOL_VERSIONS)}."
                 ),
                 rpc_id=rpc_id,
                 status_code=400,

--- a/tests/unit/test_mcp_2026_docs_contract.py
+++ b/tests/unit/test_mcp_2026_docs_contract.py
@@ -54,3 +54,11 @@ def test_candidate_protocol_operator_documentation_is_explicitly_release_gated()
 
     assert "MCP 2026 Stateless Compatibility Lane" in navigation
     assert "adr/0006-mcp-2026-stateless-compatibility-lane.md" in navigation
+
+
+def test_stable_streamable_http_docs_follow_negotiated_protocol_version() -> None:
+    transport = TRANSPORT.read_text(encoding="utf-8")
+
+    assert "negotiated protocol version" in transport
+    assert "Codex" in transport
+    assert "must include `MCP-Protocol-Version: 2025-11-25`" not in transport

--- a/tests/unit/test_mcp_protocol_contract.py
+++ b/tests/unit/test_mcp_protocol_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
 from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
@@ -323,7 +324,10 @@ def test_streamable_http_rejects_unsupported_protocol_version_header(
         response,
         status_code=400,
         code=-32002,
-        message=f"Unsupported MCP-Protocol-Version: 1900-01-01. Expected {MCP_PROTOCOL_VERSION}.",
+        message=(
+            "Unsupported MCP-Protocol-Version: 1900-01-01. "
+            f"Supported versions: {', '.join(SUPPORTED_PROTOCOL_VERSIONS)}."
+        ),
         request_id=1,
     )
 
@@ -413,3 +417,52 @@ def test_contract_middleware_bounds_remembered_streamable_http_sessions() -> Non
     assert middleware._has_session("session-0") is False
     assert middleware._has_session("session-256") is True
     assert len(middleware._session_ids) == 256
+
+
+def test_streamable_http_accepts_codex_negotiated_2025_06_18_protocol(
+    sample_project: Path,
+) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.stateful_http = False
+    server = build_server("minimal")
+    protocol_version = "2025-06-18"
+    transport_headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    initialize_request = {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": protocol_version,
+            "capabilities": {"elicitation": {"form": {}, "url": {}}},
+            "clientInfo": {"name": "codex-mcp-client", "version": "0.150.1"},
+        },
+    }
+    negotiated_headers = {
+        **transport_headers,
+        "MCP-Protocol-Version": protocol_version,
+    }
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        initialized = client.post("/mcp", headers=transport_headers, json=initialize_request)
+        notification = client.post(
+            "/mcp",
+            headers=negotiated_headers,
+            json=_initialized_notification(),
+        )
+        listed = client.post(
+            "/mcp",
+            headers=negotiated_headers,
+            json=_tools_list_request(request_id=1),
+        )
+
+    assert initialized.status_code == 200
+    assert initialized.json()["result"]["protocolVersion"] == protocol_version
+    assert notification.status_code == 202
+    assert listed.status_code == 200
+    tool_names = {tool["name"] for tool in listed.json()["result"]["tools"]}
+    assert "kicad_get_version" in tool_names


### PR DESCRIPTION
## Summary
- honor the protocol version negotiated by the pinned MCP SDK instead of forcing every stable Streamable HTTP follow-up request to `2025-11-25`
- keep unknown protocol versions fail-closed using the SDK's own `SUPPORTED_PROTOCOL_VERSIONS` allow-list
- add a regression reproducing Codex CLI 0.150.1 (`2025-06-18`) initialize -> initialized -> tools/list behavior
- correct Streamable HTTP docs so the public stable baseline remains `2025-11-25` while backward-compatible clients echo their negotiated version

## Root cause / physical evidence
A real Codex CLI 0.150.1 session negotiated MCP `2025-06-18`. The pinned MCP Python SDK accepted it and returned `protocolVersion=2025-06-18`, but the repository's custom Streamable HTTP middleware rejected Codex's subsequent `MCP-Protocol-Version: 2025-06-18` header with HTTP 400 because it independently required `2025-11-25`.

After this fix, the same real Codex CLI flow on KiCad 10.0.5 completed initialize (`200`), initialized (`202`), tools/list (`200`), and a real `kicad_get_version` MCP tool call. The tool returned KiCad CLI/IPC 10.0.5 and server 3.33.3. The fixture board hash remained unchanged and the test host KiCad config/share trees were restored to their pre-test hashes.

## Verification so far
- RED regression reproduced `notification.status_code == 400` before the fix
- focused protocol/compatibility/docs suite: 48 passed
- Ruff check + format check: pass
- mypy `src/kicad_mcp/server.py`: pass
- `git diff --check`: pass
- real Codex CLI 0.150.1 + KiCad 10.0.5 physical connect/tool-call smoke: pass
- full repository pytest/coverage is running independently on the same production-code commit; remote CI is also required before merge

Public registry metadata intentionally continues to advertise the GA baseline `2025-11-25`; this change only fixes backward-compatible runtime negotiation already supported by the pinned SDK.

Refs #731
