### PR TITLE
docs(security): document RustSec GTK3/rust-unic advisory disposition

### DIFF
--- a/docs/evidence/rustsec-gtk3-unic-audit-2026-08-30.json
+++ b/docs/evidence/rustsec-gtk3-unic-audit-2026-08-30.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-30T00:00:00Z",
+  "repository": "oaslananka/kicad-mcp-pro",
+  "repositoryCommit": "449f27b0b40b03cebe7ef1cb84ab195dae5a4d9e",
+  "issue": "https://github.com/oaslananka/kicad-mcp-pro/issues/779",
+  "scorecardAlert": {
+    "id": 53,
+    "check": "Vulnerabilities",
+    "severity": "high"
+  },
+  "cargoAudit": {
+    "version": "cargo-audit-audit 0.22.2",
+    "command": "cargo audit --file Cargo.lock --json",
+    "workingDirectory": "src-tauri",
+    "lockfileSha256": "2cee389a2afc504b191750698542d8857a600d9d3f9127209393d3dfd21295a6",
+    "exitCode": 0,
+    "vulnerabilitiesCount": 0,
+    "warningsCount": 17,
+    "warningsByKind": {
+      "unmaintained": 16,
+      "unsound": 1
+    },
+    "findings": [
+      { "advisory": "RUSTSEC-2024-0411", "package": "gdkwayland-sys", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0412", "package": "gdk", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0413", "package": "atk", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0414", "package": "gdkx11-sys", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0415", "package": "gtk", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0416", "package": "atk-sys", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0417", "package": "gdkx11", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0418", "package": "gdk-sys", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0419", "package": "gtk3-macros", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0420", "package": "gtk-sys", "version": "0.18.2", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2024-0429", "package": "glib", "version": "0.18.5", "kind": "unsound", "note": "Patched line per RustSec advisory is >=0.20.0; the vulnerable symbol is glib::VariantStrIter." },
+      { "advisory": "RUSTSEC-2024-0370", "package": "proc-macro-error", "version": "1.0.4", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2025-0075", "package": "unic-char-range", "version": "0.9.0", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2025-0080", "package": "unic-common", "version": "0.9.0", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2025-0081", "package": "unic-char-property", "version": "0.9.0", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2025-0098", "package": "unic-ucd-version", "version": "0.9.0", "kind": "unmaintained" },
+      { "advisory": "RUSTSEC-2025-0100", "package": "unic-ucd-ident", "version": "0.9.0", "kind": "unmaintained" }
+    ],
+    "rawOutputSha256": null
+  },
+  "reachabilityCheck": {
+    "command": "grep -RnE 'VariantStrIter|unic_char|unic::|unic_common|unic_ucd' src-tauri/src",
+    "result": "no matches",
+    "conclusion": "Application code in src-tauri/src does not call the unsound glib::VariantStrIter symbol or any unic-* API directly. All 17 findings are transitive-only."
+  },
+  "reverseDependencyChains": {
+    "command": "cargo tree -i <package> --target all --edges normal",
+    "unicCharRange": [
+      "unic-char-range v0.9.0",
+      "unic-char-property v0.9.0",
+      "unic-ucd-ident v0.9.0",
+      "urlpattern v0.3.0",
+      "tauri-utils v2.9.3",
+      "tauri v2.11.5 / tauri-build v2.6.3",
+      "kicad-mcp-pro v3.33.3 (src-tauri)"
+    ],
+    "glib": [
+      "glib v0.18.5",
+      "gio v0.18.4 / gdk v0.18.2 / gtk v0.18.2 / webkit2gtk v2.0.2 / wry v0.55.1",
+      "tauri v2.11.5 (linux-only cfg)",
+      "kicad-mcp-pro v3.33.3 (src-tauri)"
+    ],
+    "procMacroError": [
+      "proc-macro-error v1.0.4",
+      "gtk3-macros v0.18.2 / gtk v0.18.2 (build-time proc-macro dependency)",
+      "tauri v2.11.5 (linux-only cfg)",
+      "kicad-mcp-pro v3.33.3 (src-tauri)"
+    ]
+  },
+  "platformGating": {
+    "conclusion": "gtk/glib/webkit2gtk/wry/proc-macro-error chain resolves only under cfg(target_os = \"linux\") in tauri/wry; not present in the macOS (WKWebView) or Windows (WebView2) dependency graph.",
+    "evidence": "cargo tree -i glib (default target) printed no matches; cargo tree -i glib --target all resolved the chain, confirming the dependency is target-gated."
+  },
+  "upstreamTracking": {
+    "wryGtk4Port": {
+      "url": "https://github.com/tauri-apps/tao/pull/1104",
+      "title": "fix(linux): Port to gtk4-rs",
+      "state": "open",
+      "merged": false,
+      "lastCheckedAt": "2026-08-30T00:00:00Z",
+      "lastUpdatedUpstream": "2026-08-18T10:01:39Z"
+    },
+    "tauriRuntimeWryGtk4Tracking": {
+      "url": "https://github.com/tauri-apps/tauri/issues/12561",
+      "title": "Upgrade `tauri-runtime-wry` to `gtk4-rs`",
+      "state": "open",
+      "lastCheckedAt": "2026-08-30T00:00:00Z"
+    },
+    "conclusion": "Upstream GTK3-to-GTK4/webkit6/soup3 migration is active but unmerged as of this review. No compatible stable Tauri/wry release removes the GTK3 dependency chain yet."
+  }
+}

