### PR TITLE
fix(evals): replace stale DeepSeek free gate model

### DIFF
--- a/.github/workflows/live-model-release-gate.yml
+++ b/.github/workflows/live-model-release-gate.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-5-lightning-30b-a3b
-          - opencode-cli-deepseek-v4-flash-free
+          - opencode-cli-mimo-v2-5-free
           - opencode-cli-nemotron-3-ultra-free
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -155,7 +155,7 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-5-lightning-30b-a3b
-          - opencode-cli-deepseek-v4-flash-free
+          - opencode-cli-mimo-v2-5-free
           - opencode-cli-nemotron-3-ultra-free
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/evals/README.md
+++ b/evals/README.md
@@ -290,13 +290,14 @@ also requires review of the protected run and provider billing. It cannot enter 
 blocking matrix until protected smoke and
 three independent full-corpus runs on one exact revision are complete and clean.
 
-Six OpenCode Zen free-model records are also versioned for manual experimental
-comparison: `deepseek-v4-flash-free`, `mimo-v2.5-free`, `laguna-s-2.1-free`,
-`ling-3.0-flash-free`, `north-mini-code-free`, and `nemotron-3-ultra-free`. They use
+Three reviewed OpenCode Zen free-model records are versioned for protected or manual
+comparison: `mimo-v2.5-free`, `nemotron-3-ultra-free`, and
+`nemotron-3.5-lightning-free`. They use
 the documented OpenAI-compatible Zen chat endpoint
 and require `OPENCODE_ZEN_API_KEY`, which must be synchronized from Doppler into the protected
-`live-model-evals` environment before a billed/live run. Free-model availability can change, so these records
-are intentionally excluded from the blocking release-gate matrix. `big-pickle` is not
+`live-model-evals` environment before a live run. The raw chat records remain nonblocking;
+the reviewed OpenCode CLI MiMo V2.5 and Nemotron 3 Ultra records are blocking release-gate configurations.
+Free-model availability can change, so provider availability is revalidated by protected smoke before full runs. `big-pickle` is not
 allowlisted because its underlying model identity is not stable enough for a versioned
 benchmark baseline.
 

--- a/evals/live/baselines.yaml
+++ b/evals/live/baselines.yaml
@@ -12,6 +12,6 @@ evidence: {}
 minimum_repeats: 3
 required_configurations:
 - nvidia-nemotron-3-5-lightning-30b-a3b
-- opencode-cli-deepseek-v4-flash-free
+- opencode-cli-mimo-v2-5-free
 - opencode-cli-nemotron-3-ultra-free
 configurations: {}

--- a/evals/live/configurations.yaml
+++ b/evals/live/configurations.yaml
@@ -133,11 +133,11 @@ configurations:
       max_total_tokens: 3000000
       max_total_cost_micros: 1000000
 
-  - id: opencode-deepseek-v4-flash-free
+  - id: opencode-mimo-v2-5-free
     host: opencode-zen
-    model: deepseek-v4-flash-free
+    model: mimo-v2.5-free
     adapter: subprocess
-    command: [python, scripts/opencode_zen_eval_adapter.py, --model, deepseek-v4-flash-free, --structured-output, none]
+    command: [python, scripts/opencode_zen_eval_adapter.py, --model, mimo-v2.5-free, --structured-output, none]
     required_env: [OPENCODE_ZEN_API_KEY]
     limits: &opencode_free_limits
       timeout_seconds: 70
@@ -147,43 +147,19 @@ configurations:
       max_total_tokens: 3000000
       max_total_cost_micros: 0
 
-  - id: opencode-mimo-v2-5-free
-    host: opencode-zen
-    model: mimo-v2.5-free
-    adapter: subprocess
-    command: [python, scripts/opencode_zen_eval_adapter.py, --model, mimo-v2.5-free, --structured-output, none]
-    required_env: [OPENCODE_ZEN_API_KEY]
-    limits: *opencode_free_limits
-
-  - id: opencode-laguna-s-2-1-free
-    host: opencode-zen
-    model: laguna-s-2.1-free
-    adapter: subprocess
-    command: [python, scripts/opencode_zen_eval_adapter.py, --model, laguna-s-2.1-free, --structured-output, none]
-    required_env: [OPENCODE_ZEN_API_KEY]
-    limits: *opencode_free_limits
-
-  - id: opencode-ling-3-0-flash-free
-    host: opencode-zen
-    model: ling-3.0-flash-free
-    adapter: subprocess
-    command: [python, scripts/opencode_zen_eval_adapter.py, --model, ling-3.0-flash-free, --structured-output, none]
-    required_env: [OPENCODE_ZEN_API_KEY]
-    limits: *opencode_free_limits
-
-  - id: opencode-north-mini-code-free
-    host: opencode-zen
-    model: north-mini-code-free
-    adapter: subprocess
-    command: [python, scripts/opencode_zen_eval_adapter.py, --model, north-mini-code-free, --structured-output, none]
-    required_env: [OPENCODE_ZEN_API_KEY]
-    limits: *opencode_free_limits
-
   - id: opencode-nemotron-3-ultra-free
     host: opencode-zen
     model: nemotron-3-ultra-free
     adapter: subprocess
     command: [python, scripts/opencode_zen_eval_adapter.py, --model, nemotron-3-ultra-free, --structured-output, none]
