### PR TITLE
fix(eval): drop rate-limited nvidia-minimax-m3 from the protected release gate

### DIFF
--- a/.github/workflows/live-model-release-gate.yml
+++ b/.github/workflows/live-model-release-gate.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-nano-30b-a3b
-          - nvidia-minimax-m3
+          - opencode-cli-deepseek-v4-flash-free
           - opencode-cli-nemotron-3-ultra-free
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -62,14 +62,6 @@ jobs:
           npm ci --prefix evals/live --ignore-scripts --no-audit --no-fund
           test "$(evals/live/node_modules/opencode-linux-x64/bin/opencode --version)" = "$OPENCODE_CLI_VERSION"
           echo "$GITHUB_WORKSPACE/evals/live/node_modules/opencode-linux-x64/bin" >> "$GITHUB_PATH"
-      - name: Cool down shared NVIDIA trial endpoint
-        if: matrix.configuration == 'nvidia-minimax-m3'
-        env:
-          NVIDIA_SHARED_COOLDOWN_SECONDS: "420"
-        run: |
-          set -euo pipefail
-          echo "Cooling down the shared NVIDIA trial endpoint before ${{ matrix.configuration }}."
-          sleep "$NVIDIA_SHARED_COOLDOWN_SECONDS"
       - name: Run bounded live smoke
         env:
           CONFIGURATION_ID: ${{ matrix.configuration }}
@@ -163,7 +155,7 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-nano-30b-a3b
-          - nvidia-minimax-m3
+          - opencode-cli-deepseek-v4-flash-free
           - opencode-cli-nemotron-3-ultra-free
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -183,14 +175,6 @@ jobs:
           npm ci --prefix evals/live --ignore-scripts --no-audit --no-fund
           test "$(evals/live/node_modules/opencode-linux-x64/bin/opencode --version)" = "$OPENCODE_CLI_VERSION"
           echo "$GITHUB_WORKSPACE/evals/live/node_modules/opencode-linux-x64/bin" >> "$GITHUB_PATH"
-      - name: Cool down shared NVIDIA trial endpoint
-        if: matrix.configuration == 'nvidia-minimax-m3'
-        env:
-          NVIDIA_SHARED_COOLDOWN_SECONDS: "420"
-        run: |
-          set -euo pipefail
-          echo "Cooling down the shared NVIDIA trial endpoint before ${{ matrix.configuration }}."
-          sleep "$NVIDIA_SHARED_COOLDOWN_SECONDS"
       - name: Run bounded live benchmark
         env:
           CONFIGURATION_ID: ${{ matrix.configuration }}

--- a/evals/live/baselines.yaml
+++ b/evals/live/baselines.yaml
@@ -1,5 +1,10 @@
 schema_version: 1
-approved: true
+# Pending re-approval: required_configurations changed (#711 dropped the rate-limited
+# NVIDIA trial MiniMax slot for a free OpenCode Zen model). approved stays false, and
+# the stale approved_at/source_revision/agent_contract_digest/evidence fields below are
+# unused while unapproved (see release_policy.py), until a real Live Model Release Gate
+# run produces a fresh reviewed baseline candidate for opencode-cli-deepseek-v4-flash-free.
+approved: false
 approved_at: '2026-08-14'
 source_revision: 68b6bd6985808323deb951bc0fe85175c2ed2e7f
 agent_contract_digest: d843962dceeea2163fca86d4d3b0f16688e916d58eceac9caabadd9ccbe2a0f3
@@ -9,7 +14,7 @@ evidence:
 minimum_repeats: 3
 required_configurations:
 - nvidia-nemotron-3-nano-30b-a3b
-- nvidia-minimax-m3
+- opencode-cli-deepseek-v4-flash-free
 - opencode-cli-nemotron-3-ultra-free
 configurations:
   nvidia-nemotron-3-nano-30b-a3b:
@@ -23,17 +28,6 @@ configurations:
       instability_rate: 0.0
       p95_latency_ms: 1717.516
       mean_tokens: 3094.0358974358974
-  nvidia-minimax-m3:
-    host: nvidia-nim
-    model: minimaxai/minimax-m3
-    token_metrics_required: true
-    metrics:
-      pass_rate: 1.0
-      mean_recall: 1.0
-      unnecessary_call_rate: 0.0
-      instability_rate: 0.0
-      p95_latency_ms: 71205.406
-      mean_tokens: 3063.851282051282
   opencode-cli-nemotron-3-ultra-free:
     host: opencode-zen-cli
     model: nemotron-3-ultra-free

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -18,19 +18,19 @@ THRESHOLDS = ROOT / "evals/tool_selection/thresholds.yaml"
 
 CONFIG_IDS = (
     "nvidia-nemotron-3-nano-30b-a3b",
-    "nvidia-minimax-m3",
+    "opencode-cli-deepseek-v4-flash-free",
     "opencode-cli-nemotron-3-ultra-free",
 )
 MODELS = (
     "nvidia/nemotron-3-nano-30b-a3b",
-    "minimaxai/minimax-m3",
+    "deepseek-v4-flash-free",
     "nemotron-3-ultra-free",
 )
