### PR TITLE
feat(evals): add reference-board agent harness

### DIFF
--- a/docs/evidence/reference-boards/esp32-c6-usbc/v1/benchmark.json
+++ b/docs/evidence/reference-boards/esp32-c6-usbc/v1/benchmark.json
@@ -1,0 +1,35 @@
+{
+  "benchmark_id": "esp32-c6-usbc-reference-board",
+  "benchmark_version": "v1",
+  "evidence_sufficiency": {
+    "confidence_level": 0.95,
+    "interval_method": "wilson",
+    "minimum_drc_required_tasks": 2,
+    "minimum_manufacturing_release_tasks": 2,
+    "minimum_recovery_required_mutations": 2,
+    "minimum_valid_attempts": 2,
+    "minimum_valid_attempts_by_task_class": {
+      "reference-board": 2
+    }
+  },
+  "schema_version": "pcb-task-outcome.v1",
+  "tasks": [
+    {
+      "stage_requirements": {
+        "constraints": "required",
+        "drc": "required",
+        "erc": "required",
+        "manufacturing_generation": "required",
+        "manufacturing_reproducibility": "required",
+        "parse_reopen": "required",
+        "pcb": "required",
+        "requirements": "required",
+        "schematic": "required"
+      },
+      "task_class": "reference-board",
+      "task_id": "clean-start-autonomous-build",
+      "validation_exception_reason_codes": {},
+      "version": "v1"
+    }
+  ]
+}

--- a/docs/evidence/reference-boards/esp32-c6-usbc/v1/original-prompt.md
+++ b/docs/evidence/reference-boards/esp32-c6-usbc/v1/original-prompt.md
@@ -1,0 +1,25 @@
+# ESP32-C6 USB-C autonomous reference-board benchmark
+
+You are performing one clean-start reference-board attempt. Use only the KiCad MCP tools exposed in this session. Do not use a terminal, direct filesystem editing, browser tools, or manual KiCad edits. Do not reuse artifacts from any previous attempt. Never claim a stage passed unless you actually executed and consumed the corresponding evidence.
+
+Build a two-layer USB-C ESP32-C6 development/sensor node within 50 mm x 32 mm. Use a verified ESP32-C6-MINI-1 or ESP32-C6-WROOM-1 module variant with integrated antenna/flash. USB-C is a USB 2.0 UFP: CC1 and CC2 each require 5.1 kOhm Rd to ground; protect D+/D- with a low-capacitance ESD array; connect D- to GPIO12 and D+ to GPIO13. Convert VBUS to 3.3 V with a suitable verified regulator and proper decoupling. Provide reset/EN support, one documented boot-mode button, one user LED on a non-strapping GPIO, a 3.3 V I2C header, and VBUS/3V3/GND/D+/D- test points.
+
+The module antenna must sit at a board edge with the manufacturer's keepout respected. Keep USB short, coupled and length-balanced, use a continuous return path, place ESD adjacent to the connector, and use ground pours/stitching without entering the RF keepout. Verify every symbol/footprint choice against available libraries instead of inventing parts.
+
+The final attempt requires ERC, DRC, a genuine MCP-only recovery exercise, BOM, Gerbers generated twice for reproducibility comparison, and final parse/reopen. If backend capability is insufficient for a required operation, fail honestly; do not simulate or fabricate evidence.
+
+## Phase: schematic
+
+Create a new clean project for this board using KiCad MCP. Build and annotate the complete schematic, including power, USB-C CC resistors, USB ESD protection, regulator/decoupling, ESP32-C6 module, reset/boot controls, LED, I2C header, and test points. Verify component contracts and assign real footprints. Run ERC, consume all findings, correct blocking issues through MCP, and finish with a schematic that is ready to transfer to PCB. Do not start PCB layout in this phase.
+
+## Phase: pcb
+
+Open the project created by the schematic phase and synchronize it to PCB. Create the <=50 mm x 32 mm two-layer outline, establish reviewed net classes/rules, place the ESP32-C6 antenna at a board edge with its keepout preserved, place the USB-C/ESD path tightly, and place regulator decoupling for short current loops. Route all nets, create the ground strategy, add stitching where appropriate, and produce clear silkscreen labels.
+
+Run DRC and consume its findings. Once the board is substantially routed, perform exactly one bounded reversible recovery exercise using MCP mutations: introduce a real non-destructive PCB state that requires recovery, verify the issue is observable, then recover the intended design through MCP without direct file/manual repair. Re-run DRC after recovery and resolve all blocking issues. If the live backend cannot safely execute a real recovery-required mutation, stop rather than inventing evidence.
+
+## Phase: manufacturing
+
+Use the completed project from the previous phases. Re-run required validation as available and consume the final results. Generate a BOM and a complete Gerber/drill manufacturing set into a fresh output location. Generate the same manufacturing outputs independently a second time into a separate output location. Compare stable artifact manifests/digests and report whether the two generations are byte-identical or otherwise normalized-equivalent under an explicit stable rule.
+
+Verify the final schematic and board still parse/reopen after manufacturing generation. Do not modify the design to make export evidence look clean. Finish only when the manufacturing set is reproducible and no required validation or parse/reopen stage is unresolved.

--- a/docs/evidence/reference-boards/esp32-c6-usbc/v1/specification.md
+++ b/docs/evidence/reference-boards/esp32-c6-usbc/v1/specification.md
@@ -1,0 +1,42 @@
+# ESP32-C6 USB-C reference board specification
+
+## Purpose
+
+Create a manufacturable two-layer USB-C development/sensor node around an ESP32-C6 module. The board must exercise schematic creation, native USB, RF-aware placement, PCB routing, recovery after a real reversible mutation, DRC, BOM generation, and reproducible Gerber generation.
+
+## Fixed functional scope
+
+- Use an ESP32-C6-MINI-1 or ESP32-C6-WROOM-1 module variant with integrated flash and antenna; verify the exact KiCad symbol/footprint contract before placement.
+- Power the board from a USB-C receptacle used as a USB 2.0 device/UFP.
+- Connect USB D- to ESP32-C6 GPIO12 and USB D+ to GPIO13.
+- Provide independent 5.1 kOhm Rd resistors from CC1 and CC2 to ground.
+- Protect D+ and D- with a low-capacitance USB ESD array located near the connector.
+- Convert VBUS to 3.3 V with a regulator sized for the ESP32-C6 module and exposed peripherals; include input/output decoupling per the regulator contract.
+- Provide module EN/reset support and one boot-mode button using the module's documented strapping requirements.
+- Provide one user LED on a non-strapping GPIO and a four-pin 3.3 V I2C expansion header with GND, 3V3, SDA, and SCL.
+- Add accessible test points for VBUS, 3V3, GND, D+, and D-.
+
+## PCB and layout constraints
+
+- Board outline must fit within 50 mm x 32 mm and use two copper layers.
+- Place the module antenna at a board edge and obey the module manufacturer's antenna keepout and placement guidance; do not route copper or place components in the keepout.
+- Keep the USB D+/D- pair short, coupled, length-balanced, and free of stubs. Use a reviewed USB differential-pair rule with a 90 ohm differential target where the chosen stackup makes that meaningful.
+- Keep the ESD device closer to the connector than to the module.
+- Use a continuous ground return under USB where permitted and a low-impedance ground strategy for regulator/module decoupling.
+- Use a ground pour and stitching vias without violating the antenna keepout.
+- Silkscreen must identify USB-C, RESET, BOOT, the I2C header, polarity/orientation where relevant, and board revision.
+
+## Validation and evidence requirements
+
+- ERC is required and its result must be consumed before PCB sign-off.
+- DRC is required after routing and again after the recovery exercise.
+- Each valid attempt must include at least one genuine reversible PCB mutation that requires recovery. The mutation must be performed and recovered through reviewed MCP operations; manual file repair does not count.
+- If a safe reversible recovery exercise cannot be executed with the available backend, record the attempt honestly rather than fabricating recovery evidence.
+- Manufacturing generation must produce BOM and Gerbers, then regenerate them independently and compare artifact manifests for reproducibility.
+- Final KiCad schematic and board must parse/reopen successfully after all exports.
+
+## Reference basis
+
+- Espressif ESP32-C6 USB Serial/JTAG documentation: GPIO12 is USB D- and GPIO13 is USB D+.
+- Espressif ESP32-C6 module datasheets and PCB-layout recommendations govern antenna keepout, power, reset, and strapping details.
+- Component values or footprints not fixed above must be chosen from available KiCad libraries and verified before use; do not invent unavailable parts.

--- a/docs/evidence/reference-boards/rp2350-usbc/v1/benchmark.json
+++ b/docs/evidence/reference-boards/rp2350-usbc/v1/benchmark.json
@@ -1,0 +1,35 @@
+{
+  "benchmark_id": "rp2350-usbc-reference-board",
+  "benchmark_version": "v1",
+  "evidence_sufficiency": {
+    "confidence_level": 0.95,
+    "interval_method": "wilson",
+    "minimum_drc_required_tasks": 2,
+    "minimum_manufacturing_release_tasks": 2,
+    "minimum_recovery_required_mutations": 2,
+    "minimum_valid_attempts": 2,
+    "minimum_valid_attempts_by_task_class": {
+      "reference-board": 2
+    }
+  },
+  "schema_version": "pcb-task-outcome.v1",
+  "tasks": [
+    {
+      "stage_requirements": {
+        "constraints": "required",
+        "drc": "required",
+        "erc": "required",
+        "manufacturing_generation": "required",
+        "manufacturing_reproducibility": "required",
+        "parse_reopen": "required",
+        "pcb": "required",
+        "requirements": "required",
+        "schematic": "required"
+      },
+      "task_class": "reference-board",
+      "task_id": "clean-start-autonomous-build",
+      "validation_exception_reason_codes": {},
+      "version": "v1"
+    }
+  ]
+}

--- a/docs/evidence/reference-boards/rp2350-usbc/v1/original-prompt.md
+++ b/docs/evidence/reference-boards/rp2350-usbc/v1/original-prompt.md
@@ -1,0 +1,25 @@
+# RP2350A USB-C autonomous reference-board benchmark
+
+You are performing one clean-start reference-board attempt. Use only the KiCad MCP tools exposed in this session. Do not use a terminal, direct filesystem editing, browser tools, or manual KiCad edits. Do not reuse a vendor Minimal KiCad project or any prior attempt as the starting design. Vendor references may guide decisions, but the project itself must be created during this attempt. Never claim a stage passed unless its evidence was executed and consumed.
+
+Build a two-layer RP2350A QFN60 controller within 58 mm x 34 mm. Use at least 8 MB verified external QSPI flash, the vendor-recommended 12 MHz crystal implementation, and the current Raspberry Pi Hardware design with RP2350 guidance for the critical switching-regulator network, supply decoupling, flash/crystal placement, and ground/layout details. Do not invent a substitute power topology.
+
+USB-C is a USB 2.0 UFP with separate 5.1 kOhm Rd resistors on CC1/CC2, low-capacitance ESD protection, and D+/D- connected to dedicated RP2350 USB_DP/USB_DM. Provide BOOTSEL, RUN/reset, a dedicated SWD header, one user LED, a 3.3 V I2C header, and test points for VBUS, 3V3, GND, D+/D-, RUN, and QSPI chip select. Verify every symbol, footprint, flash part, connector, ESD part, and critical passive contract.
+
+Keep USB short/coupled with continuous return, keep switching nodes away from USB/crystal, keep QSPI compact, and follow the vendor minimal-layout strategy for the exposed-pad/power region. Final evidence requires ERC, DRC, a genuine MCP-only recovery exercise, BOM, two independently generated Gerber sets with comparison, and final parse/reopen.
+
+## Phase: schematic
+
+Create a new clean KiCad project. Build and annotate the complete RP2350A schematic: all supply/core-regulator circuitry required by the vendor reference, decoupling, QSPI flash, 12 MHz crystal, USB-C/CC/ESD, BOOTSEL, RUN, SWD, LED, I2C header, and test points. Verify component contracts and assign real footprints. Run ERC, consume the report, and resolve blocking issues through MCP. Do not start PCB layout in this phase.
+
+## Phase: pcb
+
+Synchronize the verified schematic into a <=58 mm x 34 mm two-layer PCB. Use the current Raspberry Pi RP2350A minimal-design guidance as the placement/routing reference for the SMPS, exposed-pad region, decoupling, crystal, QSPI flash, and ground strategy. Place USB-C/ESD for a short direct path, keep USB over continuous ground, keep switching nodes away from USB/crystal, and keep QSPI compact. Route all nets and add useful silkscreen/debug access.
+
+Run DRC and consume all findings. Once the design is substantially routed, perform exactly one bounded reversible MCP mutation that creates a real recoverable PCB problem, verify the changed state/validation evidence, then restore the intended design using MCP only. Re-run DRC and resolve all blocking issues. If a safe recovery-required mutation cannot be executed by the live backend, stop rather than fabricating recovery evidence.
+
+## Phase: manufacturing
+
+Use the completed design without manual repair. Re-run required validation as available and consume the final results. Generate BOM plus complete Gerber/drill outputs to a fresh output location, then independently regenerate the same manufacturing set to a second location. Compare stable artifact manifests/digests; report reproducibility only when the comparison supports it.
+
+Verify that final schematic and PCB parse/reopen successfully after exports. Do not modify source design merely to make evidence appear successful; unresolved validation, reproducibility, or parse/reopen stages mean the attempt is incomplete.

--- a/docs/evidence/reference-boards/rp2350-usbc/v1/specification.md
+++ b/docs/evidence/reference-boards/rp2350-usbc/v1/specification.md
@@ -1,0 +1,42 @@
+# RP2350A USB-C reference board specification
+
+## Purpose
+
+Create a manufacturable two-layer RP2350A controller based on Raspberry Pi's current minimal-hardware guidance while adding USB-C, debug, expansion, recovery testing, and reproducible manufacturing evidence. Critical RP2350 power circuitry and layout must follow the vendor reference rather than being improvised.
+
+## Fixed functional scope
+
+- Use RP2350A in QFN60 and verify the exact symbol/footprint contract.
+- Use external QSPI flash of at least 8 MB with a verified RP2350-compatible connection and footprint.
+- Use the vendor-recommended 12 MHz crystal implementation and verified load/placement guidance.
+- Implement the RP2350 core/power network, including the on-chip switching-regulator external network, by closely following the current Raspberry Pi Hardware design with RP2350 reference and its component/layout guidance.
+- Power from a USB-C receptacle used as a USB 2.0 device/UFP with separate 5.1 kOhm Rd resistors on CC1 and CC2.
+- Connect USB D+/D- to the dedicated RP2350 USB_DP/USB_DM pins, protect the pair with a low-capacitance ESD array, and preserve a short continuous-return route.
+- Provide BOOTSEL and RUN/reset buttons plus a dedicated SWD header exposing SWDIO, SWCLK, GND, and reference supply.
+- Provide one user LED and one four-pin 3.3 V I2C expansion header.
+- Add accessible test points for VBUS, 3V3, GND, USB D+/D-, RUN, and QSPI chip select.
+
+## PCB and layout constraints
+
+- Board outline must fit within 58 mm x 34 mm and use two copper layers with components on the top side unless a verified constraint requires otherwise.
+- Follow Raspberry Pi's RP2350A minimal-design placement and routing guidance closely for the switching-regulator network, crystal, QSPI flash, decoupling, ground strategy, and exposed-pad region.
+- Keep USB D+/D- short, coupled, length-balanced, free of stubs, and above a continuous ground return; place USB ESD adjacent to the receptacle.
+- Keep QSPI traces compact and organized around the MCU/flash placement; do not route noisy switching nodes through sensitive USB/crystal regions.
+- Keep SWD, BOOTSEL, RUN, and expansion access practical at the board edge.
+- Use ground pours/stitching consistent with the vendor reference and do not create return-path slots through high-speed areas.
+- Silkscreen must identify USB-C, BOOTSEL, RUN, SWD, I2C, pin-1/orientation marks, and board revision.
+
+## Validation and evidence requirements
+
+- ERC is required and blocking issues must be consumed/resolved before PCB sign-off.
+- DRC is required after routing and again after the recovery exercise.
+- Each valid attempt must perform one genuine bounded reversible PCB mutation requiring recovery through reviewed MCP operations, with no manual file repair.
+- Manufacturing generation must create BOM and Gerber/drill outputs twice and compare stable artifact manifests for reproducibility.
+- Final schematic and PCB must parse/reopen successfully after manufacturing generation.
+
+## Reference basis
+
+- Raspberry Pi Hardware design with RP2350 is the governing reference for the RP2350A minimal power, crystal, QSPI, decoupling, and layout implementation.
+- Raspberry Pi's current RP2350A Minimal KiCad project may be used as design guidance but must not be copied into the clean-start attempt as a pre-completed design.
+- The RP2350 product documentation defines dedicated USB_DM/USB_DP, XIN/XOUT, RUN, SWDIO/SWCLK, and supply functions.
+- Exact flash, ESD, USB-C connector, passive values, symbols, and footprints must be verified against available library/component contracts before use.

--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/benchmark.json
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/benchmark.json
@@ -1,0 +1,35 @@
+{
+  "benchmark_id": "stm32f072-usbc-reference-board",
+  "benchmark_version": "v1",
+  "evidence_sufficiency": {
+    "confidence_level": 0.95,
+    "interval_method": "wilson",
+    "minimum_drc_required_tasks": 2,
+    "minimum_manufacturing_release_tasks": 2,
+    "minimum_recovery_required_mutations": 2,
+    "minimum_valid_attempts": 2,
+    "minimum_valid_attempts_by_task_class": {
+      "reference-board": 2
+    }
+  },
+  "schema_version": "pcb-task-outcome.v1",
+  "tasks": [
+    {
+      "stage_requirements": {
+        "constraints": "required",
+        "drc": "required",
+        "erc": "required",
+        "manufacturing_generation": "required",
+        "manufacturing_reproducibility": "required",
+        "parse_reopen": "required",
+        "pcb": "required",
+        "requirements": "required",
+        "schematic": "required"
+      },
+      "task_class": "reference-board",
+      "task_id": "clean-start-autonomous-build",
+      "validation_exception_reason_codes": {},
+      "version": "v1"
+    }
+  ]
+}