+    required_env: [OPENCODE_ZEN_API_KEY]
+    limits: *opencode_free_limits
+
+  - id: opencode-cli-mimo-v2-5-free
+    host: opencode-zen-cli
+    model: mimo-v2.5-free
+    adapter: subprocess
+    command: [python, scripts/opencode_cli_eval_adapter.py, --model, mimo-v2.5-free, --opencode-bin, opencode, --timeout-seconds, "65"]
     required_env: [OPENCODE_ZEN_API_KEY]
     limits: *opencode_free_limits
 
@@ -208,11 +184,3 @@ configurations:
       max_total_tool_calls: 1000
       max_total_tokens: 3000000
       max_total_cost_micros: 0
-
-  - id: opencode-cli-deepseek-v4-flash-free
-    host: opencode-zen-cli
-    model: deepseek-v4-flash-free
-    adapter: subprocess
-    command: [python, scripts/opencode_cli_eval_adapter.py, --model, deepseek-v4-flash-free, --opencode-bin, opencode, --timeout-seconds, "65"]
-    required_env: [OPENCODE_ZEN_API_KEY]
-    limits: *opencode_free_limits

--- a/src/kicad_mcp/evals/opencode_zen_adapter.py
+++ b/src/kicad_mcp/evals/opencode_zen_adapter.py
@@ -15,11 +15,7 @@ from .nvidia_nim_adapter import (
 OPENCODE_ZEN_CHAT_COMPLETIONS_URL = "https://opencode.ai/zen/v1/chat/completions"
 OPENCODE_ZEN_FREE_MODELS = frozenset(
     {
-        "deepseek-v4-flash-free",
         "mimo-v2.5-free",
-        "laguna-s-2.1-free",
-        "ling-3.0-flash-free",
-        "north-mini-code-free",
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
     }

--- a/tests/unit/test_live_model_eval_runner.py
+++ b/tests/unit/test_live_model_eval_runner.py
@@ -1162,13 +1162,16 @@ def test_committed_paid_opencode_minimax_candidate_is_nonblocking_and_bounded() 
 def test_committed_opencode_configurations_are_experimental_and_key_scoped() -> None:
     configurations = load_configurations(COMMITTED_LIVE_CONFIG)
     expected = {
-        "opencode-deepseek-v4-flash-free": "deepseek-v4-flash-free",
         "opencode-mimo-v2-5-free": "mimo-v2.5-free",
-        "opencode-laguna-s-2-1-free": "laguna-s-2.1-free",
-        "opencode-ling-3-0-flash-free": "ling-3.0-flash-free",
-        "opencode-north-mini-code-free": "north-mini-code-free",
         "opencode-nemotron-3-ultra-free": "nemotron-3-ultra-free",
     }
+    stale = {
+        "opencode-deepseek-v4-flash-free",
+        "opencode-laguna-s-2-1-free",
+        "opencode-ling-3-0-flash-free",
+        "opencode-north-mini-code-free",
+    }
+    assert stale.isdisjoint(configurations)
 
     for configuration_id, model in expected.items():
         configuration = configurations[configuration_id]

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -18,12 +18,12 @@ THRESHOLDS = ROOT / "evals/tool_selection/thresholds.yaml"
 
 CONFIG_IDS = (
     "nvidia-nemotron-3-5-lightning-30b-a3b",
-    "opencode-cli-deepseek-v4-flash-free",
+    "opencode-cli-mimo-v2-5-free",
     "opencode-cli-nemotron-3-ultra-free",
 )
 MODELS = (
     "nvidia/nemotron-3.5-lightning-30b-a3b",
-    "deepseek-v4-flash-free",
+    "mimo-v2.5-free",
     "nemotron-3-ultra-free",
 )
 HOSTS = ("nvidia-nim", "opencode-zen-cli", "opencode-zen-cli")

--- a/tests/unit/test_opencode_cli_mimo_candidate.py
+++ b/tests/unit/test_opencode_cli_mimo_candidate.py
@@ -1,32 +1,29 @@
-"""Regression contract for the zero-cost DeepSeek OpenCode CLI configuration.
-
-#711 promoted this configuration from a non-blocking candidate to the third
-required release-gate slot, replacing the NVIDIA trial nvidia-minimax-m3 slot
-that was repeatedly exhausted by shared trial-endpoint rate limits. See
-tests/unit/test_live_model_release_gate.py for the blocking-record contract.
-"""
+"""Regression contract for the current zero-cost MiMo OpenCode CLI release candidate."""
 
 from pathlib import Path
+
+import yaml
 
 from kicad_mcp.evals.live_runner import load_configurations
 
 ROOT = Path(__file__).resolve().parents[2]
 CONFIGURATIONS = ROOT / "evals/live/configurations.yaml"
+BASELINES = ROOT / "evals/live/baselines.yaml"
 RELEASE_GATE = ROOT / ".github/workflows/live-model-release-gate.yml"
 
 
-def test_deepseek_cli_configuration_is_bounded_key_scoped_and_blocking() -> None:
+def test_mimo_cli_configuration_is_current_bounded_key_scoped_and_blocking() -> None:
     configurations = load_configurations(CONFIGURATIONS)
-    configuration = configurations["opencode-cli-deepseek-v4-flash-free"]
+    configuration = configurations["opencode-cli-mimo-v2-5-free"]
 
     assert configuration.host == "opencode-zen-cli"
-    assert configuration.model == "deepseek-v4-flash-free"
+    assert configuration.model == "mimo-v2.5-free"
     assert configuration.required_env == ("OPENCODE_ZEN_API_KEY",)
     assert configuration.command == (
         "python",
         "scripts/opencode_cli_eval_adapter.py",
         "--model",
-        "deepseek-v4-flash-free",
+        "mimo-v2.5-free",
         "--opencode-bin",
         "opencode",
         "--timeout-seconds",
@@ -35,6 +32,13 @@ def test_deepseek_cli_configuration_is_bounded_key_scoped_and_blocking() -> None
     assert configuration.limits.timeout_seconds == 70
     assert configuration.limits.max_retries == 2
     assert configuration.limits.max_total_cost_micros == 0
+    assert "opencode-cli-deepseek-v4-flash-free" not in configurations
 
     release_gate = RELEASE_GATE.read_text(encoding="utf-8")
-    assert "opencode-cli-deepseek-v4-flash-free" in release_gate
+    assert "opencode-cli-mimo-v2-5-free" in release_gate
+    assert "opencode-cli-deepseek-v4-flash-free" not in release_gate
+
+    baselines = yaml.safe_load(BASELINES.read_text(encoding="utf-8"))
+    required = baselines["required_configurations"]
+    assert "opencode-cli-mimo-v2-5-free" in required
+    assert "opencode-cli-deepseek-v4-flash-free" not in required

--- a/tests/unit/test_opencode_zen_eval_adapter.py
+++ b/tests/unit/test_opencode_zen_eval_adapter.py
@@ -23,7 +23,7 @@ def test_opencode_request_uses_fixed_endpoint_and_sanitizes_response() -> None:
         assert request.url == OPENCODE_ZEN_CHAT_COMPLETIONS_URL
         assert request.headers["Authorization"].startswith("Bearer ")
         payload = json.loads(request.content)
-        assert payload["model"] == "deepseek-v4-flash-free"
+        assert payload["model"] == "mimo-v2.5-free"
         return httpx.Response(
             200,
             json={
@@ -44,7 +44,7 @@ def test_opencode_request_uses_fixed_endpoint_and_sanitizes_response() -> None:
         )
 
     result = request_opencode_zen(
-        model="deepseek-v4-flash-free",
+        model="mimo-v2.5-free",
         prompt="Summarize the board.",
         api_key="test-" + "key",
         catalog=({"name": "pcb_get_board_summary", "summary": "Summarize."},),
@@ -61,11 +61,7 @@ def test_opencode_request_uses_fixed_endpoint_and_sanitizes_response() -> None:
 def test_opencode_free_model_allowlist_matches_reviewed_experimental_set() -> None:
     assert OPENCODE_ZEN_FREE_MODELS == frozenset(
         {
-            "deepseek-v4-flash-free",
             "mimo-v2.5-free",
-            "laguna-s-2.1-free",
-            "ling-3.0-flash-free",
-            "north-mini-code-free",
             "nemotron-3-ultra-free",
             "nemotron-3.5-lightning-free",
         }
@@ -124,7 +120,7 @@ def test_opencode_cli_fails_closed_without_key(
         __import__("io").StringIO('{"schema_version":1,"case_id":"x","prompt":"Inspect."}'),
     )
 
-    exit_code = opencode_cli.main(["--model", "deepseek-v4-flash-free"])
+    exit_code = opencode_cli.main(["--model", "mimo-v2.5-free"])
 
     payload = json.loads(capsys.readouterr().out)
     assert exit_code == 1


### PR DESCRIPTION
## Summary
- replace the stale `opencode-cli-deepseek-v4-flash-free` blocking configuration with `opencode-cli-mimo-v2-5-free`
- remove provider identities that are no longer in the reviewed current free-model set
- keep the baseline unapproved and update the required-config contract; no metrics are copied forward
- update eval documentation and regression contracts

## Evidence
Protected release-gate run `33799471862` on `f9f6b0c2536ca11f8767bbe5654951d24cbe4d4d` showed:
- NVIDIA Nemotron 3.5 Lightning smoke: PASS after #831
- DeepSeek V4 Flash Free CLI: 11/11 `provider_unavailable`, 0 completed observations, 0 selection failures

The change therefore addresses provider-availability drift, not a behavioral score failure.

## Verification
- 83 targeted live-eval tests pass
- GitHub Actions policy passes for 30 workflows
- Ruff format/check pass
- strict mypy passes for the two OpenCode adapter modules
- `git diff --check` passes

The protected full gate must be rerun on `main` after merge before any baseline promotion.