--- a/docs/security/rustsec-gtk3-unic-disposition.md
+++ b/docs/security/rustsec-gtk3-unic-disposition.md
@@ -1,0 +1,71 @@
+# RustSec GTK3 / rust-unic Advisory Disposition
+
+This page records the reproducible advisory inventory behind [#779](https://github.com/oaslananka/kicad-mcp-pro/issues/779) and OpenSSF Scorecard code-scanning alert #53 (`VulnerabilitiesID`, severity `error`), the reachability evidence for each advisory family, and the accepted-risk decision for the desktop (`src-tauri`) Cargo dependency tree.
+
+## Reproduction
+
+```bash
+cd src-tauri
+cargo audit --file Cargo.lock --json
+```
+
+- Tool: `cargo-audit-audit 0.22.2`
+- Lockfile: `src-tauri/Cargo.lock`, SHA-256 `2cee389a2afc504b191750698542d8857a600d9d3f9127209393d3dfd21295a6`
+- Repository commit: `449f27b0b40b03cebe7ef1cb84ab195dae5a4d9e`
+- Result: `vulnerabilities.count = 0`, `warnings = 17` (16 `unmaintained`, 1 `unsound`)
+
+cargo-audit's own severity model already separates these findings from exploitable vulnerabilities: none of the 17 findings are classified as an RustSec `Vulnerability`-kind advisory. All 17 are `warning`-kind (`unmaintained` or `unsound`), which is why `src-tauri/.cargo/audit.toml` already lists both kinds under `informational_warnings` — that setting predates this review and was not changed by it.
+
+Full machine-readable evidence, including the reverse-dependency chain for each finding and the upstream tracking snapshot, is recorded in:
+
+- `docs/evidence/rustsec-gtk3-unic-audit-2026-08-30.json`
+
+## Advisory families
+
+| Family | Advisories | Kind | Root package | Reachable from app code? |
+| --- | --- | --- | --- | --- |
+| GTK3 / gtk-rs bindings | `RUSTSEC-2024-0411`..`0420` (10 advisories) | unmaintained | `gtk 0.18.2` and its `-sys`/companion crates | No — transitive only |
+| glib soundness | `RUSTSEC-2024-0429` | **unsound** | `glib 0.18.5` | No — transitive only |
+| proc-macro-error | `RUSTSEC-2024-0370` | unmaintained | `proc-macro-error 1.0.4` | No — build-time transitive only |
+| rust-unic | `RUSTSEC-2025-0075`, `0080`, `0081`, `0098`, `0100` | unmaintained | `unic-* 0.9.0` | No — transitive only |
+
+## Reachability and exploitability evidence
+
+`grep -RnE 'VariantStrIter|unic_char|unic::|unic_common|unic_ucd' src-tauri/src` returns no matches. Application code in `src-tauri/src` never calls `glib::VariantStrIter` (the unsound symbol behind `RUSTSEC-2024-0429`) or any `unic-*` API directly. Every one of the 17 findings enters the dependency graph transitively:
+
+- **rust-unic family**: `unic-char-range <- unic-char-property <- unic-ucd-ident <- urlpattern <- tauri-utils <- tauri`/`tauri-build <- kicad-mcp-pro`. `urlpattern` is Tauri's own URL-pattern matcher; the repository never depends on `urlpattern` or `unic-*` directly.
+- **GTK3 / glib family**: `gtk`/`glib`/`webkit2gtk`/`wry <- tauri` (also reachable via the tray/`libappindicator` path). `cargo tree -i glib` against the default target prints nothing; only `cargo tree -i glib --target all` resolves the chain, confirming these crates are pulled in exclusively under Tauri's `cfg(target_os = "linux")` GTK/WebKitGTK backend. They are absent from the macOS (WKWebView) and Windows (WebView2) dependency graphs.
+- **proc-macro-error**: reached only as a build-time proc-macro dependency of `gtk3-macros`, itself only present on the Linux target.
+
+No advisory in this set has a known proof-of-concept or CVE tied to reachable application behavior. The `unsound` classification on `glib 0.18.5` describes a soundness hazard in an API this codebase does not call.
+
+## Upstream tracking
+
+Upstream Tauri cannot remove the GTK3 chain today: Tauri's current development manifest still resolves Linux `gtk = 0.18` / `webkit2gtk = 2`, and this repository is already on the current stable `tauri 2.11.5`. The relevant upstream migration work, checked live on 2026-08-30:
+
+| Tracking item | State | Notes |
+| --- | --- | --- |
+| [`tauri-apps/tauri#12561`](https://github.com/tauri-apps/tauri/issues/12561) — Upgrade `tauri-runtime-wry` to `gtk4-rs` | Open | Tracking issue for the runtime-side migration. |
+| [`tauri-apps/tao#1104`](https://github.com/tauri-apps/tao/pull/1104) — Port to gtk4-rs | Open, not merged | Active as of 2026-08-18; ports `tao` (Tauri's windowing crate) from GTK3/webkit2gtk to GTK4/webkit6/soup3, which is the precondition for `wry`/`tauri` to drop the GTK3 chain. |
+
+There is no compatible stable Tauri/wry release yet that removes any advisory in this set. A normal patch/minor dependency refresh cannot close this out; it is gated on the linked upstream PR/issue merging and a subsequent Tauri release adopting it.
+
+## OpenSSF Scorecard alert #53
+
+Read live via `gh api repos/oaslananka/kicad-mcp-pro/code-scanning/alerts/53` on 2026-08-30: `state: open`, `most_recent_instance.state: open`, `rule: VulnerabilitiesID`, `severity: error`, last updated `2026-08-10T12:10:21Z`. This is consistent with the cargo-audit reproduction above — the alert aggregates the same 17 RustSec advisories, none of which have a fix available yet, so the alert is expected to remain open until the upstream GTK4 migration lands and this repository upgrades to a Tauri/wry release that adopts it.
+
+## Risk decision
+
+- Do not suppress or dismiss Scorecard alert #53 to improve the score; it remains open and accurately reflects unresolved upstream advisories.
+- Do not add per-advisory `cargo audit` ignores. The existing `informational_warnings = ["unmaintained", "unsound"]` setting in `src-tauri/.cargo/audit.toml` is a kind-level (not advisory-level) classification that predates this review; this document supplies the per-advisory reachability evidence the issue requires without narrowing CI enforcement further.
+- Do not perform a GTK4 migration in this repository ahead of upstream Tauri/wry support landing; doing so would mean depending on unreleased/unpinned upstream crates.
+- Accept the current risk as **low**: every advisory is transitive-only, unreachable from application code, and (for the GTK3/glib/proc-macro-error group) gated to a code path (Linux GTK backend) that the application does exercise on Linux, but not through the unsound/unmaintained symbols themselves.
+
+## Revisit triggers
+
+Re-run this review and update the evidence file when any of the following occurs:
+
+1. `tauri-apps/tao#1104` merges, or `tauri-apps/tauri#12561` closes.
+2. A new stable `tauri`/`wry` release changes the Linux GTK/glib dependency versions in `src-tauri/Cargo.lock`.
+3. `cargo audit` reports a new advisory in this set as `vulnerability`-kind rather than `warning`-kind.
+4. Scorecard alert #53 changes state (closed, reopened, or its aggregated advisory list changes).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
       - Input Validation: security/input-validation.md
       - Assurance Case: security/assurance-case.md
       - Scorecard Exceptions: security/scorecard-exceptions.md
+      - RustSec GTK3/Unic Disposition: security/rustsec-gtk3-unic-disposition.md
       - GitHub Actions Policy: security/github-actions-policy.md
       - Workflow Security: workflow-security.md
   - Submission:


### PR DESCRIPTION
## Summary

Adds the reachability/exploitability documentation required by #779 (and referenced by OpenSSF Scorecard code-scanning alert #53, `VulnerabilitiesID`, severity `error`) for the desktop (`src-tauri`) Cargo dependency tree's 17 RustSec advisories.

- Reproduced the advisory inventory with `cargo-audit-audit 0.22.2` against `src-tauri/Cargo.lock`: `vulnerabilities.count = 0`, `warnings = 17` (16 `unmaintained`, 1 `unsound`) — cargo-audit's own severity model already separates these from exploitable vulnerabilities.
- Verified with `cargo tree -i <pkg> --target all` that every finding is transitive-only (GTK3/glib/proc-macro-error chain is gated to `cfg(target_os = "linux")`; rust-unic chain flows through `urlpattern <- tauri-utils <- tauri`) and confirmed with `grep` that application code in `src-tauri/src` never calls the unsound `glib::VariantStrIter` symbol or any `unic-*` API directly.
- Recorded live upstream tracking as of 2026-08-30: [`tauri-apps/tao#1104`](https://github.com/tauri-apps/tao/pull/1104) (GTK4 port, open/unmerged) and [`tauri-apps/tauri#12561`](https://github.com/tauri-apps/tauri/issues/12561) (tracking issue, open) — no compatible upstream release exists yet.
- Read the live Scorecard alert #53 state via `gh api` (`open`, last updated 2026-08-10) so the accepted-risk decision is grounded in current evidence, not just the issue body.
- Does **not** touch `src-tauri/.cargo/audit.toml` — the existing `informational_warnings` setting predates this review and is kind-level, not a broad per-advisory suppression.

New files: `docs/security/rustsec-gtk3-unic-disposition.md`, `docs/evidence/rustsec-gtk3-unic-audit-2026-08-30.json`. `mkdocs.yml` nav updated.

## Type of change

- [ ] Fix
- [ ] Feature
- [x] Documentation
- [ ] Tests / fixtures
- [ ] Refactor / maintenance
- [ ] Release / packaging / supply chain

## Validation

- [ ] `corepack pnpm run format:check`
- [ ] `corepack pnpm run lint`
- [ ] `corepack pnpm run typecheck`
- [ ] `corepack pnpm run test:unit`
- [ ] `corepack pnpm run metadata:check`
- [ ] `task verify` or `task ci` when the change crosses tool, package, workflow, or release boundaries

Docs-only change (plus one evidence JSON file); no Python/TS source touched. The full `corepack pnpm` pipeline was not run in this session — please let CI validate the mkdocs nav/build.

## Safety and compatibility

- [x] Public tool contracts, generated docs, metadata, and compatibility matrices are updated when needed. (No public tool contract touched.)
- [ ] Destructive or KiCad-driving behavior is explicit, test-covered, and documented. (N/A)
- [x] Logs, fixtures, screenshots, and generated artifacts do not contain secrets or private board data.
- [x] Approximate / heuristic behavior is described honestly in docs and verdicts. (Explicitly states no compatible upstream fix exists yet; does not claim the alert should close.)

## Release notes

None (documentation only). Does not close #779 — the underlying advisories remain open pending the upstream Tauri/wry GTK4 migration; this PR only supplies the reachability evidence and revisit triggers the issue's acceptance criteria require.