-HOSTS = ("nvidia-nim", "nvidia-nim", "opencode-zen-cli")
-REQUEST_INTERVALS = (5.0, 5.0, 0.0)
+HOSTS = ("nvidia-nim", "opencode-zen-cli", "opencode-zen-cli")
+REQUEST_INTERVALS = (5.0, 0.0, 0.0)
 REQUIRED_ENVS = (
     ("NVIDIA_API_KEY",),
-    ("NVIDIA_API_KEY",),
+    ("OPENCODE_ZEN_API_KEY",),
     ("OPENCODE_ZEN_API_KEY",),
 )
 COMMANDS = (
@@ -44,13 +44,13 @@ COMMANDS = (
     ),
     (
         "python",
-        "scripts/nvidia_nim_eval_adapter.py",
+        "scripts/opencode_cli_eval_adapter.py",
         "--model",
         MODELS[1],
+        "--opencode-bin",
+        "opencode",
         "--timeout-seconds",
-        "90",
-        "--structured-output",
-        "none",
+        "65",
     ),
     (
         "python",
@@ -339,11 +339,18 @@ def test_committed_live_configurations_are_three_reviewed_blocking_records() -> 
 def test_committed_baseline_records_reviewed_required_configurations() -> None:
     baseline = yaml.safe_load((ROOT / "evals/live/baselines.yaml").read_text(encoding="utf-8"))
 
-    assert baseline["approved"] is True
-    assert baseline["approved_at"] == "2026-08-14"
+    # #711 dropped the rate-limited nvidia-minimax-m3 slot for a free OpenCode Zen
+    # model. The baseline is pending re-approval from a real gate run until a reviewed
+    # candidate exists for opencode-cli-deepseek-v4-flash-free.
+    assert baseline["approved"] is False
     assert baseline["required_configurations"] == list(CONFIG_IDS)
-    assert list(baseline["configurations"]) == list(CONFIG_IDS)
-    for config_id, model, host in zip(CONFIG_IDS, MODELS, HOSTS, strict=True):
+    assert "opencode-cli-deepseek-v4-flash-free" not in baseline["configurations"]
+    for config_id, model, host in zip(
+        ("nvidia-nemotron-3-nano-30b-a3b", "opencode-cli-nemotron-3-ultra-free"),
+        ("nvidia/nemotron-3-nano-30b-a3b", "nemotron-3-ultra-free"),
+        ("nvidia-nim", "opencode-zen-cli"),
+        strict=True,
+    ):
         configuration = baseline["configurations"][config_id]
         assert configuration["host"] == host
         assert configuration["model"] == model
@@ -400,10 +407,7 @@ def test_release_gate_workflow_is_main_only_protected_and_sequential() -> None:
     assert "fail-fast: false" in benchmark_block
     assert "needs: [smoke, benchmark]" in aggregate_block
     assert "if: ${{ always() && needs.smoke.result == 'success' }}" in aggregate_block
-    assert workflow.count("name: Cool down shared NVIDIA trial endpoint") == 2
-    assert workflow.count("if: matrix.configuration == 'nvidia-minimax-m3'") == 2
-    assert workflow.count('NVIDIA_SHARED_COOLDOWN_SECONDS: "420"') == 2
-    assert workflow.count('sleep "$NVIDIA_SHARED_COOLDOWN_SECONDS"') == 2
+    assert "name: Cool down shared NVIDIA trial endpoint" not in workflow
     assert "timeout-minutes: 50" in workflow
     assert "--case-tag live-smoke" in workflow
     assert "--repeats 1" in workflow

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -277,17 +277,12 @@ def test_committed_release_policy_tracks_model_facing_inputs_only() -> None:
     assert "evals/live/baselines.yaml" not in policy.agent_contract_paths
 
     baseline = yaml.safe_load(BASELINE_PATH.read_text(encoding="utf-8"))
-    assert baseline["approved"] is True
-    assert baseline["approved_at"] == "2026-08-14"
-    assert baseline["source_revision"] == "68b6bd6985808323deb951bc0fe85175c2ed2e7f"
-    assert baseline["agent_contract_digest"] == (
-        "d843962dceeea2163fca86d4d3b0f16688e916d58eceac9caabadd9ccbe2a0f3"
-    )
-    assert baseline["evidence"] == {
-        "workflow_run_id": 30788805474,
-        "aggregate_sha256": ("587603f5c191b46f3faf317ecc9947c07df47c52d566b40d33cbddcbbd9a59b4"),
-    }
-    assert set(baseline["configurations"]) == set(baseline["required_configurations"])
+    # #711 dropped the rate-limited nvidia-minimax-m3 slot for a free OpenCode Zen
+    # model. approved stays false (and the stale approved_at/source_revision/
+    # agent_contract_digest/evidence fields go unvalidated per release_policy.py) until
+    # a real Live Model Release Gate run produces a fresh reviewed baseline candidate.
+    assert baseline["approved"] is False
+    assert set(baseline["configurations"]) < set(baseline["required_configurations"])
 
 
 def test_push_assurance_runs_smoke_only_for_agent_contract_changes(tmp_path: Path) -> None:

--- a/tests/unit/test_opencode_cli_deepseek_candidate.py
+++ b/tests/unit/test_opencode_cli_deepseek_candidate.py
@@ -1,4 +1,10 @@
-"""Regression contract for the zero-cost DeepSeek OpenCode CLI candidate."""
+"""Regression contract for the zero-cost DeepSeek OpenCode CLI configuration.
+
+#711 promoted this configuration from a non-blocking candidate to the third
+required release-gate slot, replacing the NVIDIA trial nvidia-minimax-m3 slot
+that was repeatedly exhausted by shared trial-endpoint rate limits. See
+tests/unit/test_live_model_release_gate.py for the blocking-record contract.
+"""
 
 from pathlib import Path
 
@@ -9,7 +15,7 @@ CONFIGURATIONS = ROOT / "evals/live/configurations.yaml"
 RELEASE_GATE = ROOT / ".github/workflows/live-model-release-gate.yml"
 
 
-def test_deepseek_cli_candidate_is_bounded_key_scoped_and_nonblocking() -> None:
+def test_deepseek_cli_configuration_is_bounded_key_scoped_and_blocking() -> None:
     configurations = load_configurations(CONFIGURATIONS)
     configuration = configurations["opencode-cli-deepseek-v4-flash-free"]
 
@@ -31,4 +37,4 @@ def test_deepseek_cli_candidate_is_bounded_key_scoped_and_nonblocking() -> None:
     assert configuration.limits.max_total_cost_micros == 0
 
     release_gate = RELEASE_GATE.read_text(encoding="utf-8")
-    assert "opencode-cli-deepseek-v4-flash-free" not in release_gate
+    assert "opencode-cli-deepseek-v4-flash-free" in release_gate


### PR DESCRIPTION
## Summary

- The shared NVIDIA trial endpoint repeatedly exhausted `nvidia-minimax-m3`'s capacity mid-gate (see #711), blocking release PR #685 on infrastructure availability rather than model quality or safety.
- Replace the blocking slot in `.github/workflows/live-model-release-gate.yml` (smoke + benchmark matrices) with the already-defined free `opencode-cli-deepseek-v4-flash-free` configuration, and drop the now-dead NVIDIA cooldown step from both jobs.
- Update `evals/live/baselines.yaml`: swap `required_configurations`, drop the stale `nvidia-minimax-m3` metrics entry, and mark the baseline `approved: false` rather than fabricating metrics for the new slot — `evaluate_release_gate` fails closed until a real gate run supplies reviewed data.
- A separate `opencode-cli-deepseek-v4-flash-free` regression test previously asserted it must stay **non-blocking**; updated it to assert the opposite now that it's a deliberate, reviewed promotion.

Closes #711 (pending a real protected gate run to re-approve the baseline — see "Release notes" below).

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Tests / fixtures
- [ ] Refactor / maintenance
- [ ] Release / packaging / supply chain

## Validation

- [ ] `corepack pnpm run format:check`
- [ ] `corepack pnpm run lint`
- [ ] `corepack pnpm run typecheck`
- [ ] `corepack pnpm run test:unit`
- [ ] `corepack pnpm run metadata:check`
- [ ] `task verify` or `task ci` when the change crosses tool, package, workflow, or release boundaries

Ran directly instead: `uv run pytest tests/unit/test_live_model_release_gate.py tests/unit/test_live_model_release_policy.py tests/unit/test_live_model_eval_runner.py tests/unit/test_workflow_tooling.py tests/unit/test_opencode_cli_deepseek_candidate.py tests/unit/test_opencode_cli_lightning_candidate.py tests/unit/test_openai_eval_candidate.py tests/unit/test_opencode_zen_eval_adapter.py tests/unit/test_opencode_cli_eval_adapter.py` — all passing. The full `corepack pnpm` pipeline was not run in this session; please run it (or let CI run it) before merge.

## Safety and compatibility

- [x] Public tool contracts, generated docs, metadata, and compatibility matrices are updated when needed. (No public tool contract touched — this is CI/eval-gate configuration only.)
- [ ] Destructive or KiCad-driving behavior is explicit, test-covered, and documented. (N/A — no KiCad-driving behavior in this change.)
- [x] Logs, fixtures, screenshots, and generated artifacts do not contain secrets or private board data.
- [x] Approximate / heuristic behavior is described honestly in docs and verdicts. (Baseline explicitly marked unapproved rather than claiming a false pass.)

## Release notes

None (internal CI/eval gate only). **Action required after merge**: trigger the `Live Model Release Gate` workflow (`workflow_dispatch`, `main`, `repeats: 3`) to produce real evidence for `opencode-cli-deepseek-v4-flash-free`, then promote the generated `baselines.candidate.yaml` through a follow-up reviewed PR to restore `approved: true` and unblock #685.