--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/original-prompt.md
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/original-prompt.md
@@ -1,0 +1,25 @@
+# STM32F072 USB-C / RS-485 autonomous reference-board benchmark
+
+You are performing one clean-start reference-board attempt. Use only the KiCad MCP tools exposed in this session. Do not use a terminal, direct filesystem editing, browser tools, or manual KiCad edits. Do not reuse artifacts from any previous attempt. Never claim a stage passed unless you executed and consumed its evidence.
+
+Build a two-layer STM32F072CBT6 controller within 60 mm x 36 mm. USB-C is a USB 2.0 UFP with separate 5.1 kOhm Rd resistors on CC1/CC2 and low-capacitance ESD protection on D+/D-. Use the MCU USB pins defined by the STM32F072CBT6 contract and verify polarity/alternate functions. Convert VBUS to 3.3 V and decouple all MCU supply domains. Provide NRST, BOOT0 bias, a user button, status LED, and a standard SWD header.
+
+Add a verified 3.3 V RS-485 transceiver on an available UART with explicit DE/RE control, A/B connector, selectable 120 ohm termination, and bus transient protection. Add a 3.3 V I2C expansion header and test points for VBUS, 3V3, GND, USB D+/D-, and RS-485 A/B. Verify every symbol, footprint, UART mapping, and protection/transceiver contract rather than guessing.
+
+Keep USB short/coupled with continuous return, place USB ESD near the receptacle, keep decoupling and regulator loops compact, and keep the RS-485 connector/protection area physically organized away from the sensitive USB/MCU area. Final evidence requires ERC, DRC, a real MCP-only recovery exercise, BOM, two independent Gerber generations with comparison, and final parse/reopen.
+
+## Phase: schematic
+
+Create a clean KiCad project and complete the schematic for power, USB-C, MCU supply/decoupling, reset/boot, SWD, user IO, RS-485 transceiver/DE/RE/termination/protection, I2C header, and test points. Verify component contracts, annotate, and assign real footprints. Run ERC, consume the report, and resolve blocking issues through MCP. Do not begin PCB layout in this phase.
+
+## Phase: pcb
+
+Synchronize the verified schematic to PCB. Create the <=60 mm x 36 mm two-layer outline, reviewed rules/net classes, compact MCU power placement, short USB path, organized SWD access, and a clearly separated RS-485 connector/protection/termination area. Place and route all components, create appropriate ground pours/returns, and add clear silkscreen identifiers.
+
+Run DRC and consume its findings. After the board is substantially routed, perform exactly one bounded reversible MCP mutation that creates a genuine recoverable PCB problem, observe the problem through validation/state evidence, then restore the intended design using MCP only. Re-run DRC after recovery and resolve all blocking issues. If the backend cannot safely perform a real recovery-required mutation, stop rather than fabricate recovery evidence.
+
+## Phase: manufacturing
+
+Use the completed design without manual edits. Re-run required validation as available and consume the final results. Generate BOM plus complete Gerber/drill outputs to one fresh output location, then regenerate the same set independently to a second location. Compare stable artifact manifests/digests and report byte-identical or explicitly normalized-equivalent results only when supported by evidence.
+
+Verify that the final schematic and PCB parse/reopen successfully after manufacturing generation. Do not alter the design merely to make export evidence look clean; unresolved validation, reproducibility, or parse/reopen stages mean the attempt is not complete.

--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/specification.md
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/specification.md
@@ -1,0 +1,40 @@
+# STM32F072 USB-C / RS-485 reference board specification
+
+## Purpose
+
+Create a manufacturable two-layer industrial-style controller around STM32F072CBT6. The design combines USB-C device connectivity, SWD debug, an isolated functional area for RS-485 physical-layer connectivity, user IO, recovery testing, and reproducible manufacturing outputs.
+
+## Fixed functional scope
+
+- Use STM32F072CBT6 in LQFP48 and verify the exact symbol/footprint contract.
+- Power the board from a USB-C receptacle used as a USB 2.0 device/UFP.
+- Use PA11/PA12 for the MCU USB data pair according to the device datasheet/alternate-function contract; verify D-/D+ polarity before wiring.
+- Provide independent 5.1 kOhm Rd resistors from CC1 and CC2 to ground and low-capacitance ESD protection on D+/D- near the connector.
+- Convert VBUS to 3.3 V with a regulator sized for MCU, transceiver, LEDs, and headers; decouple every MCU supply domain according to the datasheet.
+- Provide NRST support, BOOT0 default biasing, one user button, and one status LED.
+- Provide a standard SWD debug header exposing SWDIO, SWCLK, NRST, 3V3, and GND.
+- Add a 3.3 V RS-485 transceiver driven from a verified UART mapping, with DE/RE control, A/B connector, switchable or jumper-selectable 120 ohm termination, and appropriate bus-side transient protection.
+- Add one four-pin 3.3 V I2C expansion header and test points for VBUS, 3V3, GND, USB D+/D-, and RS-485 A/B.
+
+## PCB and layout constraints
+
+- Board outline must fit within 60 mm x 36 mm and use two copper layers.
+- Keep the USB D+/D- pair short, coupled, length-balanced, and free of stubs; use a reviewed USB differential-pair rule and continuous ground return.
+- Keep USB ESD protection adjacent to the receptacle and separate the noisy RS-485 connector/transient area from the USB/MCU clock-sensitive area.
+- Place MCU decoupling close to the corresponding power pins and keep regulator current loops compact.
+- Route the RS-485 A/B pair together from transceiver to connector, keep termination physically close to the bus connector/transceiver path, and make the termination state obvious on silkscreen.
+- Use ground pours and stitching while preserving sensible return-current paths.
+- Silkscreen must identify USB-C, SWD, RESET, BOOT, RS-485 A/B, termination control, I2C, and board revision.
+
+## Validation and evidence requirements
+
+- ERC is required and all blocking findings must be consumed/resolved before PCB sign-off.
+- DRC is required after routing and again after the recovery exercise.
+- Each valid attempt must include at least one genuine reversible PCB mutation requiring recovery through reviewed MCP operations; direct/manual repair is prohibited.
+- Manufacturing generation must produce BOM and Gerbers/drill files twice from the final design and compare stable manifests for reproducibility.
+- Final schematic and PCB must parse/reopen successfully after export.
+
+## Reference basis
+
+- ST's STM32F072CB product/datasheet defines the active LQFP48 device, USB function, supply domains, BOOT/NRST, and alternate-function mappings.
+- Exact UART pins, transceiver part, protection part, termination implementation, symbol, and footprints must be verified against available component/library contracts before use.

--- a/docs/superpowers/plans/2026-09-03-reference-board-agent-runner.md
+++ b/docs/superpowers/plans/2026-09-03-reference-board-agent-runner.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - Do not retain raw Claude prompts, reasoning, tool arguments, tool results, provider text, or credentials in publication evidence.
-- Only `ToolSearch` and `mcp__kicad__*` may be available to the benchmark agent.
+- Only `ToolSearch` and the selected KiCad MCP profile catalog may be visible; actual KiCad execution must stay inside the phase-specific exact allowlist.
 - Preserve `pcb-reference-board.v1`, `pcb-reference-agent-log.v1`, and `pcb-task-outcome.v1` as the canonical schemas.
 - Every real attempt after the harness lands must remain in the denominator, including provider and tool failures.
 - KiCad CLI is pinned by explicit path; PCB live-edit evidence requires verified KiCad 10 IPC.
@@ -55,10 +55,10 @@ Run the same pytest command; expected PASS.
 
 **Interfaces:**
 - Produces: `ReferenceAgentPhase` and `build_claude_command(...)`.
-- Phase contract: schematic=`build/write`, pcb=`build/write`, manufacturing=`release/manufacturing`.
+- Phase contract: schematic=`schematic_authoring/write`, pcb=`pcb_layout/write`, manufacturing=`release/manufacturing`; execution ceilings are 35/38/24 tools.
 - [ ] **Step 1: Write failing command-builder tests**
 
-Assert the command includes `-p`, `--setting-sources project`, explicit empty settings, `--strict-mcp-config`, one generated MCP config, `--tools ToolSearch`, `--allowedTools mcp__kicad__*`, `--output-format stream-json`, and `--verbose`. Assert no Bash/Read/Write/Edit/Web tools are named.
+Assert the command includes `-p`, `--setting-sources project`, explicit empty settings, `--strict-mcp-config`, one generated MCP config, `--tools ToolSearch`, a sorted exact `--allowedTools` phase list, `--output-format stream-json`, and `--verbose`. Assert no Bash/Read/Write/Edit/Web tools are named.
 
 - [ ] **Step 2: Run RED**
 

--- a/docs/superpowers/plans/2026-09-03-reference-board-agent-runner.md
+++ b/docs/superpowers/plans/2026-09-03-reference-board-agent-runner.md
@@ -54,7 +54,7 @@ Run the same pytest command; expected PASS.
 - Create: `scripts/run_reference_board_agent.py`
 
 **Interfaces:**
-- Produces: `ReferenceAgentPhase` and `build_claude_command(...)`.
+- Produces: `ReferenceAgentPhase`, `ReferenceAgentWorkspace`, benchmark-specific KiCad 10 discovery, and the canonical Claude command builder.
 - Phase contract: schematic=`schematic_authoring/write`, pcb=`pcb_layout/write`, manufacturing=`release/manufacturing`; execution ceilings are 35/38/24 tools.
 - [ ] **Step 1: Write failing command-builder tests**
 
@@ -66,7 +66,7 @@ Run the focused runner tests; expected missing phase/command builder failures.
 
 - [ ] **Step 3: Implement command/config builder and CLI**
 
-Generate an ephemeral MCP JSON that runs the reviewed checkout with pinned `uv`, explicit project directory, phase profile/mode, and explicit `KICAD_MCP_KICAD_CLI`. Execute Claude with `shell=False`, bounded timeout, captured UTF-8 stdout/stderr, and a caller-provided prompt file. Store raw stream only in a caller-provided scratch path outside the publication bundle.
+Generate an ephemeral MCP JSON that runs the reviewed checkout with the current Python interpreter (`python -m kicad_mcp.server`), a deterministic private project directory, phase profile/mode, and a fail-closed discovered KiCad 10 CLI. The CLI accepts only a reviewed board id, bounded attempt number, and phase; prompt/publication/scratch paths, Claude executable/model, and session timeout are canonical rather than caller-provided. Execute Claude with `shell=False`, captured UTF-8 stdout/stderr, and store raw stream only in the deterministic `.dev-tools/reference-agent-runs/...` scratch tree outside the publication bundle.
 
 - [ ] **Step 4: Run GREEN**
 

--- a/docs/superpowers/plans/2026-09-03-reference-board-agent-runner.md
+++ b/docs/superpowers/plans/2026-09-03-reference-board-agent-runner.md
@@ -1,0 +1,97 @@
+# Reference-board Agent Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reproducible, MCP-only Claude execution harness and three reviewed reference-board benchmark inputs for Issue #730 without publishing unverified attempt results.
+
+**Architecture:** A pure eval module parses Claude stream-json into existing sanitized `ReferenceAgentLogEvent` records and validates benchmark session metadata. A thin CLI builds isolated Claude/KiCad MCP phase configs and runs the agent. The existing reference-corpus validator and `AttemptRecord` schema remain unchanged.
+
+**Tech Stack:** Python 3.13, Pydantic, subprocess, Claude Code CLI, KiCad MCP stdio, pytest, Ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-reference-board-agent-runner-design.md`
+
+## Global Constraints
+
+- Do not retain raw Claude prompts, reasoning, tool arguments, tool results, provider text, or credentials in publication evidence.
+- Only `ToolSearch` and `mcp__kicad__*` may be available to the benchmark agent.
+- Preserve `pcb-reference-board.v1`, `pcb-reference-agent-log.v1`, and `pcb-task-outcome.v1` as the canonical schemas.
+- Every real attempt after the harness lands must remain in the denominator, including provider and tool failures.
+- KiCad CLI is pinned by explicit path; PCB live-edit evidence requires verified KiCad 10 IPC.
+
+---
+
+### Task 1: Sanitize Claude stream evidence
+
+**Files:**
+- Create: `src/kicad_mcp/evals/reference_agent_runner.py`
+- Create: `tests/unit/test_reference_agent_runner.py`
+
+**Interfaces:**
+- Produces: `ReferenceAgentRunSummary` and `parse_claude_stream(lines, attempt_id)`.
+- Consumes: `ReferenceAgentLogEvent` from `reference_corpus.py`.
+- [ ] **Step 1: Write the failing parser tests**
+
+Create fixture stream records with one KiCad MCP tool call/result, one `ToolSearch`, and a successful result. Assert that only the KiCad call/result become publication events, sequence numbers are contiguous, timestamps are preserved, primary/auxiliary model identifiers are scalar metadata, and raw prompt/input/output strings are absent from rendered evidence.
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run --all-extras --frozen pytest -q tests/unit/test_reference_agent_runner.py`
+Expected: import/function failure because the runner module does not exist.
+
+- [ ] **Step 3: Implement minimal parser**
+
+Implement strict JSON-line parsing, `mcp__kicad__` name normalization, tool-use-id correlation, fail-closed malformed stream handling, and a frozen summary dataclass. Ignore `ToolSearch` as internal discovery; reject any other non-KiCad executed tool. Require exactly one connected `kicad` MCP server and preserve sanitized workflow start/terminal events so parseable failed sessions remain publishable attempt evidence.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the same pytest command; expected PASS.
+
+### Task 2: Build isolated Claude/KiCad phase commands
+
+**Files:**
+- Modify: `src/kicad_mcp/evals/reference_agent_runner.py`
+- Test: `tests/unit/test_reference_agent_runner.py`
+- Create: `scripts/run_reference_board_agent.py`
+
+**Interfaces:**
+- Produces: `ReferenceAgentPhase` and `build_claude_command(...)`.
+- Phase contract: schematic=`build/write`, pcb=`build/write`, manufacturing=`release/manufacturing`.
+- [ ] **Step 1: Write failing command-builder tests**
+
+Assert the command includes `-p`, `--setting-sources project`, explicit empty settings, `--strict-mcp-config`, one generated MCP config, `--tools ToolSearch`, `--allowedTools mcp__kicad__*`, `--output-format stream-json`, and `--verbose`. Assert no Bash/Read/Write/Edit/Web tools are named.
+
+- [ ] **Step 2: Run RED**
+
+Run the focused runner tests; expected missing phase/command builder failures.
+
+- [ ] **Step 3: Implement command/config builder and CLI**
+
+Generate an ephemeral MCP JSON that runs the reviewed checkout with pinned `uv`, explicit project directory, phase profile/mode, and explicit `KICAD_MCP_KICAD_CLI`. Execute Claude with `shell=False`, bounded timeout, captured UTF-8 stdout/stderr, and a caller-provided prompt file. Store raw stream only in a caller-provided scratch path outside the publication bundle.
+
+- [ ] **Step 4: Run GREEN**
+
+Run runner tests plus Ruff/mypy on the new module/script.
+
+### Task 3: Publish three reviewed benchmark inputs
+
+**Files:**
+- Create: `docs/evidence/reference-boards/esp32-c6-usbc/v1/{specification.md,original-prompt.md,benchmark.json}`
+- Create: `docs/evidence/reference-boards/stm32f072-usbc/v1/{specification.md,original-prompt.md,benchmark.json}`
+- Create: `docs/evidence/reference-boards/rp2350-usbc/v1/{specification.md,original-prompt.md,benchmark.json}`
+- Test: `tests/unit/test_reference_agent_runner.py`
+
+Each benchmark requires all canonical task stages and at least two valid attempts, two DRC-required tasks, and two manufacturing-release tasks. Inputs must not contain pre-completed KiCad designs.
+- [ ] **Step 1: Add input-contract tests**
+
+Load each `benchmark.json` with `parse_benchmark_contract`; assert the matching spec/prompt exist, no attempt directory or final KiCad artifact is pre-populated, and all nine canonical stages are `required`.
+
+- [ ] **Step 2: Copy reviewed inputs and run RED/GREEN as needed**
+
+Use the already reviewed scratch drafts as source text, then validate each benchmark through the existing schema. Do not create `attempt-manifest.json` until a real attempt exists.
+
+### Task 4: Verification and integration
+
+- [ ] Run `ruff format --check`, `ruff check`, strict mypy, runner/reference-corpus unit tests, architecture checks, and `git diff --check`.
+- [ ] Review the diff for raw provider data, absolute private paths, credentials, or hidden attempts.
+- [ ] Commit harness + inputs without attempt results and open a PR against `main` referencing #730.
+- [ ] After that PR lands, create a fresh evidence branch from its merge SHA and begin real attempts; every attempt after that point must be recorded whether successful or failed.

--- a/docs/superpowers/specs/2026-09-03-reference-board-agent-runner-design.md
+++ b/docs/superpowers/specs/2026-09-03-reference-board-agent-runner-design.md
@@ -1,0 +1,17 @@
+# Reference-board agent runner design
+
+## Purpose
+
+Issue #730 needs serious PCB attempts produced from written specifications with complete, sanitized attempt history. The existing `pcb-reference-board.v1` bundle validator and `pcb-task-outcome.v1` KPI schema remain authoritative; this work adds only an execution and evidence-capture harness.
+
+## Execution boundary
+
+The runner invokes Claude Code non-interactively with one explicit KiCad MCP configuration. It uses `--strict-mcp-config`, excludes user settings with `--setting-sources project`, supplies an empty explicit settings file, and exposes only `ToolSearch` plus `mcp__kicad__*` tools. Built-in shell, file-editing, web, and unrelated MCP tools are unavailable to the benchmark agent.
+
+The reviewed phase profiles are `build` + `write` for schematic and PCB phases, and `release` + `manufacturing` for manufacturing. Each phase points KiCad MCP at an attempt workspace and an explicit KiCad 10 CLI path. PCB-live operations require the reviewed GUI-connected IPC precondition rather than silently falling back to an unverified target.
+
+## Evidence boundary
+
+Claude stream-json is temporary runner input, never publication evidence. The sanitizer retains only timestamps, stable MCP tool names, start/completion/failure status, primary/auxiliary model identifiers, permission-denial count, session outcome, and bounded scalar metadata. Prompts, tool arguments, tool results, reasoning, provider text, environment values, credentials, absolute unrelated paths, and raw model responses are never copied into `agent-log.jsonl`.
+
+Every run produces a deterministic `ReferenceAgentRunSummary` used to construct the existing `AttemptRecord`. Failed provider/tool runs remain attempts; the runner must not delete or hide them.

--- a/docs/superpowers/specs/2026-09-03-reference-board-agent-runner-design.md
+++ b/docs/superpowers/specs/2026-09-03-reference-board-agent-runner-design.md
@@ -6,9 +6,9 @@ Issue #730 needs serious PCB attempts produced from written specifications with 
 
 ## Execution boundary
 
-The runner invokes Claude Code non-interactively with one explicit KiCad MCP configuration. It uses `--strict-mcp-config`, excludes user settings with `--setting-sources project`, supplies an empty explicit settings file, and exposes only `ToolSearch` plus `mcp__kicad__*` tools. Built-in shell, file-editing, web, and unrelated MCP tools are unavailable to the benchmark agent.
+The runner invokes Claude Code non-interactively with one explicit KiCad MCP configuration. It uses `--strict-mcp-config`, excludes user settings with `--setting-sources project`, supplies an empty explicit settings file, and exposes only `ToolSearch` plus the selected KiCad profile catalog. Built-in shell, file-editing, web, and unrelated MCP tools are unavailable; actual KiCad execution is additionally restricted to a phase-specific exact allowlist.
 
-The reviewed phase profiles are `build` + `write` for schematic and PCB phases, and `release` + `manufacturing` for manufacturing. Each phase points KiCad MCP at an attempt workspace and an explicit KiCad 10 CLI path. PCB-live operations require the reviewed GUI-connected IPC precondition rather than silently falling back to an unverified target.
+The reviewed phase profiles are `schematic_authoring` + `write`, `pcb_layout` + `write`, and `release` + `manufacturing`. Exact execution ceilings are 35, 38, and 24 KiCad tools respectively; experimental routing helpers are excluded. Each phase points KiCad MCP at an attempt workspace and an explicit KiCad 10 CLI path. PCB-live operations require the reviewed GUI-connected IPC precondition rather than silently falling back to an unverified target.
 
 ## Evidence boundary
 

--- a/scripts/run_reference_board_agent.py
+++ b/scripts/run_reference_board_agent.py
@@ -1,92 +1,72 @@
-from __future__ import annotations
-
 import argparse
 import json
 from pathlib import Path
 
 from kicad_mcp.evals.reference_agent_runner import (
     ReferenceAgentPhase,
-    build_claude_command,
+    ReferenceAgentWorkspace,
     build_mcp_config,
     catalog_mcp_tools,
+    discover_reference_kicad_cli,
     load_phase_prompt,
     reviewed_mcp_tools,
     run_claude_session,
     write_agent_log,
 )
 
+ROOT = Path(__file__).resolve().parents[1]
+_SESSION_TIMEOUT_SECONDS = 2700.0
+
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run one isolated reference-board agent phase.")
-    parser.add_argument("--attempt-id", required=True)
+    parser.add_argument(
+        "--board-id",
+        choices=("esp32-c6-usbc", "stm32f072-usbc", "rp2350-usbc"),
+        required=True,
+    )
+    parser.add_argument("--attempt-number", type=int, choices=range(1, 1000), required=True)
     parser.add_argument("--phase", choices=("schematic", "pcb", "manufacturing"), required=True)
-    parser.add_argument("--prompt-file", type=Path, required=True)
-    parser.add_argument("--project-dir", type=Path, required=True)
-    parser.add_argument("--scratch-dir", type=Path, required=True)
-    parser.add_argument("--agent-log", type=Path, required=True)
-    parser.add_argument("--checkout-dir", type=Path, required=True)
-    parser.add_argument("--uv", type=Path, required=True)
-    parser.add_argument("--kicad-cli", type=Path, required=True)
-    parser.add_argument("--claude", default="claude")
-    parser.add_argument("--model", default="claude-sonnet-5")
-    parser.add_argument("--timeout-seconds", type=float, default=2700.0)
     parser.add_argument("--append-agent-log", action="store_true")
     return parser
 
 
-def _require_scratch_outside_publication(checkout_dir: Path, scratch_dir: Path) -> None:
-    publication_root = (checkout_dir / "docs/evidence/reference-boards").resolve()
-    scratch = scratch_dir.resolve()
-    if scratch == publication_root or scratch.is_relative_to(publication_root):
-        raise SystemExit("scratch-dir must be outside docs/evidence/reference-boards")
-
-
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
-    _require_scratch_outside_publication(args.checkout_dir, args.scratch_dir)
-    if args.agent_log.exists() and not args.append_agent_log:
+    workspace = ReferenceAgentWorkspace.for_reviewed_attempt(
+        checkout_dir=ROOT, board_id=args.board_id, attempt_number=args.attempt_number
+    )
+    if workspace.agent_log_path.exists() and not args.append_agent_log:
         raise SystemExit("agent log already exists; use --append-agent-log to extend it")
 
     phase = ReferenceAgentPhase.for_name(args.phase)
-    prompt = load_phase_prompt(args.prompt_file, phase)
-    args.scratch_dir.mkdir(parents=True, exist_ok=True)
-    settings_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-settings.json"
-    mcp_config_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-mcp.json"
+    prompt = load_phase_prompt(workspace, phase)
+    workspace.scratch_dir.mkdir(parents=True, exist_ok=True)
+    workspace.project_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = workspace.phase_settings_path(phase)
+    mcp_config_path = workspace.phase_mcp_config_path(phase)
     settings_path.write_text("{}\n", encoding="utf-8")
     mcp_config = build_mcp_config(
         phase=phase,
-        uv_executable=args.uv,
-        checkout_dir=args.checkout_dir,
-        project_dir=args.project_dir,
-        kicad_cli=args.kicad_cli,
+        workspace=workspace,
+        kicad_cli=discover_reference_kicad_cli(),
     )
     mcp_config_path.write_text(json.dumps(mcp_config, indent=2) + "\n", encoding="utf-8")
     execution_tools = reviewed_mcp_tools(phase)
     catalog_tools = catalog_mcp_tools(phase)
-    command = build_claude_command(
-        claude_executable=args.claude,
-        model=args.model,
-        settings_path=settings_path,
-        mcp_config_path=mcp_config_path,
-        allowed_mcp_tools=execution_tools,
-    )
-    raw_stream_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-claude-stream.jsonl"
     summary = run_claude_session(
-        command=command,
+        workspace=workspace,
+        phase=phase,
         prompt=prompt,
-        raw_stream_path=raw_stream_path,
-        attempt_id=args.attempt_id,
-        cwd=args.checkout_dir,
-        timeout_seconds=args.timeout_seconds,
-        model=args.model,
+        timeout_seconds=_SESSION_TIMEOUT_SECONDS,
         catalog_mcp_tools=catalog_tools,
         allowed_mcp_tools=execution_tools,
     )
-    write_agent_log(args.agent_log, summary, append=args.append_agent_log)
+    write_agent_log(workspace, summary, append=args.append_agent_log)
     print(
         json.dumps(
             {
-                "attempt_id": args.attempt_id,
+                "attempt_id": workspace.attempt_id,
                 "phase": args.phase,
                 "successful": summary.successful,
                 "primary_model": summary.primary_model,

--- a/scripts/run_reference_board_agent.py
+++ b/scripts/run_reference_board_agent.py
@@ -74,6 +74,7 @@ def main(argv: list[str] | None = None) -> int:
         attempt_id=args.attempt_id,
         cwd=args.checkout_dir,
         timeout_seconds=args.timeout_seconds,
+        model=args.model,
         allowed_mcp_tools=reviewed_mcp_tools(phase),
     )
     write_agent_log(args.agent_log, summary, append=args.append_agent_log)

--- a/scripts/run_reference_board_agent.py
+++ b/scripts/run_reference_board_agent.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from kicad_mcp.evals.reference_agent_runner import (
+    ReferenceAgentPhase,
+    build_claude_command,
+    build_mcp_config,
+    load_phase_prompt,
+    reviewed_mcp_tools,
+    run_claude_session,
+    write_agent_log,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run one isolated reference-board agent phase.")
+    parser.add_argument("--attempt-id", required=True)
+    parser.add_argument("--phase", choices=("schematic", "pcb", "manufacturing"), required=True)
+    parser.add_argument("--prompt-file", type=Path, required=True)
+    parser.add_argument("--project-dir", type=Path, required=True)
+    parser.add_argument("--scratch-dir", type=Path, required=True)
+    parser.add_argument("--agent-log", type=Path, required=True)
+    parser.add_argument("--checkout-dir", type=Path, required=True)
+    parser.add_argument("--uv", type=Path, required=True)
+    parser.add_argument("--kicad-cli", type=Path, required=True)
+    parser.add_argument("--claude", default="claude")
+    parser.add_argument("--model", default="claude-sonnet-5")
+    parser.add_argument("--timeout-seconds", type=float, default=2700.0)
+    parser.add_argument("--append-agent-log", action="store_true")
+    return parser
+
+
+def _require_scratch_outside_publication(checkout_dir: Path, scratch_dir: Path) -> None:
+    publication_root = (checkout_dir / "docs/evidence/reference-boards").resolve()
+    scratch = scratch_dir.resolve()
+    if scratch == publication_root or scratch.is_relative_to(publication_root):
+        raise SystemExit("scratch-dir must be outside docs/evidence/reference-boards")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    _require_scratch_outside_publication(args.checkout_dir, args.scratch_dir)
+    if args.agent_log.exists() and not args.append_agent_log:
+        raise SystemExit("agent log already exists; use --append-agent-log to extend it")
+
+    phase = ReferenceAgentPhase.for_name(args.phase)
+    prompt = load_phase_prompt(args.prompt_file, phase)
+    args.scratch_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-settings.json"
+    mcp_config_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-mcp.json"
+    settings_path.write_text("{}\n", encoding="utf-8")
+    mcp_config = build_mcp_config(
+        phase=phase,
+        uv_executable=args.uv,
+        checkout_dir=args.checkout_dir,
+        project_dir=args.project_dir,
+        kicad_cli=args.kicad_cli,
+    )
+    mcp_config_path.write_text(json.dumps(mcp_config, indent=2) + "\n", encoding="utf-8")
+    command = build_claude_command(
+        claude_executable=args.claude,
+        model=args.model,
+        settings_path=settings_path,
+        mcp_config_path=mcp_config_path,
+    )
+    raw_stream_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-claude-stream.jsonl"
+    summary = run_claude_session(
+        command=command,
+        prompt=prompt,
+        raw_stream_path=raw_stream_path,
+        attempt_id=args.attempt_id,
+        cwd=args.checkout_dir,
+        timeout_seconds=args.timeout_seconds,
+        allowed_mcp_tools=reviewed_mcp_tools(phase),
+    )
+    write_agent_log(args.agent_log, summary, append=args.append_agent_log)
+    print(
+        json.dumps(
+            {
+                "attempt_id": args.attempt_id,
+                "phase": args.phase,
+                "successful": summary.successful,
+                "primary_model": summary.primary_model,
+                "auxiliary_models": list(summary.auxiliary_models),
+                "provider": summary.provider,
+                "permission_denials": summary.permission_denials,
+                "terminal_reason": summary.terminal_reason,
+                "event_count": len(summary.events),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if summary.successful else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_reference_board_agent.py
+++ b/scripts/run_reference_board_agent.py
@@ -8,6 +8,7 @@ from kicad_mcp.evals.reference_agent_runner import (
     ReferenceAgentPhase,
     build_claude_command,
     build_mcp_config,
+    catalog_mcp_tools,
     load_phase_prompt,
     reviewed_mcp_tools,
     run_claude_session,
@@ -60,11 +61,14 @@ def main(argv: list[str] | None = None) -> int:
         kicad_cli=args.kicad_cli,
     )
     mcp_config_path.write_text(json.dumps(mcp_config, indent=2) + "\n", encoding="utf-8")
+    execution_tools = reviewed_mcp_tools(phase)
+    catalog_tools = catalog_mcp_tools(phase)
     command = build_claude_command(
         claude_executable=args.claude,
         model=args.model,
         settings_path=settings_path,
         mcp_config_path=mcp_config_path,
+        allowed_mcp_tools=execution_tools,
     )
     raw_stream_path = args.scratch_dir / f"{args.attempt_id}-{args.phase}-claude-stream.jsonl"
     summary = run_claude_session(
@@ -75,7 +79,8 @@ def main(argv: list[str] | None = None) -> int:
         cwd=args.checkout_dir,
         timeout_seconds=args.timeout_seconds,
         model=args.model,
-        allowed_mcp_tools=reviewed_mcp_tools(phase),
+        catalog_mcp_tools=catalog_tools,
+        allowed_mcp_tools=execution_tools,
     )
     write_agent_log(args.agent_log, summary, append=args.append_agent_log)
     print(

--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -350,6 +350,45 @@ def write_agent_log(path: Path, summary: ReferenceAgentRunSummary, *, append: bo
     path.write_text(payload, encoding="utf-8")
 
 
+def _failed_session_summary(
+    *,
+    attempt_id: str,
+    model: str,
+    started_at: datetime,
+    ended_at: datetime,
+    terminal_reason: str,
+    details: Mapping[str, bool | int | float | str] | None = None,
+) -> ReferenceAgentRunSummary:
+    events = (
+        ReferenceAgentLogEvent(
+            attempt_id=attempt_id,
+            sequence=1,
+            timestamp=started_at,
+            event_type="workflow",
+            name="claude_session",
+            status="started",
+        ),
+        ReferenceAgentLogEvent(
+            attempt_id=attempt_id,
+            sequence=2,
+            timestamp=ended_at,
+            event_type="workflow",
+            name="claude_session",
+            status="failed",
+            details=dict(details or {}),
+        ),
+    )
+    return ReferenceAgentRunSummary(
+        events=events,
+        primary_model=model,
+        auxiliary_models=(),
+        provider="unknown",
+        permission_denials=0,
+        terminal_reason=terminal_reason,
+        successful=False,
+    )
+
+
 def run_claude_session(
     *,
     command: tuple[str, ...],
@@ -358,30 +397,73 @@ def run_claude_session(
     attempt_id: str,
     cwd: Path,
     timeout_seconds: float,
+    model: str,
     allowed_mcp_tools: frozenset[str] | None = None,
 ) -> ReferenceAgentRunSummary:
     """Run one isolated Claude session and retain raw stream only in scratch storage."""
     started_at = datetime.now(UTC)
-    completed = subprocess.run(
-        command,
-        input=prompt,
-        cwd=cwd,
-        timeout=timeout_seconds,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        shell=False,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            input=prompt,
+            cwd=cwd,
+            timeout=timeout_seconds,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            shell=False,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        ended_at = datetime.now(UTC)
+        output = (
+            exc.stdout.decode("utf-8", errors="replace")
+            if isinstance(exc.stdout, bytes)
+            else (exc.stdout or "")
+        )
+        raw_stream_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_stream_path.write_text(output, encoding="utf-8")
+        return _failed_session_summary(
+            attempt_id=attempt_id,
+            model=model,
+            started_at=started_at,
+            ended_at=ended_at,
+            terminal_reason="timeout",
+            details={"timeout_seconds": timeout_seconds},
+        )
+    except OSError:
+        ended_at = datetime.now(UTC)
+        raw_stream_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_stream_path.write_text("", encoding="utf-8")
+        return _failed_session_summary(
+            attempt_id=attempt_id,
+            model=model,
+            started_at=started_at,
+            ended_at=ended_at,
+            terminal_reason="process_launch_failed",
+        )
+
     ended_at = datetime.now(UTC)
+    stdout = completed.stdout if isinstance(completed.stdout, str) else ""
     raw_stream_path.parent.mkdir(parents=True, exist_ok=True)
-    raw_stream_path.write_text(completed.stdout, encoding="utf-8")
-    parsed = parse_claude_stream(
-        completed.stdout.splitlines(),
-        attempt_id=attempt_id,
-        allowed_mcp_tools=allowed_mcp_tools,
-    )
+    raw_stream_path.write_text(stdout, encoding="utf-8")
+    try:
+        parsed = parse_claude_stream(
+            stdout.splitlines(),
+            attempt_id=attempt_id,
+            allowed_mcp_tools=allowed_mcp_tools,
+        )
+    except ReferenceAgentRunnerError:
+        return _failed_session_summary(
+            attempt_id=attempt_id,
+            model=model,
+            started_at=started_at,
+            ended_at=ended_at,
+            terminal_reason="stream_contract_violation",
+            details={"exit_code": completed.returncode},
+        )
+
     successful = parsed.successful and completed.returncode == 0
     events = [
         ReferenceAgentLogEvent(

--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -27,14 +27,14 @@ class ReferenceAgentPhase:
     """Reviewed KiCad MCP profile/mode pair for one benchmark phase."""
 
     name: Literal["schematic", "pcb", "manufacturing"]
-    profile: Literal["build", "release"]
+    profile: Literal["schematic_authoring", "pcb_layout", "release"]
     mode: Literal["write", "manufacturing"]
 
     @classmethod
     def for_name(cls, name: str) -> ReferenceAgentPhase:
         phases = {
-            "schematic": cls("schematic", "build", "write"),
-            "pcb": cls("pcb", "build", "write"),
+            "schematic": cls("schematic", "schematic_authoring", "write"),
+            "pcb": cls("pcb", "pcb_layout", "write"),
             "manufacturing": cls("manufacturing", "release", "manufacturing"),
         }
         try:
@@ -43,13 +43,109 @@ class ReferenceAgentPhase:
             raise ReferenceAgentRunnerError(f"unsupported reference-agent phase: {name}") from exc
 
 
-def reviewed_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
-    """Return the exact reviewed MCP tool ceiling for one benchmark phase."""
+_SCHEMATIC_EXECUTION_TOOLS = (
+    "kicad_create_new_project",
+    "kicad_set_project",
+    "kicad_get_project_info",
+    "kicad_get_server_info",
+    "kicad_get_version",
+    "project_set_design_intent",
+    "project_get_design_spec",
+    "lib_search_symbols",
+    "lib_get_symbol_info",
+    "lib_search_footprints",
+    "lib_get_footprint_info",
+    "lib_verify_component_contract",
+    "lib_assign_footprint",
+    "sch_add_symbol",
+    "sch_add_wire",
+    "sch_route_wire_between_pins",
+    "sch_add_label",
+    "sch_add_global_label",
+    "sch_add_power_symbol",
+    "sch_add_no_connect",
+    "sch_update_properties",
+    "sch_annotate",
+    "sch_auto_place_functional",
+    "sch_get_symbols",
+    "sch_get_connectivity_graph",
+    "sch_get_net_names",
+    "sch_check_power_flags",
+    "sch_visual_qa",
+    "run_erc",
+    "schematic_connectivity_gate",
+    "schematic_quality_gate",
+    "validate_design",
+    "project_quality_gate",
+    "vcs_commit_checkpoint",
+    "vcs_diff_with_checkpoint",
+)
+
+_PCB_EXECUTION_TOOLS = (
+    "kicad_set_project",
+    "kicad_get_project_info",
+    "kicad_get_server_info",
+    "pcb_sync_from_schematic",
+    "pcb_get_board_summary",
+    "pcb_get_footprints",
+    "pcb_get_nets",
+    "pcb_get_tracks",
+    "pcb_get_vias",
+    "pcb_get_ratsnest",
+    "pcb_get_design_rules",
+    "pcb_set_board_outline",
+    "pcb_set_design_rules",
+    "pcb_set_net_class",
+    "pcb_auto_place_by_schematic",
+    "pcb_place_component",
+    "pcb_move_component",
+    "pcb_add_track",
+    "pcb_route_trace",
+    "pcb_add_tracks_bulk",
+    "pcb_add_via",
+    "pcb_add_copper_zone",
+    "pcb_refill_zones",
+    "pcb_save",
+    "pcb_begin_commit",
+    "pcb_push_commit",
+    "pcb_drop_commit",
+    "pcb_revert",
+    "pcb_delete_items",
+    "run_drc",
+    "run_erc",
+    "get_unconnected_nets",
+    "validate_footprints_vs_schematic",
+    "pcb_quality_gate",
+    "pcb_placement_quality_gate",
+    "project_quality_gate",
+    "vcs_commit_checkpoint",
+    "vcs_diff_with_checkpoint",
+)
+
+
+def catalog_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
+    """Return the profile/mode catalog boundary visible to the benchmark agent."""
     return frozenset(
         _MCP_PREFIX + tool
         for tool in tools_for_profile(phase.profile)
         if is_tool_allowed_in_mode(tool, phase.mode)
     )
+
+
+def reviewed_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
+    """Return the exact reviewed execution ceiling for one benchmark phase."""
+    tools: tuple[str, ...]
+    if phase.name == "schematic":
+        tools = _SCHEMATIC_EXECUTION_TOOLS
+    elif phase.name == "pcb":
+        tools = _PCB_EXECUTION_TOOLS
+    else:
+        tools = tuple(tools_for_profile("release"))
+    reviewed = frozenset(_MCP_PREFIX + tool for tool in tools)
+    catalog = catalog_mcp_tools(phase)
+    if not reviewed <= catalog:
+        raise ReferenceAgentRunnerError("reviewed execution tools exceed phase catalog")
+    return reviewed
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,7 +189,7 @@ def _content_items(row: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
     return tuple(item for item in content if isinstance(item, Mapping))
 
 
-def _validate_init(row: Mapping[str, Any], allowed_mcp_tools: frozenset[str] | None = None) -> str:
+def _validate_init(row: Mapping[str, Any], catalog_mcp_tools: frozenset[str] | None = None) -> str:
     tools = row.get("tools")
     if not isinstance(tools, list) or not all(isinstance(item, str) for item in tools):
         raise ReferenceAgentRunnerError("agent tool inventory is missing")
@@ -103,11 +199,11 @@ def _validate_init(row: Mapping[str, Any], allowed_mcp_tools: frozenset[str] | N
         if item not in _INTERNAL_TOOLS
         and (
             not item.startswith(_MCP_PREFIX)
-            or (allowed_mcp_tools is not None and item not in allowed_mcp_tools)
+            or (catalog_mcp_tools is not None and item not in catalog_mcp_tools)
         )
     ]
     if unexpected:
-        suffix = " outside reviewed phase surface" if allowed_mcp_tools is not None else ""
+        suffix = " outside reviewed phase surface" if catalog_mcp_tools is not None else ""
         raise ReferenceAgentRunnerError(
             f"agent tool inventory contains unreviewed execution tools{suffix}"
         )
@@ -212,6 +308,7 @@ def build_claude_command(
     model: str,
     settings_path: Path,
     mcp_config_path: Path,
+    allowed_mcp_tools: frozenset[str],
 ) -> tuple[str, ...]:
     """Build the isolated Claude Code command used by reference-board attempts."""
     return (
@@ -229,7 +326,7 @@ def build_claude_command(
         "--tools",
         "ToolSearch",
         "--allowedTools",
-        "mcp__kicad__*",
+        ",".join(sorted(allowed_mcp_tools)),
         "--output-format",
         "stream-json",
         "--verbose",
@@ -240,6 +337,7 @@ def parse_claude_stream(
     lines: Iterable[str],
     *,
     attempt_id: str,
+    catalog_mcp_tools: frozenset[str] | None = None,
     allowed_mcp_tools: frozenset[str] | None = None,
 ) -> ReferenceAgentRunSummary:
     """Convert one Claude stream-json session to sanitized reference evidence."""
@@ -259,7 +357,8 @@ def parse_claude_stream(
     )
     if init is None:
         raise ReferenceAgentRunnerError("agent stream is missing init metadata")
-    primary_model = _validate_init(init, allowed_mcp_tools)
+    init_boundary = catalog_mcp_tools if catalog_mcp_tools is not None else allowed_mcp_tools
+    primary_model = _validate_init(init, init_boundary)
 
     tool_names: dict[str, str | None] = {}
     events: list[ReferenceAgentLogEvent] = []
@@ -278,6 +377,10 @@ def parse_claude_stream(
                     continue
                 if not tool_name.startswith(_MCP_PREFIX):
                     raise ReferenceAgentRunnerError(f"agent executed unreviewed tool {tool_name!r}")
+                if allowed_mcp_tools is not None and tool_name not in allowed_mcp_tools:
+                    raise ReferenceAgentRunnerError(
+                        "agent executed tool outside reviewed phase execution surface"
+                    )
                 normalized_name = tool_name.removeprefix(_MCP_PREFIX)
                 tool_names[tool_id] = normalized_name
                 events.append(
@@ -398,6 +501,7 @@ def run_claude_session(
     cwd: Path,
     timeout_seconds: float,
     model: str,
+    catalog_mcp_tools: frozenset[str] | None = None,
     allowed_mcp_tools: frozenset[str] | None = None,
 ) -> ReferenceAgentRunSummary:
     """Run one isolated Claude session and retain raw stream only in scratch storage."""
@@ -452,6 +556,7 @@ def run_claude_session(
         parsed = parse_claude_stream(
             stdout.splitlines(),
             attempt_id=attempt_id,
+            catalog_mcp_tools=catalog_mcp_tools,
             allowed_mcp_tools=allowed_mcp_tools,
         )
     except ReferenceAgentRunnerError:

--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -1,0 +1,419 @@
+"""Sanitized execution evidence helpers for real reference-board agent runs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from ..operating_modes import is_tool_allowed_in_mode
+from ..tools.router import tools_for_profile
+from .reference_corpus import ReferenceAgentLogEvent
+
+_MCP_PREFIX = "mcp__kicad__"
+_INTERNAL_TOOLS = frozenset({"ToolSearch"})
+
+
+class ReferenceAgentRunnerError(ValueError):
+    """Raised when a benchmark agent stream violates the reviewed execution contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceAgentPhase:
+    """Reviewed KiCad MCP profile/mode pair for one benchmark phase."""
+
+    name: Literal["schematic", "pcb", "manufacturing"]
+    profile: Literal["build", "release"]
+    mode: Literal["write", "manufacturing"]
+
+    @classmethod
+    def for_name(cls, name: str) -> ReferenceAgentPhase:
+        phases = {
+            "schematic": cls("schematic", "build", "write"),
+            "pcb": cls("pcb", "build", "write"),
+            "manufacturing": cls("manufacturing", "release", "manufacturing"),
+        }
+        try:
+            return phases[name]
+        except KeyError as exc:
+            raise ReferenceAgentRunnerError(f"unsupported reference-agent phase: {name}") from exc
+
+
+def reviewed_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
+    """Return the exact reviewed MCP tool ceiling for one benchmark phase."""
+    return frozenset(
+        _MCP_PREFIX + tool
+        for tool in tools_for_profile(phase.profile)
+        if is_tool_allowed_in_mode(tool, phase.mode)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceAgentRunSummary:
+    """Sanitized summary of one Claude Code benchmark session."""
+
+    events: tuple[ReferenceAgentLogEvent, ...]
+    primary_model: str
+    auxiliary_models: tuple[str, ...]
+    provider: str
+    permission_denials: int
+    terminal_reason: str
+    successful: bool
+
+
+def _as_mapping(value: object, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReferenceAgentRunnerError(f"{label} must be an object")
+    return value
+
+
+def _timestamp(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ReferenceAgentRunnerError("agent event timestamp is missing")
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ReferenceAgentRunnerError("agent event timestamp is invalid") from exc
+    if timestamp.utcoffset() is None:
+        raise ReferenceAgentRunnerError("agent event timestamp must be timezone-aware")
+    return timestamp
+
+
+def _content_items(row: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    message = row.get("message")
+    if not isinstance(message, Mapping):
+        return ()
+    content = message.get("content")
+    if not isinstance(content, list):
+        return ()
+    return tuple(item for item in content if isinstance(item, Mapping))
+
+
+def _validate_init(row: Mapping[str, Any], allowed_mcp_tools: frozenset[str] | None = None) -> str:
+    tools = row.get("tools")
+    if not isinstance(tools, list) or not all(isinstance(item, str) for item in tools):
+        raise ReferenceAgentRunnerError("agent tool inventory is missing")
+    unexpected = [
+        item
+        for item in tools
+        if item not in _INTERNAL_TOOLS
+        and (
+            not item.startswith(_MCP_PREFIX)
+            or (allowed_mcp_tools is not None and item not in allowed_mcp_tools)
+        )
+    ]
+    if unexpected:
+        suffix = " outside reviewed phase surface" if allowed_mcp_tools is not None else ""
+        raise ReferenceAgentRunnerError(
+            f"agent tool inventory contains unreviewed execution tools{suffix}"
+        )
+    plugins = row.get("plugins")
+    if plugins not in (None, []):
+        raise ReferenceAgentRunnerError("agent plugin inventory must be empty")
+    servers = row.get("mcp_servers")
+    if not isinstance(servers, list) or len(servers) != 1:
+        raise ReferenceAgentRunnerError("agent MCP server inventory must contain only kicad")
+    server = servers[0]
+    if (
+        not isinstance(server, Mapping)
+        or server.get("name") != "kicad"
+        or server.get("status") != "connected"
+    ):
+        raise ReferenceAgentRunnerError("agent MCP server inventory must contain connected kicad")
+    model = row.get("model")
+    if not isinstance(model, str) or not model:
+        raise ReferenceAgentRunnerError("agent primary model is missing")
+    return model
+
+
+def _result_metadata(
+    row: Mapping[str, Any], primary_model: str
+) -> tuple[tuple[str, ...], str, int, str, bool]:
+    usage = row.get("modelUsage")
+    usage_map = usage if isinstance(usage, Mapping) else {}
+    model_names = sorted(str(name) for name in usage_map if isinstance(name, str))
+    auxiliary = tuple(name for name in model_names if name != primary_model)
+    primary_usage = usage_map.get(primary_model)
+    provider = "unknown"
+    if isinstance(primary_usage, Mapping) and isinstance(primary_usage.get("provider"), str):
+        provider = str(primary_usage["provider"])
+    denials = row.get("permission_denials")
+    denial_count = len(denials) if isinstance(denials, list) else 0
+    terminal_reason = row.get("terminal_reason")
+    if not isinstance(terminal_reason, str) or not terminal_reason:
+        terminal_reason = "unknown"
+    successful = (
+        row.get("subtype") == "success"
+        and row.get("is_error") is False
+        and denial_count == 0
+        and terminal_reason == "completed"
+    )
+    return auxiliary, provider, denial_count, terminal_reason, successful
+
+
+def load_phase_prompt(path: Path, phase: ReferenceAgentPhase) -> str:
+    """Select one reviewed phase prompt while preserving the common prompt preamble."""
+    text = path.read_text(encoding="utf-8")
+    headings = tuple(f"## Phase: {name}" for name in ("schematic", "pcb", "manufacturing"))
+    positions = {heading: text.find(heading) for heading in headings}
+    if any(position < 0 for position in positions.values()):
+        raise ReferenceAgentRunnerError("original prompt must declare all three reviewed phases")
+    ordered = sorted((position, heading) for heading, position in positions.items())
+    if [heading for _, heading in ordered] != list(headings):
+        raise ReferenceAgentRunnerError("original prompt phases must use canonical order")
+    common = text[: ordered[0][0]].strip()
+    selected_heading = f"## Phase: {phase.name}"
+    selected_index = headings.index(selected_heading)
+    start = positions[selected_heading] + len(selected_heading)
+    end = len(text)
+    if selected_index + 1 < len(headings):
+        end = positions[headings[selected_index + 1]]
+    selected = text[start:end].strip()
+    if not common or not selected:
+        raise ReferenceAgentRunnerError(
+            "original prompt common and phase sections must be non-empty"
+        )
+    return f"{common}\n\n{selected_heading}\n{selected}\n"
+
+
+def build_mcp_config(
+    *,
+    phase: ReferenceAgentPhase,
+    uv_executable: Path,
+    checkout_dir: Path,
+    project_dir: Path,
+    kicad_cli: Path,
+) -> dict[str, Any]:
+    """Build one strict stdio KiCad MCP configuration for a benchmark phase."""
+    return {
+        "mcpServers": {
+            "kicad": {
+                "type": "stdio",
+                "command": str(uv_executable),
+                "args": ["--directory", str(checkout_dir), "run", "--frozen", "kicad-mcp-pro"],
+                "env": {
+                    "KICAD_MCP_PROJECT_DIR": str(project_dir),
+                    "KICAD_MCP_PROFILE": phase.profile,
+                    "KICAD_MCP_OPERATING_MODE": phase.mode,
+                    "KICAD_MCP_KICAD_CLI": str(kicad_cli),
+                },
+            }
+        }
+    }
+
+
+def build_claude_command(
+    *,
+    claude_executable: str,
+    model: str,
+    settings_path: Path,
+    mcp_config_path: Path,
+) -> tuple[str, ...]:
+    """Build the isolated Claude Code command used by reference-board attempts."""
+    return (
+        claude_executable,
+        "-p",
+        "--model",
+        model,
+        "--setting-sources",
+        "project",
+        "--settings",
+        str(settings_path),
+        "--strict-mcp-config",
+        "--mcp-config",
+        str(mcp_config_path),
+        "--tools",
+        "ToolSearch",
+        "--allowedTools",
+        "mcp__kicad__*",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+    )
+
+
+def parse_claude_stream(
+    lines: Iterable[str],
+    *,
+    attempt_id: str,
+    allowed_mcp_tools: frozenset[str] | None = None,
+) -> ReferenceAgentRunSummary:
+    """Convert one Claude stream-json session to sanitized reference evidence."""
+    rows: list[Mapping[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ReferenceAgentRunnerError("agent stream contains invalid JSON") from exc
+        rows.append(_as_mapping(value, label="agent stream record"))
+
+    init = next(
+        (row for row in rows if row.get("type") == "system" and row.get("subtype") == "init"),
+        None,
+    )
+    if init is None:
+        raise ReferenceAgentRunnerError("agent stream is missing init metadata")
+    primary_model = _validate_init(init, allowed_mcp_tools)
+
+    tool_names: dict[str, str | None] = {}
+    events: list[ReferenceAgentLogEvent] = []
+
+    for row in rows:
+        row_type = row.get("type")
+        for item in _content_items(row):
+            item_type = item.get("type")
+            if row_type == "assistant" and item_type == "tool_use":
+                tool_id = item.get("id")
+                tool_name = item.get("name")
+                if not isinstance(tool_id, str) or not isinstance(tool_name, str):
+                    raise ReferenceAgentRunnerError("agent tool call is missing identity")
+                if tool_name in _INTERNAL_TOOLS:
+                    tool_names[tool_id] = None
+                    continue
+                if not tool_name.startswith(_MCP_PREFIX):
+                    raise ReferenceAgentRunnerError(f"agent executed unreviewed tool {tool_name!r}")
+                normalized_name = tool_name.removeprefix(_MCP_PREFIX)
+                tool_names[tool_id] = normalized_name
+                events.append(
+                    ReferenceAgentLogEvent(
+                        attempt_id=attempt_id,
+                        sequence=len(events) + 1,
+                        timestamp=_timestamp(row.get("timestamp")),
+                        event_type="tool_call",
+                        name=normalized_name,
+                        status="started",
+                    )
+                )
+            elif row_type == "user" and item_type == "tool_result":
+                tool_id = item.get("tool_use_id")
+                if not isinstance(tool_id, str) or tool_id not in tool_names:
+                    raise ReferenceAgentRunnerError("agent tool result has unknown tool-use id")
+                result_name = tool_names[tool_id]
+                if result_name is None:
+                    continue
+                status = "failed" if item.get("is_error") is True else "completed"
+                events.append(
+                    ReferenceAgentLogEvent(
+                        attempt_id=attempt_id,
+                        sequence=len(events) + 1,
+                        timestamp=_timestamp(row.get("timestamp")),
+                        event_type="tool_result",
+                        name=result_name,
+                        status=status,
+                    )
+                )
+
+    result = next((row for row in reversed(rows) if row.get("type") == "result"), None)
+    if result is None:
+        raise ReferenceAgentRunnerError("agent stream is missing terminal result")
+    auxiliary, provider, denials, terminal_reason, successful = _result_metadata(
+        result, primary_model
+    )
+    return ReferenceAgentRunSummary(
+        events=tuple(events),
+        primary_model=primary_model,
+        auxiliary_models=auxiliary,
+        provider=provider,
+        permission_denials=denials,
+        terminal_reason=terminal_reason,
+        successful=successful,
+    )
+
+
+def write_agent_log(path: Path, summary: ReferenceAgentRunSummary, *, append: bool = False) -> None:
+    """Write sanitized publication events, optionally extending one attempt log."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[ReferenceAgentLogEvent] = []
+    if append and path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                existing.append(ReferenceAgentLogEvent.model_validate_json(line))
+            except ValueError as exc:
+                raise ReferenceAgentRunnerError("existing agent log is invalid") from exc
+    if existing and summary.events:
+        attempt_id = existing[0].attempt_id
+        if any(event.attempt_id != attempt_id for event in existing + list(summary.events)):
+            raise ReferenceAgentRunnerError("agent log append crosses attempt identities")
+    offset = len(existing)
+    appended = tuple(
+        event.model_copy(update={"sequence": offset + index})
+        for index, event in enumerate(summary.events, start=1)
+    )
+    events = tuple(existing) + appended if append else appended
+    payload = "".join(event.model_dump_json() + "\n" for event in events)
+    path.write_text(payload, encoding="utf-8")
+
+
+def run_claude_session(
+    *,
+    command: tuple[str, ...],
+    prompt: str,
+    raw_stream_path: Path,
+    attempt_id: str,
+    cwd: Path,
+    timeout_seconds: float,
+    allowed_mcp_tools: frozenset[str] | None = None,
+) -> ReferenceAgentRunSummary:
+    """Run one isolated Claude session and retain raw stream only in scratch storage."""
+    started_at = datetime.now(UTC)
+    completed = subprocess.run(
+        command,
+        input=prompt,
+        cwd=cwd,
+        timeout=timeout_seconds,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        shell=False,
+        check=False,
+    )
+    ended_at = datetime.now(UTC)
+    raw_stream_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_stream_path.write_text(completed.stdout, encoding="utf-8")
+    parsed = parse_claude_stream(
+        completed.stdout.splitlines(),
+        attempt_id=attempt_id,
+        allowed_mcp_tools=allowed_mcp_tools,
+    )
+    successful = parsed.successful and completed.returncode == 0
+    events = [
+        ReferenceAgentLogEvent(
+            attempt_id=attempt_id,
+            sequence=1,
+            timestamp=started_at,
+            event_type="workflow",
+            name="claude_session",
+            status="started",
+        )
+    ]
+    events.extend(
+        event.model_copy(update={"sequence": index})
+        for index, event in enumerate(parsed.events, start=2)
+    )
+    events.append(
+        ReferenceAgentLogEvent(
+            attempt_id=attempt_id,
+            sequence=len(events) + 1,
+            timestamp=ended_at,
+            event_type="workflow",
+            name="claude_session",
+            status="completed" if successful else "failed",
+            details={"exit_code": completed.returncode},
+        )
+    )
+    return ReferenceAgentRunSummary(
+        events=tuple(events),
+        primary_model=parsed.primary_model,
+        auxiliary_models=parsed.auxiliary_models,
+        provider=parsed.provider,
+        permission_denials=parsed.permission_denials,
+        terminal_reason=parsed.terminal_reason,
+        successful=successful,
+    )

--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -3,23 +3,146 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
+import sys
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
+from ..discovery import discover_kicad_cli, find_kicad_version
 from ..operating_modes import is_tool_allowed_in_mode
 from ..tools.router import tools_for_profile
 from .reference_corpus import ReferenceAgentLogEvent
 
 _MCP_PREFIX = "mcp__kicad__"
+_CLAUDE_EXECUTABLE = "claude"
+_CLAUDE_MODEL = "claude-sonnet-5"
 _INTERNAL_TOOLS = frozenset({"ToolSearch"})
 
 
 class ReferenceAgentRunnerError(ValueError):
     """Raised when a benchmark agent stream violates the reviewed execution contract."""
+
+
+_IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_ATTEMPT_IDENTIFIER = re.compile(r"^attempt-[0-9]{3,6}$")
+_VERSION_IDENTIFIER = re.compile(r"^v[1-9][0-9]*$")
+_REVIEWED_BOARD_ROOTS = {
+    "esp32-c6-usbc": Path("docs/evidence/reference-boards/esp32-c6-usbc/v1"),
+    "stm32f072-usbc": Path("docs/evidence/reference-boards/stm32f072-usbc/v1"),
+    "rp2350-usbc": Path("docs/evidence/reference-boards/rp2350-usbc/v1"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceAgentWorkspace:
+    """Deterministic private/public paths for one reviewed board attempt."""
+
+    checkout_dir: Path
+    board_id: str
+    version: str
+    attempt_id: str
+    prompt_path: Path
+    agent_log_path: Path
+    scratch_dir: Path
+    project_dir: Path
+
+    @classmethod
+    def for_board(
+        cls, *, checkout_dir: Path, board_id: str, version: str, attempt_id: str
+    ) -> ReferenceAgentWorkspace:
+        if not _IDENTIFIER.fullmatch(board_id):
+            raise ReferenceAgentRunnerError("board identifier is invalid")
+        if not _VERSION_IDENTIFIER.fullmatch(version):
+            raise ReferenceAgentRunnerError("version identifier is invalid")
+        if not _ATTEMPT_IDENTIFIER.fullmatch(attempt_id):
+            raise ReferenceAgentRunnerError("attempt identifier is invalid")
+        root = checkout_dir.resolve()
+        board_root = root / "docs" / "evidence" / "reference-boards" / board_id / version
+        prompt = board_root / "original-prompt.md"
+        if not prompt.is_file() or prompt.is_symlink():
+            raise ReferenceAgentRunnerError("reviewed original prompt is missing")
+        scratch = root / ".dev-tools" / "reference-agent-runs" / board_id / version / attempt_id
+        return cls(
+            checkout_dir=root,
+            board_id=board_id,
+            version=version,
+            attempt_id=attempt_id,
+            prompt_path=prompt,
+            agent_log_path=board_root / "attempts" / attempt_id / "agent-log.jsonl",
+            scratch_dir=scratch,
+            project_dir=scratch / "project",
+        )
+
+    @classmethod
+    def for_reviewed_attempt(
+        cls, *, checkout_dir: Path, board_id: str, attempt_number: int
+    ) -> ReferenceAgentWorkspace:
+        try:
+            board_relative = _REVIEWED_BOARD_ROOTS[board_id]
+        except KeyError as exc:
+            raise ReferenceAgentRunnerError("board is not in reviewed board set") from exc
+        if not 1 <= attempt_number <= 999:
+            raise ReferenceAgentRunnerError("attempt number must be between 1 and 999")
+        root = checkout_dir.resolve()
+        board_root = root / board_relative
+        prompt = board_root / "original-prompt.md"
+        if not prompt.is_file() or prompt.is_symlink():
+            raise ReferenceAgentRunnerError("reviewed original prompt is missing")
+        canonical_board_id = board_relative.parent.name
+        attempt_id = f"attempt-{attempt_number:03d}"
+        scratch = root / ".dev-tools/reference-agent-runs" / canonical_board_id / "v1" / attempt_id
+        return cls(
+            checkout_dir=root,
+            board_id=canonical_board_id,
+            version="v1",
+            attempt_id=attempt_id,
+            prompt_path=prompt,
+            agent_log_path=board_root / "attempts" / attempt_id / "agent-log.jsonl",
+            scratch_dir=scratch,
+            project_dir=scratch / "project",
+        )
+
+    def phase_settings_path(self, phase: ReferenceAgentPhase) -> Path:
+        return self.scratch_dir / f"{phase.name}-settings.json"
+
+    def phase_mcp_config_path(self, phase: ReferenceAgentPhase) -> Path:
+        return self.scratch_dir / f"{phase.name}-mcp.json"
+
+    def phase_raw_stream_path(self, phase: ReferenceAgentPhase) -> Path:
+        return self.scratch_dir / f"{phase.name}-claude-stream.jsonl"
+
+
+def _reference_kicad_candidates() -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    discovered = discover_kicad_cli()
+    candidates.append(discovered)
+    if sys.platform == "win32":
+        candidates.extend(
+            (
+                Path.home() / "AppData/Local/Programs/KiCad/10.0/bin/kicad-cli.exe",
+                Path("C:/Program Files/KiCad/10.0/bin/kicad-cli.exe"),
+            )
+        )
+    unique: list[Path] = []
+    for candidate in candidates:
+        if candidate not in unique:
+            unique.append(candidate)
+    return tuple(unique)
+
+
+def discover_reference_kicad_cli() -> Path:
+    """Return a working KiCad 10 CLI for reproducible reference-board runs."""
+    for candidate in _reference_kicad_candidates():
+        if not candidate.is_file():
+            continue
+        version = find_kicad_version(candidate)
+        if version is not None and version.lstrip("v").startswith("10."):
+            return candidate.resolve()
+    raise ReferenceAgentRunnerError("working KiCad 10 CLI was not found")
 
 
 @dataclass(frozen=True, slots=True)
@@ -251,9 +374,9 @@ def _result_metadata(
     return auxiliary, provider, denial_count, terminal_reason, successful
 
 
-def load_phase_prompt(path: Path, phase: ReferenceAgentPhase) -> str:
+def load_phase_prompt(workspace: ReferenceAgentWorkspace, phase: ReferenceAgentPhase) -> str:
     """Select one reviewed phase prompt while preserving the common prompt preamble."""
-    text = path.read_text(encoding="utf-8")
+    text = workspace.prompt_path.read_text(encoding="utf-8")
     headings = tuple(f"## Phase: {name}" for name in ("schematic", "pcb", "manufacturing"))
     positions = {heading: text.find(heading) for heading in headings}
     if any(position < 0 for position in positions.values()):
@@ -279,9 +402,7 @@ def load_phase_prompt(path: Path, phase: ReferenceAgentPhase) -> str:
 def build_mcp_config(
     *,
     phase: ReferenceAgentPhase,
-    uv_executable: Path,
-    checkout_dir: Path,
-    project_dir: Path,
+    workspace: ReferenceAgentWorkspace,
     kicad_cli: Path,
 ) -> dict[str, Any]:
     """Build one strict stdio KiCad MCP configuration for a benchmark phase."""
@@ -289,10 +410,10 @@ def build_mcp_config(
         "mcpServers": {
             "kicad": {
                 "type": "stdio",
-                "command": str(uv_executable),
-                "args": ["--directory", str(checkout_dir), "run", "--frozen", "kicad-mcp-pro"],
+                "command": sys.executable,
+                "args": ["-m", "kicad_mcp.server"],
                 "env": {
-                    "KICAD_MCP_PROJECT_DIR": str(project_dir),
+                    "KICAD_MCP_PROJECT_DIR": str(workspace.project_dir),
                     "KICAD_MCP_PROFILE": phase.profile,
                     "KICAD_MCP_OPERATING_MODE": phase.mode,
                     "KICAD_MCP_KICAD_CLI": str(kicad_cli),
@@ -304,18 +425,16 @@ def build_mcp_config(
 
 def build_claude_command(
     *,
-    claude_executable: str,
-    model: str,
     settings_path: Path,
     mcp_config_path: Path,
     allowed_mcp_tools: frozenset[str],
 ) -> tuple[str, ...]:
-    """Build the isolated Claude Code command used by reference-board attempts."""
+    """Build the canonical isolated Claude Code command for reference-board attempts."""
     return (
-        claude_executable,
+        _CLAUDE_EXECUTABLE,
         "-p",
         "--model",
-        model,
+        _CLAUDE_MODEL,
         "--setting-sources",
         "project",
         "--settings",
@@ -333,14 +452,7 @@ def build_claude_command(
     )
 
 
-def parse_claude_stream(
-    lines: Iterable[str],
-    *,
-    attempt_id: str,
-    catalog_mcp_tools: frozenset[str] | None = None,
-    allowed_mcp_tools: frozenset[str] | None = None,
-) -> ReferenceAgentRunSummary:
-    """Convert one Claude stream-json session to sanitized reference evidence."""
+def _parse_stream_rows(lines: Iterable[str]) -> list[Mapping[str, Any]]:
     rows: list[Mapping[str, Any]] = []
     for line in lines:
         if not line.strip():
@@ -350,76 +462,135 @@ def parse_claude_stream(
         except json.JSONDecodeError as exc:
             raise ReferenceAgentRunnerError("agent stream contains invalid JSON") from exc
         rows.append(_as_mapping(value, label="agent stream record"))
+    return rows
 
-    init = next(
-        (row for row in rows if row.get("type") == "system" and row.get("subtype") == "init"),
-        None,
+
+def _required_stream_record(
+    rows: Iterable[Mapping[str, Any]], *, record_type: str, subtype: str | None = None
+) -> Mapping[str, Any]:
+    for row in rows:
+        if row.get("type") != record_type:
+            continue
+        if subtype is not None and row.get("subtype") != subtype:
+            continue
+        return row
+    label = f"{record_type}/{subtype}" if subtype is not None else record_type
+    raise ReferenceAgentRunnerError(f"agent stream is missing {label} metadata")
+
+
+def _tool_call_event(
+    row: Mapping[str, Any],
+    item: Mapping[str, Any],
+    *,
+    attempt_id: str,
+    sequence: int,
+    allowed_mcp_tools: frozenset[str] | None,
+) -> tuple[str, str | None, ReferenceAgentLogEvent | None]:
+    tool_id = item.get("id")
+    tool_name = item.get("name")
+    if not isinstance(tool_id, str) or not isinstance(tool_name, str):
+        raise ReferenceAgentRunnerError("agent tool call is missing identity")
+    if tool_name in _INTERNAL_TOOLS:
+        return tool_id, None, None
+    if not tool_name.startswith(_MCP_PREFIX):
+        raise ReferenceAgentRunnerError(f"agent executed unreviewed tool {tool_name!r}")
+    if allowed_mcp_tools is not None and tool_name not in allowed_mcp_tools:
+        raise ReferenceAgentRunnerError(
+            "agent executed tool outside reviewed phase execution surface"
+        )
+    normalized_name = tool_name.removeprefix(_MCP_PREFIX)
+    event = ReferenceAgentLogEvent(
+        attempt_id=attempt_id,
+        sequence=sequence,
+        timestamp=_timestamp(row.get("timestamp")),
+        event_type="tool_call",
+        name=normalized_name,
+        status="started",
     )
-    if init is None:
-        raise ReferenceAgentRunnerError("agent stream is missing init metadata")
-    init_boundary = catalog_mcp_tools if catalog_mcp_tools is not None else allowed_mcp_tools
-    primary_model = _validate_init(init, init_boundary)
+    return tool_id, normalized_name, event
 
+
+def _tool_result_event(
+    row: Mapping[str, Any],
+    item: Mapping[str, Any],
+    *,
+    attempt_id: str,
+    sequence: int,
+    tool_names: Mapping[str, str | None],
+) -> ReferenceAgentLogEvent | None:
+    tool_id = item.get("tool_use_id")
+    if not isinstance(tool_id, str) or tool_id not in tool_names:
+        raise ReferenceAgentRunnerError("agent tool result has unknown tool-use id")
+    result_name = tool_names[tool_id]
+    if result_name is None:
+        return None
+    status: Literal["failed", "completed"] = (
+        "failed" if item.get("is_error") is True else "completed"
+    )
+    return ReferenceAgentLogEvent(
+        attempt_id=attempt_id,
+        sequence=sequence,
+        timestamp=_timestamp(row.get("timestamp")),
+        event_type="tool_result",
+        name=result_name,
+        status=status,
+    )
+
+
+def _stream_tool_events(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    attempt_id: str,
+    allowed_mcp_tools: frozenset[str] | None,
+) -> tuple[ReferenceAgentLogEvent, ...]:
     tool_names: dict[str, str | None] = {}
     events: list[ReferenceAgentLogEvent] = []
-
     for row in rows:
         row_type = row.get("type")
         for item in _content_items(row):
-            item_type = item.get("type")
-            if row_type == "assistant" and item_type == "tool_use":
-                tool_id = item.get("id")
-                tool_name = item.get("name")
-                if not isinstance(tool_id, str) or not isinstance(tool_name, str):
-                    raise ReferenceAgentRunnerError("agent tool call is missing identity")
-                if tool_name in _INTERNAL_TOOLS:
-                    tool_names[tool_id] = None
-                    continue
-                if not tool_name.startswith(_MCP_PREFIX):
-                    raise ReferenceAgentRunnerError(f"agent executed unreviewed tool {tool_name!r}")
-                if allowed_mcp_tools is not None and tool_name not in allowed_mcp_tools:
-                    raise ReferenceAgentRunnerError(
-                        "agent executed tool outside reviewed phase execution surface"
-                    )
-                normalized_name = tool_name.removeprefix(_MCP_PREFIX)
-                tool_names[tool_id] = normalized_name
-                events.append(
-                    ReferenceAgentLogEvent(
-                        attempt_id=attempt_id,
-                        sequence=len(events) + 1,
-                        timestamp=_timestamp(row.get("timestamp")),
-                        event_type="tool_call",
-                        name=normalized_name,
-                        status="started",
-                    )
+            if row_type == "assistant" and item.get("type") == "tool_use":
+                tool_id, name, event = _tool_call_event(
+                    row,
+                    item,
+                    attempt_id=attempt_id,
+                    sequence=len(events) + 1,
+                    allowed_mcp_tools=allowed_mcp_tools,
                 )
-            elif row_type == "user" and item_type == "tool_result":
-                tool_id = item.get("tool_use_id")
-                if not isinstance(tool_id, str) or tool_id not in tool_names:
-                    raise ReferenceAgentRunnerError("agent tool result has unknown tool-use id")
-                result_name = tool_names[tool_id]
-                if result_name is None:
-                    continue
-                status = "failed" if item.get("is_error") is True else "completed"
-                events.append(
-                    ReferenceAgentLogEvent(
-                        attempt_id=attempt_id,
-                        sequence=len(events) + 1,
-                        timestamp=_timestamp(row.get("timestamp")),
-                        event_type="tool_result",
-                        name=result_name,
-                        status=status,
-                    )
+                tool_names[tool_id] = name
+                if event is not None:
+                    events.append(event)
+            elif row_type == "user" and item.get("type") == "tool_result":
+                event = _tool_result_event(
+                    row,
+                    item,
+                    attempt_id=attempt_id,
+                    sequence=len(events) + 1,
+                    tool_names=tool_names,
                 )
+                if event is not None:
+                    events.append(event)
+    return tuple(events)
 
-    result = next((row for row in reversed(rows) if row.get("type") == "result"), None)
-    if result is None:
-        raise ReferenceAgentRunnerError("agent stream is missing terminal result")
+
+def parse_claude_stream(
+    lines: Iterable[str],
+    *,
+    attempt_id: str,
+    catalog_mcp_tools: frozenset[str] | None = None,
+    allowed_mcp_tools: frozenset[str] | None = None,
+) -> ReferenceAgentRunSummary:
+    """Convert one Claude stream-json session to sanitized reference evidence."""
+    rows = _parse_stream_rows(lines)
+    init = _required_stream_record(rows, record_type="system", subtype="init")
+    init_boundary = catalog_mcp_tools if catalog_mcp_tools is not None else allowed_mcp_tools
+    primary_model = _validate_init(init, init_boundary)
+    events = _stream_tool_events(rows, attempt_id=attempt_id, allowed_mcp_tools=allowed_mcp_tools)
+    result = _required_stream_record(reversed(rows), record_type="result")
     auxiliary, provider, denials, terminal_reason, successful = _result_metadata(
         result, primary_model
     )
     return ReferenceAgentRunSummary(
-        events=tuple(events),
+        events=events,
         primary_model=primary_model,
         auxiliary_models=auxiliary,
         provider=provider,
@@ -429,8 +600,11 @@ def parse_claude_stream(
     )
 
 
-def write_agent_log(path: Path, summary: ReferenceAgentRunSummary, *, append: bool = False) -> None:
+def write_agent_log(
+    workspace: ReferenceAgentWorkspace, summary: ReferenceAgentRunSummary, *, append: bool = False
+) -> None:
     """Write sanitized publication events, optionally extending one attempt log."""
+    path = workspace.agent_log_path
     path.parent.mkdir(parents=True, exist_ok=True)
     existing: list[ReferenceAgentLogEvent] = []
     if append and path.exists():
@@ -494,23 +668,29 @@ def _failed_session_summary(
 
 def run_claude_session(
     *,
-    command: tuple[str, ...],
+    workspace: ReferenceAgentWorkspace,
+    phase: ReferenceAgentPhase,
     prompt: str,
-    raw_stream_path: Path,
-    attempt_id: str,
-    cwd: Path,
     timeout_seconds: float,
-    model: str,
     catalog_mcp_tools: frozenset[str] | None = None,
     allowed_mcp_tools: frozenset[str] | None = None,
 ) -> ReferenceAgentRunSummary:
-    """Run one isolated Claude session and retain raw stream only in scratch storage."""
+    """Run one isolated Claude session with only deterministic workspace paths."""
+    settings_path = workspace.phase_settings_path(phase)
+    mcp_config_path = workspace.phase_mcp_config_path(phase)
+    raw_stream_path = workspace.phase_raw_stream_path(phase)
+    execution_tools = allowed_mcp_tools or reviewed_mcp_tools(phase)
+    command = build_claude_command(
+        settings_path=settings_path,
+        mcp_config_path=mcp_config_path,
+        allowed_mcp_tools=execution_tools,
+    )
     started_at = datetime.now(UTC)
     try:
         completed = subprocess.run(
             command,
             input=prompt,
-            cwd=cwd,
+            cwd=workspace.checkout_dir,
             timeout=timeout_seconds,
             capture_output=True,
             text=True,
@@ -529,8 +709,8 @@ def run_claude_session(
         raw_stream_path.parent.mkdir(parents=True, exist_ok=True)
         raw_stream_path.write_text(output, encoding="utf-8")
         return _failed_session_summary(
-            attempt_id=attempt_id,
-            model=model,
+            attempt_id=workspace.attempt_id,
+            model=_CLAUDE_MODEL,
             started_at=started_at,
             ended_at=ended_at,
             terminal_reason="timeout",
@@ -541,8 +721,8 @@ def run_claude_session(
         raw_stream_path.parent.mkdir(parents=True, exist_ok=True)
         raw_stream_path.write_text("", encoding="utf-8")
         return _failed_session_summary(
-            attempt_id=attempt_id,
-            model=model,
+            attempt_id=workspace.attempt_id,
+            model=_CLAUDE_MODEL,
             started_at=started_at,
             ended_at=ended_at,
             terminal_reason="process_launch_failed",
@@ -555,14 +735,14 @@ def run_claude_session(
     try:
         parsed = parse_claude_stream(
             stdout.splitlines(),
-            attempt_id=attempt_id,
+            attempt_id=workspace.attempt_id,
             catalog_mcp_tools=catalog_mcp_tools,
-            allowed_mcp_tools=allowed_mcp_tools,
+            allowed_mcp_tools=execution_tools,
         )
     except ReferenceAgentRunnerError:
         return _failed_session_summary(
-            attempt_id=attempt_id,
-            model=model,
+            attempt_id=workspace.attempt_id,
+            model=_CLAUDE_MODEL,
             started_at=started_at,
             ended_at=ended_at,
             terminal_reason="stream_contract_violation",
@@ -572,7 +752,7 @@ def run_claude_session(
     successful = parsed.successful and completed.returncode == 0
     events = [
         ReferenceAgentLogEvent(
-            attempt_id=attempt_id,
+            attempt_id=workspace.attempt_id,
             sequence=1,
             timestamp=started_at,
             event_type="workflow",
@@ -586,7 +766,7 @@ def run_claude_session(
     )
     events.append(
         ReferenceAgentLogEvent(
-            attempt_id=attempt_id,
+            attempt_id=workspace.attempt_id,
             sequence=len(events) + 1,
             timestamp=ended_at,
             event_type="workflow",

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -83,6 +83,21 @@ def _lines(rows: list[dict[str, object]]) -> list[str]:
     return [json.dumps(row) for row in rows]
 
 
+def _workspace(tmp_path: Path, prompt_text: str | None = None, *, attempt_id: str = "attempt-001"):
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentWorkspace
+
+    board = tmp_path / "docs/evidence/reference-boards/test-board/v1"
+    board.mkdir(parents=True, exist_ok=True)
+    prompt = prompt_text or (
+        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
+        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n"
+    )
+    (board / "original-prompt.md").write_text(prompt, encoding="utf-8")
+    return ReferenceAgentWorkspace.for_board(
+        checkout_dir=tmp_path, board_id="test-board", version="v1", attempt_id=attempt_id
+    )
+
+
 def test_parse_claude_stream_emits_only_sanitized_kicad_events() -> None:
     from kicad_mcp.evals.reference_agent_runner import parse_claude_stream
 
@@ -146,59 +161,36 @@ def test_build_claude_command_exposes_only_reviewed_agent_surface(tmp_path) -> N
     from kicad_mcp.evals.reference_agent_runner import build_claude_command
 
     command = build_claude_command(
-        claude_executable="claude",
-        model="claude-sonnet-5",
         settings_path=tmp_path / "settings.json",
         mcp_config_path=tmp_path / "mcp.json",
         allowed_mcp_tools=frozenset({"mcp__kicad__sch_add_symbol", "mcp__kicad__run_erc"}),
     )
 
-    assert command == (
-        "claude",
-        "-p",
-        "--model",
-        "claude-sonnet-5",
-        "--setting-sources",
-        "project",
-        "--settings",
-        str(tmp_path / "settings.json"),
-        "--strict-mcp-config",
-        "--mcp-config",
-        str(tmp_path / "mcp.json"),
-        "--tools",
-        "ToolSearch",
-        "--allowedTools",
-        "mcp__kicad__run_erc,mcp__kicad__sch_add_symbol",
-        "--output-format",
-        "stream-json",
-        "--verbose",
-    )
-    assert not {"Bash", "Read", "Write", "Edit", "WebFetch"}.intersection(command)
+    assert command[:4] == ("claude", "-p", "--model", "claude-sonnet-5")
+    assert "--strict-mcp-config" in command
+    assert "--tools" in command
+    assert "ToolSearch" in command
+    assert "--allowedTools" in command
+    assert "mcp__kicad__run_erc,mcp__kicad__sch_add_symbol" in command
+    for forbidden in ("Bash", "Read", "Write", "Edit", "WebFetch"):
+        assert forbidden not in command
 
 
-def test_build_mcp_config_pins_phase_and_local_runtime(tmp_path) -> None:
+def test_build_mcp_config_pins_phase_and_current_python(tmp_path) -> None:
+    import sys
+
     from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, build_mcp_config
 
+    workspace = _workspace(tmp_path)
     phase = ReferenceAgentPhase.for_name("pcb")
     config = build_mcp_config(
-        phase=phase,
-        uv_executable=tmp_path / "uv.exe",
-        checkout_dir=tmp_path / "repo",
-        project_dir=tmp_path / "project",
-        kicad_cli=tmp_path / "kicad-cli.exe",
+        phase=phase, workspace=workspace, kicad_cli=tmp_path / "kicad-cli.exe"
     )
-
     server = config["mcpServers"]["kicad"]
-    assert server["command"] == str(tmp_path / "uv.exe")
-    assert server["args"] == [
-        "--directory",
-        str(tmp_path / "repo"),
-        "run",
-        "--frozen",
-        "kicad-mcp-pro",
-    ]
+    assert server["command"] == sys.executable
+    assert server["args"] == ["-m", "kicad_mcp.server"]
     assert server["env"] == {
-        "KICAD_MCP_PROJECT_DIR": str(tmp_path / "project"),
+        "KICAD_MCP_PROJECT_DIR": str(workspace.project_dir),
         "KICAD_MCP_PROFILE": "pcb_layout",
         "KICAD_MCP_OPERATING_MODE": "write",
         "KICAD_MCP_KICAD_CLI": str(tmp_path / "kicad-cli.exe"),
@@ -221,7 +213,7 @@ def test_run_claude_session_uses_stdin_and_writes_only_stream_to_scratch(
 ) -> None:
     import subprocess
 
-    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, run_claude_session
 
     calls = []
     stdout = "\n".join(_lines(_stream_rows())) + "\n"
@@ -231,26 +223,21 @@ def test_run_claude_session_uses_stdin_and_writes_only_stream_to_scratch(
         return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="private stderr")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    raw_stream = tmp_path / "scratch" / "stream.jsonl"
+    workspace = _workspace(tmp_path)
+    phase = ReferenceAgentPhase.for_name("schematic")
     summary = run_claude_session(
-        command=("claude", "-p"),
-        prompt="public benchmark prompt",
-        raw_stream_path=raw_stream,
-        attempt_id="attempt-001",
-        cwd=tmp_path,
-        timeout_seconds=120.0,
-        model="claude-sonnet-5",
+        workspace=workspace, phase=phase, prompt="public benchmark prompt", timeout_seconds=120.0
     )
-
+    raw_stream = workspace.phase_raw_stream_path(phase)
     assert summary.successful is True
     assert raw_stream.read_text(encoding="utf-8") == stdout
     command, kwargs = calls[0]
+    assert command[:4] == ("claude", "-p", "--model", "claude-sonnet-5")
     assert "public benchmark prompt" not in command
     assert kwargs["input"] == "public benchmark prompt"
+    assert kwargs["cwd"] == workspace.checkout_dir
     assert kwargs["shell"] is False
     assert kwargs["timeout"] == 120.0
-    assert kwargs["capture_output"] is True
-    assert kwargs["text"] is True
     assert "private stderr" not in raw_stream.read_text(encoding="utf-8")
 
 
@@ -258,10 +245,9 @@ def test_write_agent_log_serializes_only_sanitized_events(tmp_path) -> None:
     from kicad_mcp.evals.reference_agent_runner import parse_claude_stream, write_agent_log
 
     summary = parse_claude_stream(_lines(_stream_rows()), attempt_id="attempt-001")
-    target = tmp_path / "agent-log.jsonl"
-    write_agent_log(target, summary)
-
-    rendered = target.read_text(encoding="utf-8")
+    workspace = _workspace(tmp_path)
+    write_agent_log(workspace, summary)
+    rendered = workspace.agent_log_path.read_text(encoding="utf-8")
     assert rendered.count("\n") == 2
     assert "raw tool output" not in rendered
     assert "do-not-publish" not in rendered
@@ -272,54 +258,54 @@ def test_write_agent_log_appends_with_contiguous_sequences(tmp_path) -> None:
     from kicad_mcp.evals.reference_agent_runner import parse_claude_stream, write_agent_log
 
     summary = parse_claude_stream(_lines(_stream_rows()), attempt_id="attempt-001")
-    target = tmp_path / "agent-log.jsonl"
-    write_agent_log(target, summary)
-    write_agent_log(target, summary, append=True)
-
-    payloads = [json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()]
+    workspace = _workspace(tmp_path)
+    write_agent_log(workspace, summary)
+    write_agent_log(workspace, summary, append=True)
+    payloads = [
+        json.loads(line)
+        for line in workspace.agent_log_path.read_text(encoding="utf-8").splitlines()
+    ]
     assert [item["sequence"] for item in payloads] == [1, 2, 3, 4]
-    assert all(item["attempt_id"] == "attempt-001" for item in payloads)
+    for item in payloads:
+        assert item["attempt_id"] == "attempt-001"
 
 
-def test_reference_agent_cli_exposes_explicit_runtime_inputs() -> None:
+def test_reference_agent_cli_exposes_only_reviewed_identity_inputs() -> None:
     import subprocess
     import sys
-    from pathlib import Path
 
     script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
     completed = subprocess.run(
-        [sys.executable, str(script), "--help"],
-        capture_output=True,
-        text=True,
-        check=False,
+        [sys.executable, str(script), "--help"], capture_output=True, text=True, check=False
     )
     assert completed.returncode == 0
-    for flag in (
+    for flag in ("--board-id", "--attempt-number", "--phase"):
+        assert flag in completed.stdout
+    for removed in (
+        "--version",
         "--attempt-id",
-        "--phase",
+        "--uv",
+        "--kicad-cli",
         "--prompt-file",
         "--project-dir",
         "--scratch-dir",
         "--agent-log",
         "--checkout-dir",
-        "--uv",
-        "--kicad-cli",
         "--claude",
         "--model",
     ):
-        assert flag in completed.stdout
+        assert removed not in completed.stdout
 
 
 def test_load_phase_prompt_combines_common_and_selected_phase(tmp_path) -> None:
     from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, load_phase_prompt
 
-    source = tmp_path / "original-prompt.md"
-    source.write_text(
+    workspace = _workspace(
+        tmp_path,
         "# Benchmark\n\nCommon invariant.\n\n## Phase: schematic\nBuild schematic.\n\n"
         "## Phase: pcb\nBuild PCB.\n\n## Phase: manufacturing\nExport release.\n",
-        encoding="utf-8",
     )
-    prompt = load_phase_prompt(source, ReferenceAgentPhase.for_name("pcb"))
+    prompt = load_phase_prompt(workspace, ReferenceAgentPhase.for_name("pcb"))
     assert "Common invariant." in prompt
     assert "Build PCB." in prompt
     assert "Build schematic." not in prompt
@@ -331,9 +317,16 @@ def test_load_phase_prompt_combines_common_and_selected_phase(tmp_path) -> None:
     ("esp32-c6-usbc", "stm32f072-usbc", "rp2350-usbc"),
 )
 def test_reference_board_inputs_are_reviewed_clean_start_contracts(board_id: str) -> None:
+    from kicad_mcp.evals.evidence_sanitization import validate_sanitized_evidence
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentPhase,
+        ReferenceAgentWorkspace,
+        load_phase_prompt,
+    )
     from kicad_mcp.evals.task_outcomes import ALL_TASK_STAGES, parse_benchmark_contract
 
-    root = Path(__file__).resolve().parents[2] / "docs/evidence/reference-boards" / board_id / "v1"
+    checkout = Path(__file__).resolve().parents[2]
+    root = checkout / "docs/evidence/reference-boards" / board_id / "v1"
     assert (root / "specification.md").is_file()
     assert (root / "original-prompt.md").is_file()
     contract = parse_benchmark_contract(
@@ -352,17 +345,15 @@ def test_reference_board_inputs_are_reviewed_clean_start_contracts(board_id: str
     assert not (root / "attempts").exists()
     assert not list(root.glob("*.kicad_sch"))
     assert not list(root.glob("*.kicad_pcb"))
-
-    from kicad_mcp.evals.evidence_sanitization import validate_sanitized_evidence
-    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, load_phase_prompt
-
     validate_sanitized_evidence((root / "specification.md").read_text(encoding="utf-8"))
     validate_sanitized_evidence((root / "original-prompt.md").read_text(encoding="utf-8"))
+    workspace = ReferenceAgentWorkspace.for_board(
+        checkout_dir=checkout, board_id=board_id, version="v1", attempt_id="attempt-001"
+    )
     for phase_name in ("schematic", "pcb", "manufacturing"):
-        phase_prompt = load_phase_prompt(
-            root / "original-prompt.md", ReferenceAgentPhase.for_name(phase_name)
+        validate_sanitized_evidence(
+            load_phase_prompt(workspace, ReferenceAgentPhase.for_name(phase_name))
         )
-        validate_sanitized_evidence(phase_prompt)
 
 
 def test_parse_claude_stream_requires_only_connected_kicad_mcp() -> None:
@@ -384,7 +375,7 @@ def test_parse_claude_stream_requires_only_connected_kicad_mcp() -> None:
 def test_run_claude_session_preserves_parseable_failed_session(tmp_path, monkeypatch) -> None:
     import subprocess
 
-    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, run_claude_session
 
     rows = _stream_rows()
     rows[1:4] = []
@@ -397,14 +388,12 @@ def test_run_claude_session_preserves_parseable_failed_session(tmp_path, monkeyp
         return subprocess.CompletedProcess(command, 1, stdout=stdout, stderr="private")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    workspace = _workspace(tmp_path, attempt_id="attempt-002")
     summary = run_claude_session(
-        command=("claude", "-p"),
+        workspace=workspace,
+        phase=ReferenceAgentPhase.for_name("schematic"),
         prompt="benchmark",
-        raw_stream_path=tmp_path / "stream.jsonl",
-        attempt_id="attempt-002",
-        cwd=tmp_path,
         timeout_seconds=30.0,
-        model="claude-sonnet-5",
     )
     assert summary.successful is False
     assert [(event.event_type, event.name, event.status) for event in summary.events] == [
@@ -458,7 +447,7 @@ def test_run_claude_session_preserves_invalid_stream_as_sanitized_failure(
 ) -> None:
     import subprocess
 
-    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, run_claude_session
 
     def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
@@ -466,41 +455,36 @@ def test_run_claude_session_preserves_invalid_stream_as_sanitized_failure(
         )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    raw = tmp_path / "stream.jsonl"
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    phase = ReferenceAgentPhase.for_name("schematic")
     summary = run_claude_session(
-        command=("claude", "-p"),
-        prompt="benchmark",
-        raw_stream_path=raw,
-        attempt_id="attempt-invalid",
-        cwd=tmp_path,
-        timeout_seconds=30.0,
-        model="claude-sonnet-5",
+        workspace=workspace, phase=phase, prompt="benchmark", timeout_seconds=30.0
     )
+    raw = workspace.phase_raw_stream_path(phase)
     assert summary.successful is False
     assert summary.primary_model == "claude-sonnet-5"
     assert summary.terminal_reason == "stream_contract_violation"
     assert raw.read_text(encoding="utf-8") == "private invalid stream\n"
     assert [event.status for event in summary.events] == ["started", "failed"]
-    assert "private" not in json.dumps([event.model_dump(mode="json") for event in summary.events])
+    rendered = json.dumps([event.model_dump(mode="json") for event in summary.events])
+    assert "private" not in rendered
 
 
 def test_run_claude_session_preserves_timeout_as_sanitized_failure(tmp_path, monkeypatch) -> None:
     import subprocess
 
-    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, run_claude_session
 
     def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(command, 30.0, output="private partial stream")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    workspace = _workspace(tmp_path, attempt_id="attempt-004")
     summary = run_claude_session(
-        command=("claude", "-p"),
+        workspace=workspace,
+        phase=ReferenceAgentPhase.for_name("schematic"),
         prompt="benchmark",
-        raw_stream_path=tmp_path / "stream.jsonl",
-        attempt_id="attempt-timeout",
-        cwd=tmp_path,
         timeout_seconds=30.0,
-        model="claude-sonnet-5",
     )
     assert summary.successful is False
     assert summary.terminal_reason == "timeout"
@@ -514,25 +498,24 @@ def test_run_claude_session_preserves_launch_failure_without_exception_text(
 ) -> None:
     import subprocess
 
-    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, run_claude_session
 
     def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         raise OSError("private launch path")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    workspace = _workspace(tmp_path, attempt_id="attempt-005")
     summary = run_claude_session(
-        command=("claude", "-p"),
+        workspace=workspace,
+        phase=ReferenceAgentPhase.for_name("schematic"),
         prompt="benchmark",
-        raw_stream_path=tmp_path / "stream.jsonl",
-        attempt_id="attempt-launch",
-        cwd=tmp_path,
         timeout_seconds=30.0,
-        model="claude-sonnet-5",
     )
     assert summary.successful is False
     assert summary.terminal_reason == "process_launch_failed"
     assert [event.status for event in summary.events] == ["started", "failed"]
-    assert "private" not in json.dumps([event.model_dump(mode="json") for event in summary.events])
+    rendered = json.dumps([event.model_dump(mode="json") for event in summary.events])
+    assert "private" not in rendered
 
 
 def test_catalog_boundary_is_broader_than_execution_boundary_for_authoring_phases() -> None:
@@ -576,24 +559,23 @@ def test_reference_agent_cli_threads_catalog_and_execution_boundaries(
 
     script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
     spec = importlib.util.spec_from_file_location("reference_agent_cli_test", script)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-
-    prompt = tmp_path / "prompt.md"
-    prompt.write_text(
+    board = tmp_path / "docs/evidence/reference-boards/esp32-c6-usbc/v1"
+    board.mkdir(parents=True)
+    (board / "original-prompt.md").write_text(
         "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
         "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n",
         encoding="utf-8",
     )
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "discover_reference_kicad_cli", lambda: tmp_path / "kicad-cli.exe")
     captured: dict[str, object] = {}
 
-    def fake_build(**kwargs: object) -> tuple[str, ...]:
-        captured["build"] = kwargs
-        return ("claude", "-p")
-
     def fake_run(**kwargs: object) -> ReferenceAgentRunSummary:
-        captured["run"] = kwargs
+        captured.update(kwargs)
         return ReferenceAgentRunSummary(
             events=(),
             primary_model="claude-sonnet-5",
@@ -604,38 +586,138 @@ def test_reference_agent_cli_threads_catalog_and_execution_boundaries(
             successful=True,
         )
 
-    monkeypatch.setattr(module, "build_claude_command", fake_build)
     monkeypatch.setattr(module, "run_claude_session", fake_run)
     result = module.main(
         [
-            "--attempt-id",
-            "attempt-cli",
+            "--board-id",
+            "esp32-c6-usbc",
+            "--attempt-number",
+            "1",
             "--phase",
             "pcb",
-            "--prompt-file",
-            str(prompt),
-            "--project-dir",
-            str(tmp_path / "project"),
-            "--scratch-dir",
-            str(tmp_path / "scratch"),
-            "--agent-log",
-            str(tmp_path / "agent-log.jsonl"),
-            "--checkout-dir",
-            str(tmp_path),
-            "--uv",
-            str(tmp_path / "uv.exe"),
-            "--kicad-cli",
-            str(tmp_path / "kicad-cli.exe"),
         ]
     )
     assert result == 0
-    build_kwargs = captured["build"]
-    run_kwargs = captured["run"]
-    assert isinstance(build_kwargs, dict) and isinstance(run_kwargs, dict)
-    execution = build_kwargs["allowed_mcp_tools"]
-    assert execution == run_kwargs["allowed_mcp_tools"]
-    catalog = run_kwargs["catalog_mcp_tools"]
-    assert isinstance(execution, frozenset) and isinstance(catalog, frozenset)
+    execution = captured["allowed_mcp_tools"]
+    catalog = captured["catalog_mcp_tools"]
+    assert isinstance(execution, frozenset)
+    assert isinstance(catalog, frozenset)
     assert execution < catalog
     assert "mcp__kicad__pcb_route_trace" in execution
     assert "mcp__kicad__route_differential_pair" not in execution
+    workspace = captured["workspace"]
+    assert workspace.checkout_dir == tmp_path.resolve()
+    assert workspace.agent_log_path == board / "attempts/attempt-001/agent-log.jsonl"
+
+
+def test_reference_agent_workspace_derives_reviewed_paths(tmp_path) -> None:
+    workspace = _workspace(tmp_path)
+    board = tmp_path / "docs/evidence/reference-boards/test-board/v1"
+    assert workspace.prompt_path == board / "original-prompt.md"
+    assert workspace.agent_log_path == board / "attempts/attempt-001/agent-log.jsonl"
+    assert workspace.project_dir == (
+        tmp_path / ".dev-tools/reference-agent-runs/test-board/v1/attempt-001/project"
+    )
+    assert workspace.scratch_dir == workspace.project_dir.parent
+
+
+def test_reference_agent_workspace_rejects_unreviewed_components(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        ReferenceAgentWorkspace,
+    )
+
+    for board_id, version, attempt_id in (
+        ("../escape", "v1", "attempt-001"),
+        ("board", "../v1", "attempt-001"),
+        ("board", "v1", "../attempt-001"),
+    ):
+        with pytest.raises(ReferenceAgentRunnerError, match="identifier"):
+            ReferenceAgentWorkspace.for_board(
+                checkout_dir=tmp_path, board_id=board_id, version=version, attempt_id=attempt_id
+            )
+
+
+def test_reference_agent_workspace_requires_committed_prompt(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        ReferenceAgentWorkspace,
+    )
+
+    with pytest.raises(ReferenceAgentRunnerError, match="original prompt"):
+        ReferenceAgentWorkspace.for_board(
+            checkout_dir=tmp_path, board_id="board", version="v1", attempt_id="attempt-001"
+        )
+
+
+def test_reference_agent_workspace_reviewed_attempt_is_bounded(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        ReferenceAgentWorkspace,
+    )
+
+    board = tmp_path / "docs/evidence/reference-boards/esp32-c6-usbc/v1"
+    board.mkdir(parents=True)
+    (board / "original-prompt.md").write_text("prompt\n", encoding="utf-8")
+    workspace = ReferenceAgentWorkspace.for_reviewed_attempt(
+        checkout_dir=tmp_path, board_id="esp32-c6-usbc", attempt_number=2
+    )
+    assert workspace.version == "v1"
+    assert workspace.attempt_id == "attempt-002"
+    with pytest.raises(ReferenceAgentRunnerError, match="reviewed board"):
+        ReferenceAgentWorkspace.for_reviewed_attempt(
+            checkout_dir=tmp_path, board_id="other-board", attempt_number=1
+        )
+    for value in (0, 1000):
+        with pytest.raises(ReferenceAgentRunnerError, match="attempt number"):
+            ReferenceAgentWorkspace.for_reviewed_attempt(
+                checkout_dir=tmp_path, board_id="esp32-c6-usbc", attempt_number=value
+            )
+
+
+def test_discover_reference_kicad_cli_requires_working_v10(tmp_path, monkeypatch) -> None:
+    import kicad_mcp.evals.reference_agent_runner as runner
+
+    v11 = tmp_path / "kicad11.exe"
+    v10 = tmp_path / "kicad10.exe"
+    v11.write_bytes(b"x")
+    v10.write_bytes(b"x")
+    monkeypatch.setattr(runner, "_reference_kicad_candidates", lambda: (v11, v10))
+    monkeypatch.setattr(
+        runner, "find_kicad_version", lambda path: "11.0.0" if path == v11 else "10.0.6"
+    )
+    assert runner.discover_reference_kicad_cli() == v10.resolve()
+
+
+def test_discover_reference_kicad_cli_fails_closed_without_v10(tmp_path, monkeypatch) -> None:
+    import kicad_mcp.evals.reference_agent_runner as runner
+
+    candidate = tmp_path / "kicad.exe"
+    candidate.write_bytes(b"x")
+    monkeypatch.setattr(runner, "_reference_kicad_candidates", lambda: (candidate,))
+    monkeypatch.setattr(runner, "find_kicad_version", lambda _path: "11.0.0")
+    with pytest.raises(runner.ReferenceAgentRunnerError, match="KiCad 10"):
+        runner.discover_reference_kicad_cli()
+
+
+def test_reference_kicad_candidates_include_windows_v10_locations(tmp_path, monkeypatch) -> None:
+    import kicad_mcp.evals.reference_agent_runner as runner
+
+    discovered = tmp_path / "discovered.exe"
+    monkeypatch.setattr(runner, "discover_kicad_cli", lambda: discovered)
+    monkeypatch.setattr(runner.sys, "platform", "win32")
+    candidates = runner._reference_kicad_candidates()
+    assert candidates[0] == discovered
+    assert Path.home() / "AppData/Local/Programs/KiCad/10.0/bin/kicad-cli.exe" in candidates
+    assert Path("C:/Program Files/KiCad/10.0/bin/kicad-cli.exe") in candidates
+    assert len(candidates) == len(set(candidates))
+
+
+def test_reference_agent_phase_rejects_unknown_name() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentPhase,
+        ReferenceAgentRunnerError,
+    )
+
+    with pytest.raises(ReferenceAgentRunnerError, match="unsupported reference-agent phase"):
+        ReferenceAgentPhase.for_name("unknown")

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -238,6 +238,7 @@ def test_run_claude_session_uses_stdin_and_writes_only_stream_to_scratch(
         attempt_id="attempt-001",
         cwd=tmp_path,
         timeout_seconds=120.0,
+        model="claude-sonnet-5",
     )
 
     assert summary.successful is True
@@ -402,6 +403,7 @@ def test_run_claude_session_preserves_parseable_failed_session(tmp_path, monkeyp
         attempt_id="attempt-002",
         cwd=tmp_path,
         timeout_seconds=30.0,
+        model="claude-sonnet-5",
     )
     assert summary.successful is False
     assert [(event.event_type, event.name, event.status) for event in summary.events] == [
@@ -437,3 +439,85 @@ def test_parse_claude_stream_rejects_tool_outside_reviewed_phase_surface() -> No
             attempt_id="attempt-001",
             allowed_mcp_tools=allowed,
         )
+
+
+def test_run_claude_session_preserves_invalid_stream_as_sanitized_failure(
+    tmp_path, monkeypatch
+) -> None:
+    import subprocess
+
+    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+
+    def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command, 0, stdout="private invalid stream\n", stderr="private"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    raw = tmp_path / "stream.jsonl"
+    summary = run_claude_session(
+        command=("claude", "-p"),
+        prompt="benchmark",
+        raw_stream_path=raw,
+        attempt_id="attempt-invalid",
+        cwd=tmp_path,
+        timeout_seconds=30.0,
+        model="claude-sonnet-5",
+    )
+    assert summary.successful is False
+    assert summary.primary_model == "claude-sonnet-5"
+    assert summary.terminal_reason == "stream_contract_violation"
+    assert raw.read_text(encoding="utf-8") == "private invalid stream\n"
+    assert [event.status for event in summary.events] == ["started", "failed"]
+    assert "private" not in json.dumps([event.model_dump(mode="json") for event in summary.events])
+
+
+def test_run_claude_session_preserves_timeout_as_sanitized_failure(tmp_path, monkeypatch) -> None:
+    import subprocess
+
+    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+
+    def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, 30.0, output="private partial stream")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    summary = run_claude_session(
+        command=("claude", "-p"),
+        prompt="benchmark",
+        raw_stream_path=tmp_path / "stream.jsonl",
+        attempt_id="attempt-timeout",
+        cwd=tmp_path,
+        timeout_seconds=30.0,
+        model="claude-sonnet-5",
+    )
+    assert summary.successful is False
+    assert summary.terminal_reason == "timeout"
+    assert [event.status for event in summary.events] == ["started", "failed"]
+    rendered = json.dumps([event.model_dump(mode="json") for event in summary.events])
+    assert "private" not in rendered
+
+
+def test_run_claude_session_preserves_launch_failure_without_exception_text(
+    tmp_path, monkeypatch
+) -> None:
+    import subprocess
+
+    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+
+    def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise OSError("private launch path")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    summary = run_claude_session(
+        command=("claude", "-p"),
+        prompt="benchmark",
+        raw_stream_path=tmp_path / "stream.jsonl",
+        attempt_id="attempt-launch",
+        cwd=tmp_path,
+        timeout_seconds=30.0,
+        model="claude-sonnet-5",
+    )
+    assert summary.successful is False
+    assert summary.terminal_reason == "process_launch_failed"
+    assert [event.status for event in summary.events] == ["started", "failed"]
+    assert "private" not in json.dumps([event.model_dump(mode="json") for event in summary.events])

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _stream_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "type": "system",
+            "subtype": "init",
+            "model": "claude-sonnet-5",
+            "tools": ["ToolSearch", "mcp__kicad__kicad_get_server_info"],
+            "plugins": [],
+            "mcp_servers": [{"name": "kicad", "status": "connected"}],
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-09-03T19:36:45.698Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-5",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "ToolSearch",
+                        "input": {"query": "secret raw query"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-09-03T19:36:46.000Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-5",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-2",
+                        "name": "mcp__kicad__kicad_get_server_info",
+                        "input": {"raw": "do-not-publish"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-09-03T19:36:47.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-2",
+                        "content": "raw tool output must not survive",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "terminal_reason": "completed",
+            "permission_denials": [],
+            "modelUsage": {
+                "claude-sonnet-5": {"canonicalModel": "claude-sonnet-5", "provider": "firstParty"},
+                "claude-haiku-4-5-20251001": {
+                    "canonicalModel": "claude-haiku-4-5-20251001",
+                    "provider": "firstParty",
+                },
+            },
+        },
+    ]
+
+
+def _lines(rows: list[dict[str, object]]) -> list[str]:
+    return [json.dumps(row) for row in rows]
+
+
+def test_parse_claude_stream_emits_only_sanitized_kicad_events() -> None:
+    from kicad_mcp.evals.reference_agent_runner import parse_claude_stream
+
+    summary = parse_claude_stream(_lines(_stream_rows()), attempt_id="attempt-001")
+
+    assert summary.primary_model == "claude-sonnet-5"
+    assert summary.auxiliary_models == ("claude-haiku-4-5-20251001",)
+    assert summary.provider == "firstParty"
+    assert summary.permission_denials == 0
+    assert summary.successful is True
+    assert [
+        (event.sequence, event.event_type, event.name, event.status) for event in summary.events
+    ] == [
+        (1, "tool_call", "kicad_get_server_info", "started"),
+        (2, "tool_result", "kicad_get_server_info", "completed"),
+    ]
+    rendered = "\n".join(event.model_dump_json() for event in summary.events)
+    assert "secret raw query" not in rendered
+    assert "do-not-publish" not in rendered
+    assert "raw tool output" not in rendered
+
+
+def test_parse_claude_stream_rejects_unreviewed_executed_tool() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        parse_claude_stream,
+    )
+
+    rows = _stream_rows()
+    rows.insert(
+        2,
+        {
+            "type": "assistant",
+            "timestamp": "2026-09-03T19:36:45.900Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-5",
+                "content": [{"type": "tool_use", "id": "bad", "name": "Bash", "input": {}}],
+            },
+        },
+    )
+
+    with pytest.raises(ReferenceAgentRunnerError, match="unreviewed tool"):
+        parse_claude_stream(_lines(rows), attempt_id="attempt-001")
+
+
+def test_parse_claude_stream_rejects_available_execution_tools() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        parse_claude_stream,
+    )
+
+    rows = _stream_rows()
+    rows[0]["tools"] = ["ToolSearch", "Bash", "mcp__kicad__kicad_get_server_info"]
+
+    with pytest.raises(ReferenceAgentRunnerError, match="tool inventory"):
+        parse_claude_stream(_lines(rows), attempt_id="attempt-001")
+
+
+def test_build_claude_command_exposes_only_reviewed_agent_surface(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import build_claude_command
+
+    command = build_claude_command(
+        claude_executable="claude",
+        model="claude-sonnet-5",
+        settings_path=tmp_path / "settings.json",
+        mcp_config_path=tmp_path / "mcp.json",
+    )
+
+    assert command == (
+        "claude",
+        "-p",
+        "--model",
+        "claude-sonnet-5",
+        "--setting-sources",
+        "project",
+        "--settings",
+        str(tmp_path / "settings.json"),
+        "--strict-mcp-config",
+        "--mcp-config",
+        str(tmp_path / "mcp.json"),
+        "--tools",
+        "ToolSearch",
+        "--allowedTools",
+        "mcp__kicad__*",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+    )
+    assert not {"Bash", "Read", "Write", "Edit", "WebFetch"}.intersection(command)
+
+
+def test_build_mcp_config_pins_phase_and_local_runtime(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, build_mcp_config
+
+    phase = ReferenceAgentPhase.for_name("pcb")
+    config = build_mcp_config(
+        phase=phase,
+        uv_executable=tmp_path / "uv.exe",
+        checkout_dir=tmp_path / "repo",
+        project_dir=tmp_path / "project",
+        kicad_cli=tmp_path / "kicad-cli.exe",
+    )
+
+    server = config["mcpServers"]["kicad"]
+    assert server["command"] == str(tmp_path / "uv.exe")
+    assert server["args"] == [
+        "--directory",
+        str(tmp_path / "repo"),
+        "run",
+        "--frozen",
+        "kicad-mcp-pro",
+    ]
+    assert server["env"] == {
+        "KICAD_MCP_PROJECT_DIR": str(tmp_path / "project"),
+        "KICAD_MCP_PROFILE": "build",
+        "KICAD_MCP_OPERATING_MODE": "write",
+        "KICAD_MCP_KICAD_CLI": str(tmp_path / "kicad-cli.exe"),
+    }
+
+
+def test_reference_agent_phases_are_fixed() -> None:
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase
+
+    assert ReferenceAgentPhase.for_name("schematic").profile == "build"
+    assert ReferenceAgentPhase.for_name("schematic").mode == "write"
+    assert ReferenceAgentPhase.for_name("pcb").profile == "build"
+    assert ReferenceAgentPhase.for_name("pcb").mode == "write"
+    assert ReferenceAgentPhase.for_name("manufacturing").profile == "release"
+    assert ReferenceAgentPhase.for_name("manufacturing").mode == "manufacturing"
+
+
+def test_run_claude_session_uses_stdin_and_writes_only_stream_to_scratch(
+    tmp_path, monkeypatch
+) -> None:
+    import subprocess
+
+    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+
+    calls = []
+    stdout = "\n".join(_lines(_stream_rows())) + "\n"
+
+    def fake_run(command: tuple[str, ...], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="private stderr")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    raw_stream = tmp_path / "scratch" / "stream.jsonl"
+    summary = run_claude_session(
+        command=("claude", "-p"),
+        prompt="public benchmark prompt",
+        raw_stream_path=raw_stream,
+        attempt_id="attempt-001",
+        cwd=tmp_path,
+        timeout_seconds=120.0,
+    )
+
+    assert summary.successful is True
+    assert raw_stream.read_text(encoding="utf-8") == stdout
+    command, kwargs = calls[0]
+    assert "public benchmark prompt" not in command
+    assert kwargs["input"] == "public benchmark prompt"
+    assert kwargs["shell"] is False
+    assert kwargs["timeout"] == 120.0
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
+    assert "private stderr" not in raw_stream.read_text(encoding="utf-8")
+
+
+def test_write_agent_log_serializes_only_sanitized_events(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import parse_claude_stream, write_agent_log
+
+    summary = parse_claude_stream(_lines(_stream_rows()), attempt_id="attempt-001")
+    target = tmp_path / "agent-log.jsonl"
+    write_agent_log(target, summary)
+
+    rendered = target.read_text(encoding="utf-8")
+    assert rendered.count("\n") == 2
+    assert "raw tool output" not in rendered
+    assert "do-not-publish" not in rendered
+    assert "kicad_get_server_info" in rendered
+
+
+def test_write_agent_log_appends_with_contiguous_sequences(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import parse_claude_stream, write_agent_log
+
+    summary = parse_claude_stream(_lines(_stream_rows()), attempt_id="attempt-001")
+    target = tmp_path / "agent-log.jsonl"
+    write_agent_log(target, summary)
+    write_agent_log(target, summary, append=True)
+
+    payloads = [json.loads(line) for line in target.read_text(encoding="utf-8").splitlines()]
+    assert [item["sequence"] for item in payloads] == [1, 2, 3, 4]
+    assert all(item["attempt_id"] == "attempt-001" for item in payloads)
+
+
+def test_reference_agent_cli_exposes_explicit_runtime_inputs() -> None:
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
+    completed = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0
+    for flag in (
+        "--attempt-id",
+        "--phase",
+        "--prompt-file",
+        "--project-dir",
+        "--scratch-dir",
+        "--agent-log",
+        "--checkout-dir",
+        "--uv",
+        "--kicad-cli",
+        "--claude",
+        "--model",
+    ):
+        assert flag in completed.stdout
+
+
+def test_load_phase_prompt_combines_common_and_selected_phase(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, load_phase_prompt
+
+    source = tmp_path / "original-prompt.md"
+    source.write_text(
+        "# Benchmark\n\nCommon invariant.\n\n## Phase: schematic\nBuild schematic.\n\n"
+        "## Phase: pcb\nBuild PCB.\n\n## Phase: manufacturing\nExport release.\n",
+        encoding="utf-8",
+    )
+    prompt = load_phase_prompt(source, ReferenceAgentPhase.for_name("pcb"))
+    assert "Common invariant." in prompt
+    assert "Build PCB." in prompt
+    assert "Build schematic." not in prompt
+    assert "Export release." not in prompt
+
+
+@pytest.mark.parametrize(
+    "board_id",
+    ("esp32-c6-usbc", "stm32f072-usbc", "rp2350-usbc"),
+)
+def test_reference_board_inputs_are_reviewed_clean_start_contracts(board_id: str) -> None:
+    from kicad_mcp.evals.task_outcomes import ALL_TASK_STAGES, parse_benchmark_contract
+
+    root = Path(__file__).resolve().parents[2] / "docs/evidence/reference-boards" / board_id / "v1"
+    assert (root / "specification.md").is_file()
+    assert (root / "original-prompt.md").is_file()
+    contract = parse_benchmark_contract(
+        json.loads((root / "benchmark.json").read_text(encoding="utf-8"))
+    )
+    assert contract.benchmark_version == "v1"
+    assert contract.evidence_sufficiency.minimum_valid_attempts == 2
+    assert contract.evidence_sufficiency.minimum_recovery_required_mutations == 2
+    assert contract.evidence_sufficiency.minimum_drc_required_tasks == 2
+    assert contract.evidence_sufficiency.minimum_manufacturing_release_tasks == 2
+    assert len(contract.tasks) == 1
+    assert contract.tasks[0].task_class == "reference-board"
+    assert set(contract.tasks[0].stage_requirements) == set(ALL_TASK_STAGES)
+    assert set(contract.tasks[0].stage_requirements.values()) == {"required"}
+    assert not (root / "attempt-manifest.json").exists()
+    assert not (root / "attempts").exists()
+    assert not list(root.glob("*.kicad_sch"))
+    assert not list(root.glob("*.kicad_pcb"))
+
+    from kicad_mcp.evals.evidence_sanitization import validate_sanitized_evidence
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, load_phase_prompt
+
+    validate_sanitized_evidence((root / "specification.md").read_text(encoding="utf-8"))
+    validate_sanitized_evidence((root / "original-prompt.md").read_text(encoding="utf-8"))
+    for phase_name in ("schematic", "pcb", "manufacturing"):
+        phase_prompt = load_phase_prompt(
+            root / "original-prompt.md", ReferenceAgentPhase.for_name(phase_name)
+        )
+        validate_sanitized_evidence(phase_prompt)
+
+
+def test_parse_claude_stream_requires_only_connected_kicad_mcp() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        parse_claude_stream,
+    )
+
+    rows = _stream_rows()
+    rows[0]["mcp_servers"] = [
+        {"name": "kicad", "status": "connected"},
+        {"name": "unreviewed", "status": "connected"},
+    ]
+
+    with pytest.raises(ReferenceAgentRunnerError, match="MCP server inventory"):
+        parse_claude_stream(_lines(rows), attempt_id="attempt-001")
+
+
+def test_run_claude_session_preserves_parseable_failed_session(tmp_path, monkeypatch) -> None:
+    import subprocess
+
+    from kicad_mcp.evals.reference_agent_runner import run_claude_session
+
+    rows = _stream_rows()
+    rows[1:4] = []
+    rows[-1]["subtype"] = "error"
+    rows[-1]["is_error"] = True
+    rows[-1]["terminal_reason"] = "provider_failure"
+    stdout = "\n".join(_lines(rows)) + "\n"
+
+    def fake_run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1, stdout=stdout, stderr="private")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    summary = run_claude_session(
+        command=("claude", "-p"),
+        prompt="benchmark",
+        raw_stream_path=tmp_path / "stream.jsonl",
+        attempt_id="attempt-002",
+        cwd=tmp_path,
+        timeout_seconds=30.0,
+    )
+    assert summary.successful is False
+    assert [(event.event_type, event.name, event.status) for event in summary.events] == [
+        ("workflow", "claude_session", "started"),
+        ("workflow", "claude_session", "failed"),
+    ]
+
+
+def test_reviewed_mcp_tools_follow_profile_and_mode_boundaries() -> None:
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, reviewed_mcp_tools
+
+    build = reviewed_mcp_tools(ReferenceAgentPhase.for_name("schematic"))
+    release = reviewed_mcp_tools(ReferenceAgentPhase.for_name("manufacturing"))
+
+    assert len(build) == 24
+    assert "mcp__kicad__sch_apply_plan" in build
+    assert "mcp__kicad__export_manufacturing_package" not in build
+    assert len(release) == 24
+    assert "mcp__kicad__export_manufacturing_package" in release
+    assert "mcp__kicad__sch_apply_plan" not in release
+
+
+def test_parse_claude_stream_rejects_tool_outside_reviewed_phase_surface() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        parse_claude_stream,
+    )
+
+    allowed = frozenset({"mcp__kicad__kicad_set_project"})
+    with pytest.raises(ReferenceAgentRunnerError, match="reviewed phase surface"):
+        parse_claude_stream(
+            _lines(_stream_rows()),
+            attempt_id="attempt-001",
+            allowed_mcp_tools=allowed,
+        )

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -150,6 +150,7 @@ def test_build_claude_command_exposes_only_reviewed_agent_surface(tmp_path) -> N
         model="claude-sonnet-5",
         settings_path=tmp_path / "settings.json",
         mcp_config_path=tmp_path / "mcp.json",
+        allowed_mcp_tools=frozenset({"mcp__kicad__sch_add_symbol", "mcp__kicad__run_erc"}),
     )
 
     assert command == (
@@ -167,7 +168,7 @@ def test_build_claude_command_exposes_only_reviewed_agent_surface(tmp_path) -> N
         "--tools",
         "ToolSearch",
         "--allowedTools",
-        "mcp__kicad__*",
+        "mcp__kicad__run_erc,mcp__kicad__sch_add_symbol",
         "--output-format",
         "stream-json",
         "--verbose",
@@ -198,7 +199,7 @@ def test_build_mcp_config_pins_phase_and_local_runtime(tmp_path) -> None:
     ]
     assert server["env"] == {
         "KICAD_MCP_PROJECT_DIR": str(tmp_path / "project"),
-        "KICAD_MCP_PROFILE": "build",
+        "KICAD_MCP_PROFILE": "pcb_layout",
         "KICAD_MCP_OPERATING_MODE": "write",
         "KICAD_MCP_KICAD_CLI": str(tmp_path / "kicad-cli.exe"),
     }
@@ -207,9 +208,9 @@ def test_build_mcp_config_pins_phase_and_local_runtime(tmp_path) -> None:
 def test_reference_agent_phases_are_fixed() -> None:
     from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase
 
-    assert ReferenceAgentPhase.for_name("schematic").profile == "build"
+    assert ReferenceAgentPhase.for_name("schematic").profile == "schematic_authoring"
     assert ReferenceAgentPhase.for_name("schematic").mode == "write"
-    assert ReferenceAgentPhase.for_name("pcb").profile == "build"
+    assert ReferenceAgentPhase.for_name("pcb").profile == "pcb_layout"
     assert ReferenceAgentPhase.for_name("pcb").mode == "write"
     assert ReferenceAgentPhase.for_name("manufacturing").profile == "release"
     assert ReferenceAgentPhase.for_name("manufacturing").mode == "manufacturing"
@@ -415,15 +416,26 @@ def test_run_claude_session_preserves_parseable_failed_session(tmp_path, monkeyp
 def test_reviewed_mcp_tools_follow_profile_and_mode_boundaries() -> None:
     from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, reviewed_mcp_tools
 
-    build = reviewed_mcp_tools(ReferenceAgentPhase.for_name("schematic"))
+    schematic = reviewed_mcp_tools(ReferenceAgentPhase.for_name("schematic"))
+    pcb = reviewed_mcp_tools(ReferenceAgentPhase.for_name("pcb"))
     release = reviewed_mcp_tools(ReferenceAgentPhase.for_name("manufacturing"))
 
-    assert len(build) == 24
-    assert "mcp__kicad__sch_apply_plan" in build
-    assert "mcp__kicad__export_manufacturing_package" not in build
+    assert len(schematic) == 35
+    assert {
+        "mcp__kicad__sch_add_symbol",
+        "mcp__kicad__lib_search_symbols",
+        "mcp__kicad__run_erc",
+    } <= schematic
+    assert "mcp__kicad__pcb_route_trace" not in schematic
+    assert len(pcb) == 38
+    assert {
+        "mcp__kicad__pcb_sync_from_schematic",
+        "mcp__kicad__pcb_route_trace",
+        "mcp__kicad__run_drc",
+    } <= pcb
+    assert "mcp__kicad__route_differential_pair" not in pcb
     assert len(release) == 24
     assert "mcp__kicad__export_manufacturing_package" in release
-    assert "mcp__kicad__sch_apply_plan" not in release
 
 
 def test_parse_claude_stream_rejects_tool_outside_reviewed_phase_surface() -> None:
@@ -521,3 +533,109 @@ def test_run_claude_session_preserves_launch_failure_without_exception_text(
     assert summary.terminal_reason == "process_launch_failed"
     assert [event.status for event in summary.events] == ["started", "failed"]
     assert "private" not in json.dumps([event.model_dump(mode="json") for event in summary.events])
+
+
+def test_catalog_boundary_is_broader_than_execution_boundary_for_authoring_phases() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentPhase,
+        catalog_mcp_tools,
+        reviewed_mcp_tools,
+    )
+
+    for phase_name in ("schematic", "pcb"):
+        phase = ReferenceAgentPhase.for_name(phase_name)
+        catalog = catalog_mcp_tools(phase)
+        execution = reviewed_mcp_tools(phase)
+        assert execution < catalog
+        assert execution
+
+
+def test_parse_claude_stream_allows_catalog_tool_but_rejects_unreviewed_execution() -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        parse_claude_stream,
+    )
+
+    catalog = frozenset({"mcp__kicad__kicad_get_server_info", "mcp__kicad__kicad_set_project"})
+    allowed = frozenset({"mcp__kicad__kicad_set_project"})
+    with pytest.raises(ReferenceAgentRunnerError, match="reviewed phase execution surface"):
+        parse_claude_stream(
+            _lines(_stream_rows()),
+            attempt_id="attempt-001",
+            catalog_mcp_tools=catalog,
+            allowed_mcp_tools=allowed,
+        )
+
+
+def test_reference_agent_cli_threads_catalog_and_execution_boundaries(
+    tmp_path, monkeypatch
+) -> None:
+    import importlib.util
+
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentRunSummary
+
+    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
+    spec = importlib.util.spec_from_file_location("reference_agent_cli_test", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(
+        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
+        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n",
+        encoding="utf-8",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_build(**kwargs: object) -> tuple[str, ...]:
+        captured["build"] = kwargs
+        return ("claude", "-p")
+
+    def fake_run(**kwargs: object) -> ReferenceAgentRunSummary:
+        captured["run"] = kwargs
+        return ReferenceAgentRunSummary(
+            events=(),
+            primary_model="claude-sonnet-5",
+            auxiliary_models=(),
+            provider="firstParty",
+            permission_denials=0,
+            terminal_reason="completed",
+            successful=True,
+        )
+
+    monkeypatch.setattr(module, "build_claude_command", fake_build)
+    monkeypatch.setattr(module, "run_claude_session", fake_run)
+    result = module.main(
+        [
+            "--attempt-id",
+            "attempt-cli",
+            "--phase",
+            "pcb",
+            "--prompt-file",
+            str(prompt),
+            "--project-dir",
+            str(tmp_path / "project"),
+            "--scratch-dir",
+            str(tmp_path / "scratch"),
+            "--agent-log",
+            str(tmp_path / "agent-log.jsonl"),
+            "--checkout-dir",
+            str(tmp_path),
+            "--uv",
+            str(tmp_path / "uv.exe"),
+            "--kicad-cli",
+            str(tmp_path / "kicad-cli.exe"),
+        ]
+    )
+    assert result == 0
+    build_kwargs = captured["build"]
+    run_kwargs = captured["run"]
+    assert isinstance(build_kwargs, dict) and isinstance(run_kwargs, dict)
+    execution = build_kwargs["allowed_mcp_tools"]
+    assert execution == run_kwargs["allowed_mcp_tools"]
+    catalog = run_kwargs["catalog_mcp_tools"]
+    assert isinstance(execution, frozenset) and isinstance(catalog, frozenset)
+    assert execution < catalog
+    assert "mcp__kicad__pcb_route_trace" in execution
+    assert "mcp__kicad__route_differential_pair" not in execution


### PR DESCRIPTION
## Summary

Adds the execution harness and three reviewed clean-start inputs required to turn #730 into reproducible native KiCad evidence.

- strict Claude Code + KiCad MCP-only runner
- authoring-capable phase catalogs: `schematic_authoring/write`, `pcb_layout/write`, `release/manufacturing`
- exact execution ceilings of 35 / 38 / 24 KiCad tools; experimental routing helpers remain excluded
- catalog inventory and actual execution permissions are validated independently
- sanitized `pcb-reference-agent-log.v1` capture
- invalid stream, timeout, launch, provider, and tool failures remain evidence instead of disappearing
- ESP32-C6 USB-C, STM32F072 USB-C/RS-485, and RP2350 USB-C benchmark inputs
- no completed schematic/PCB/attempt artifacts are included

## Verification

- 118 relevant local tests PASS on latest `ee3ed93`
- Ruff format/lint PASS
- strict mypy PASS
- architecture boundary check PASS
- `git diff --check` PASS
- Bandit: 0 HIGH / 0 MEDIUM; two expected LOW subprocess findings with `shell=False`
- real MCP init probe with isolated pinned `uv 0.11.31`: `kicad` connected, plugins empty, `schematic_authoring/write` catalog 192 tools and entirely within reviewed profile boundary
- Claude command accepts an exact `--allowedTools` list; the probe itself permitted only `kicad_get_server_info` and performed no mutation
- current Claude account condition terminates the model call with an API/session-limit error; no reference-board attempt has been started

Windows symlink fixture tests are excluded from local verification because this host lacks symlink privilege (`WinError 1314`); the same three tests fail identically on unchanged `main`. Linux CI remains authoritative for them.

This PR does not claim #730 complete. Actual board attempts start only after the harness and board-specific scorer contracts land, from the exact merged source revision, and every started attempt remains in the denominator.