### PR TITLE
feat(evals): add deterministic reference-board quality scorer

### DIFF
--- a/docs/evidence/reference-boards/esp32-c6-usbc/v1/quality-gates.json
+++ b/docs/evidence/reference-boards/esp32-c6-usbc/v1/quality-gates.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "pcb-reference-board-quality.v1",
+  "board_id": "esp32-c6-usbc",
+  "benchmark_version": "v1",
+  "rules": [
+    {"id": "erc-consumed", "type": "attempt_validation", "validation_kind": "erc"},
+    {"id": "drc-consumed", "type": "attempt_validation", "validation_kind": "drc"},
+    {
+      "id": "board-envelope",
+      "type": "board_outline",
+      "max_width_mm": 50.0,
+      "max_height_mm": 32.0
+    },
+    {"id": "bom-present", "type": "artifact", "path": "BOM.csv", "kind": "file"},
+    {"id": "gerbers-present", "type": "artifact", "path": "Gerbers", "kind": "directory"},
+    {
+      "id": "manufacturing-report-present",
+      "type": "artifact",
+      "path": "manufacturing-report.md",
+      "kind": "file"
+    }
+  ]
+}

--- a/docs/evidence/reference-boards/rp2350-usbc/v1/quality-gates.json
+++ b/docs/evidence/reference-boards/rp2350-usbc/v1/quality-gates.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "pcb-reference-board-quality.v1",
+  "board_id": "rp2350-usbc",
+  "benchmark_version": "v1",
+  "rules": [
+    {"id": "erc-consumed", "type": "attempt_validation", "validation_kind": "erc"},
+    {"id": "drc-consumed", "type": "attempt_validation", "validation_kind": "drc"},
+    {
+      "id": "board-envelope",
+      "type": "board_outline",
+      "max_width_mm": 58.0,
+      "max_height_mm": 34.0
+    },
+    {"id": "bom-present", "type": "artifact", "path": "BOM.csv", "kind": "file"},
+    {"id": "gerbers-present", "type": "artifact", "path": "Gerbers", "kind": "directory"},
+    {
+      "id": "manufacturing-report-present",
+      "type": "artifact",
+      "path": "manufacturing-report.md",
+      "kind": "file"
+    }
+  ]
+}

--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/quality-gates.json
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/quality-gates.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "pcb-reference-board-quality.v1",
+  "board_id": "stm32f072-usbc",
+  "benchmark_version": "v1",
+  "rules": [
+    {"id": "erc-consumed", "type": "attempt_validation", "validation_kind": "erc"},
+    {"id": "drc-consumed", "type": "attempt_validation", "validation_kind": "drc"},
+    {
+      "id": "board-envelope",
+      "type": "board_outline",
+      "max_width_mm": 60.0,
+      "max_height_mm": 36.0
+    },
+    {"id": "bom-present", "type": "artifact", "path": "BOM.csv", "kind": "file"},
+    {"id": "gerbers-present", "type": "artifact", "path": "Gerbers", "kind": "directory"},
+    {
+      "id": "manufacturing-report-present",
+      "type": "artifact",
+      "path": "manufacturing-report.md",
+      "kind": "file"
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-09-04-reference-board-quality-scorer.md
+++ b/docs/superpowers/plans/2026-09-04-reference-board-quality-scorer.md
@@ -1,0 +1,56 @@
+# Reference-board quality scorer implementation plan
+
+## Goal
+
+Implement issue #730 board-specific deterministic scoring without changing `pcb-task-outcome.v1` or introducing a second KiCad parser. The scorer consumes reviewed `quality-gates.json`, one existing `AttemptRecord`, and attempt artifacts; it emits sanitized `board-quality-score.json`.
+
+## Task 1 — strict quality contract and report models
+
+**Files**
+- Create `src/kicad_mcp/evals/reference_board_quality.py`
+- Create `tests/unit/test_reference_board_quality.py`
+
+**Steps**
+1. RED: parse a minimal `pcb-reference-board-quality.v1` contract and reject unknown fields/rule types.
+2. GREEN: add strict Pydantic models for the seven reviewed rule types.
+3. Add deterministic `BoardQualityScore` / rule-result rendering with bounded reason codes.
+4. Verify output through `validate_sanitized_evidence()` and stable ordering.
+
+## Task 2 — existing-parser fact adapters and rule evaluation
+
+**Steps**
+1. RED: synthetic schematic fixture exercises component identity and named-net membership rules.
+2. GREEN: use `ir.from_kicad.parse_schematic()`; do not parse schematic text in scorer code.
+3. RED: synthetic PCB fixture exercises footprint, pad-net membership, and outline bounds.
+4. GREEN: reuse `_parse_board_footprint_blocks()` and `_outline_bounds_mm()` from maintained board/DFM parsing paths.
+5. Add validation and artifact rules from canonical `AttemptRecord` and regular-file/directory checks.
+
+## Task 3 — attempt scorer and CLI
+
+**Files**
+- Modify `src/kicad_mcp/evals/reference_board_quality.py`
+- Create `scripts/score_reference_board_attempt.py`
+- Extend `tests/unit/test_reference_board_quality.py`
+
+**Steps**
+1. RED: identity mismatch, missing attempt evidence, and failed required rule all produce overall fail.
+2. GREEN: implement `score_reference_board_attempt(bundle_root, attempt_id)` with canonical path derivation only.
+3. Score percentage is descriptive; `overall_pass` requires every required rule to pass.
+4. CLI writes only canonical `attempts/<id>/board-quality-score.json` and returns nonzero on failed quality.
+
+## Task 4 — publication integration and three v1 contracts
+
+**Files**
+- Modify `src/kicad_mcp/evals/reference_corpus.py`
+- Modify `tests/unit/test_reference_corpus.py`
+- Create `quality-gates.json` for ESP32-C6, STM32F072, and RP2350 v1 inputs.
+
+**Steps**
+1. RED: autonomous-success attempt without a matching passing quality report fails bundle validation.
+2. GREEN: include quality report in attempt evidence digest/manifest validation without changing attempt classification.
+3. Encode only requirements already present in each written specification; no SI/PI/EMC claims.
+4. Run schema validation on all three contracts before any real attempt begins.
+
+## Final verification
+
+Run focused scorer/corpus/task-outcome tests, Ruff, strict mypy, architecture boundary checks, `git diff --check`, sensitive-data scan, and the three quality-contract validation tests. Open a dedicated PR against `main`; real attempts start only after it merges.

--- a/docs/superpowers/specs/2026-09-04-reference-board-quality-scorer-design.md
+++ b/docs/superpowers/specs/2026-09-04-reference-board-quality-scorer-design.md
@@ -1,0 +1,59 @@
+# Reference-board quality scorer design
+
+## Purpose
+
+Issue #730 requires automated board-specific scoring in addition to the existing `pcb-task-outcome.v1` aggregate KPIs. The scorer must objectively verify each published reference-board attempt without introducing a second outcome taxonomy or relying on screenshots.
+
+The existing `AttemptRecord`, reference-bundle validator, schematic IR parser, and PCB file inspection code remain authoritative. The scorer adds a small, deterministic quality-rule layer and one sanitized machine-readable report per attempt.
+
+## Approaches considered
+
+1. **Data-driven quality contract (selected).** Add a versioned `quality-gates.json` beside each board benchmark and evaluate it with shared code. This keeps board expectations reviewable and avoids hard-coded Python logic per board.
+2. Hard-code one Python scorer per board. This is strongly typed but makes benchmark changes code changes and encourages copy/paste drift.
+3. Extend `benchmark.json` with board-specific rules. Rejected because it would overload the canonical task-outcome schema with product-specific electrical/layout details.
+
+## Contract boundary
+
+Each board revision adds `quality-gates.json` with schema id `pcb-reference-board-quality.v1`. It binds to `board_id` and `benchmark_version` and contains only deterministic required rules. Unknown rule types or fields fail closed.
+Supported initial rule types are deliberately small:
+
+- `schematic_component`: require a reference plus reviewed identity constraints such as exact/allowed library id, value, and footprint.
+- `schematic_net`: require a named net and optional required component references on that net.
+- `pcb_footprint`: require a reference and reviewed footprint identity.
+- `pcb_net`: require a named PCB net and optional required footprint references attached to it.
+- `board_outline`: require a real `Edge.Cuts` outline and optional bounded dimensions.
+- `attempt_validation`: require an existing canonical ERC/DRC validation record to be attempted, completed, consumed, and pass according to the benchmark contract.
+- `artifact`: require a named publication artifact to be a regular non-empty file or a non-empty directory.
+
+No arbitrary code, shell command, user-supplied regex execution, provider text parsing, or screenshot similarity is part of the rule language.
+
+## Data flow
+
+`score_reference_board_attempt(bundle_root, attempt_id)` loads the existing benchmark, quality contract, and `AttemptRecord`. It verifies board/version identity first. A schematic adapter calls the existing semantic `parse_schematic()` path. A PCB adapter reuses the established board-file parser by exposing only the existing footprint/net/outline facts needed by eval code; it does not create a second KiCad parser.
+
+Each rule produces a stable id, `pass`/`fail`, and a bounded reason code. Raw schematic/PCB text, absolute private paths, provider messages, and tool outputs never enter the report.
+
+The CLI writes `board-quality-score.json`. The report contains schema version, board/benchmark/attempt ids, source revision, required-rule counts, `quality_score_percent`, overall pass state, and ordered rule results. Overall pass requires every required rule to pass; the percentage is descriptive and cannot turn a failed required rule into success.
+## Failure and publication semantics
+
+The scorer never rewrites `AttemptRecord.classification`. A provider/tool failure remains a failed attempt even if no design files exist. Missing design evidence therefore yields a failed quality report when scoring is requested; it is not silently excluded.
+
+For a claimed autonomous success, the reference-bundle validator will require the quality report to exist, match the attempt identity, and report overall pass. Manual repair remains governed by the existing attempt contract and cannot be converted to autonomous success by the scorer.
+
+`board-quality-score.json` is included in the attempt evidence digest and manifest denominator once real runs begin. Regeneration after publication changes the digest and therefore fails stale evidence validation until the manifest is deliberately rebuilt.
+
+## Board-specific v1 rules
+
+The first three contracts will encode only requirements already present in their written specifications. ESP32-C6 covers the module, USB-C/power/protection path, named USB nets, PCB footprint transfer, outline, ERC/DRC, BOM and manufacturing artifacts. STM32F072 additionally checks SWD, RS-485 and I2C identities/nets. RP2350 additionally checks RP2350, external flash, USB/debug and expansion requirements.
+
+The rule files must not invent sign-off-grade SI/PI/EMC claims. Layout checks are limited to facts the maintained parser and validation stack can objectively prove.
+
+## Testing
+
+TDD fixtures will cover strict schema parsing, unknown-rule rejection, schematic component/net pass and fail cases, PCB footprint/net/outline checks, validation/artifact checks, deterministic ordering/scoring, sanitized output, identity mismatch, missing evidence, and CLI exit codes.
+
+Integration tests will score synthetic KiCad fixtures through the same parser paths. The three real board `quality-gates.json` files will be schema-validated before any real agent attempt starts. Existing reference-corpus and task-outcome suites remain unchanged and must stay green.
+
+## Scope exclusions
+
+This change does not run the agent, create PCB designs, change model/provider policy, add new electrical solvers, or alter the canonical KPI taxonomy. Real attempts begin only after both the harness and scorer contracts are reviewed and merged.

--- a/scripts/score_reference_board_attempt.py
+++ b/scripts/score_reference_board_attempt.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Score one canonical reference-board attempt and write its quality report."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from kicad_mcp.evals.reference_board_quality import (
+    render_quality_score,
+    score_reference_board_attempt,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle_root", type=Path)
+    parser.add_argument("attempt_id")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        score = score_reference_board_attempt(args.bundle_root, args.attempt_id)
+        root = args.bundle_root.resolve(strict=True)
+        output = root / "attempts" / args.attempt_id / "board-quality-score.json"
+        output.write_text(render_quality_score(score), encoding="utf-8", newline="\n")
+    except (OSError, ValueError) as exc:
+        print(f"reference-board scoring failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"wrote {output}")
+    return 0 if score.overall_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kicad_mcp/evals/reference_board_quality.py
+++ b/src/kicad_mcp/evals/reference_board_quality.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ..ir.circuit_ir import IRCircuit
+from ..ir.from_kicad import parse_schematic
+from ..tools.dfm import _outline_bounds_mm
+from ..tools.pcb import _parse_board_footprint_blocks
+from .evidence_sanitization import validate_sanitized_evidence
+from .task_outcomes import AttemptRecord, parse_attempt_record, parse_benchmark_contract
+
+QUALITY_SCHEMA_VERSION: Literal["pcb-reference-board-quality.v1"] = "pcb-reference-board-quality.v1"
+QUALITY_SCORE_SCHEMA_VERSION: Literal["pcb-reference-board-quality-score.v1"] = (
+    "pcb-reference-board-quality-score.v1"
+)
+RuleType = Literal[
+    "schematic_component",
+    "schematic_net",
+    "pcb_footprint",
+    "pcb_net",
+    "board_outline",
+    "attempt_validation",
+    "artifact",
+]
+RuleStatus = Literal["pass", "fail"]
+
+QualityReasonCode = Literal[
+    "matched",
+    "component_missing",
+    "identity_mismatch",
+    "net_missing",
+    "net_membership_mismatch",
+    "footprint_missing",
+    "outline_missing",
+    "outline_bounds_mismatch",
+    "validation_missing",
+    "validation_failed",
+    "artifact_missing",
+    "artifact_empty",
+    "evidence_missing",
+    "evidence_identity_mismatch",
+]
+
+
+class _QualityModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class _QualityRuleBase(_QualityModel):
+    id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    required: Literal[True] = True
+
+
+class SchematicComponentRule(_QualityRuleBase):
+    type: Literal["schematic_component"]
+    reference: str = Field(min_length=1, max_length=64)
+    allowed_lib_ids: tuple[str, ...] = ()
+    allowed_values: tuple[str, ...] = ()
+    allowed_footprints: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _require_identity_constraint(self) -> SchematicComponentRule:
+        if not (self.allowed_lib_ids or self.allowed_values or self.allowed_footprints):
+            raise ValueError("schematic_component requires an identity constraint")
+        return self
+
+
+class SchematicNetRule(_QualityRuleBase):
+    type: Literal["schematic_net"]
+    net_name: str = Field(min_length=1, max_length=128)
+    required_references: tuple[str, ...] = ()
+
+
+class PcbFootprintRule(_QualityRuleBase):
+    type: Literal["pcb_footprint"]
+    reference: str = Field(min_length=1, max_length=64)
+    allowed_footprints: tuple[str, ...] = Field(min_length=1)
+
+
+class PcbNetRule(_QualityRuleBase):
+    type: Literal["pcb_net"]
+    net_name: str = Field(min_length=1, max_length=128)
+    required_references: tuple[str, ...] = ()
+
+
+class BoardOutlineRule(_QualityRuleBase):
+    type: Literal["board_outline"]
+    min_width_mm: float | None = Field(default=None, gt=0)
+    max_width_mm: float | None = Field(default=None, gt=0)
+    min_height_mm: float | None = Field(default=None, gt=0)
+    max_height_mm: float | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> BoardOutlineRule:
+        if (
+            self.min_width_mm is not None
+            and self.max_width_mm is not None
+            and self.min_width_mm > self.max_width_mm
+        ):
+            raise ValueError("outline width bounds are inverted")
+        if (
+            self.min_height_mm is not None
+            and self.max_height_mm is not None
+            and self.min_height_mm > self.max_height_mm
+        ):
+            raise ValueError("outline height bounds are inverted")
+        return self
+
+
+class AttemptValidationRule(_QualityRuleBase):
+    type: Literal["attempt_validation"]
+    validation_kind: Literal["erc", "drc"]
+
+
+class ArtifactRule(_QualityRuleBase):
+    type: Literal["artifact"]
+    path: str = Field(min_length=1, max_length=256)
+    kind: Literal["file", "directory"]
+
+    @model_validator(mode="after")
+    def _require_relative_path(self) -> ArtifactRule:
+        path = PurePosixPath(self.path)
+        if path.is_absolute() or ".." in path.parts or self.path.startswith(("/", "\\")):
+            raise ValueError("artifact path must be canonical and relative")
+        return self
+
+
+RuleModel = (
+    SchematicComponentRule
+    | SchematicNetRule
+    | PcbFootprintRule
+    | PcbNetRule
+    | BoardOutlineRule
+    | AttemptValidationRule
+    | ArtifactRule
+)
+QualityRule = Annotated[RuleModel, Field(discriminator="type")]
+
+
+class BoardQualityContract(_QualityModel):
+    schema_version: Literal["pcb-reference-board-quality.v1"] = QUALITY_SCHEMA_VERSION
+    board_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    benchmark_version: str = Field(min_length=1, max_length=128)
+    rules: tuple[QualityRule, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _require_unique_rule_ids(self) -> BoardQualityContract:
+        ids = [rule.id for rule in self.rules]
+        if len(ids) != len(set(ids)):
+            raise ValueError("quality rule ids must be unique")
+        return self
+
+
+class QualityRuleResult(_QualityModel):
+    id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    type: RuleType
+    status: RuleStatus
+    reason_code: QualityReasonCode
+
+
+class BoardQualityScore(_QualityModel):
+    schema_version: Literal["pcb-reference-board-quality-score.v1"] = QUALITY_SCORE_SCHEMA_VERSION
+    board_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    benchmark_version: str = Field(min_length=1, max_length=128)
+    attempt_id: str = Field(min_length=1, max_length=128)
+    source_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    required_rule_count: int = Field(ge=1)
+    passed_required_rule_count: int = Field(ge=0)
+    quality_score_percent: float = Field(ge=0.0, le=100.0)
+    overall_pass: bool
+    results: tuple[QualityRuleResult, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_counts(self) -> BoardQualityScore:
+        if self.passed_required_rule_count > self.required_rule_count:
+            raise ValueError("passed required rule count exceeds total")
+        if len(self.results) != self.required_rule_count:
+            raise ValueError("quality result count must match required rule count")
+        passed = sum(item.status == "pass" for item in self.results)
+        if passed != self.passed_required_rule_count:
+            raise ValueError("quality pass count does not match rule results")
+        expected = round((passed / self.required_rule_count) * 100.0, 2)
+        if self.quality_score_percent != expected:
+            raise ValueError("quality score percent does not match rule results")
+        if self.overall_pass != (passed == self.required_rule_count):
+            raise ValueError("overall pass must require every rule to pass")
+        return self
+
+
+def parse_quality_contract(payload: Mapping[str, object]) -> BoardQualityContract:
+    return BoardQualityContract.model_validate(payload)
+
+
+def parse_quality_score(payload: Mapping[str, object]) -> BoardQualityScore:
+    return BoardQualityScore.model_validate(payload)
+
+
+def render_quality_score(score: BoardQualityScore) -> str:
+    payload = score.model_dump(mode="json")
+    validate_sanitized_evidence(payload)
+    return json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+
+
+SchematicRule = SchematicComponentRule | SchematicNetRule
+PcbRule = PcbFootprintRule | PcbNetRule | BoardOutlineRule
+
+
+def _rule_result(
+    rule: RuleModel, status: RuleStatus, reason_code: QualityReasonCode
+) -> QualityRuleResult:
+    return QualityRuleResult(id=rule.id, type=rule.type, status=status, reason_code=reason_code)
+
+
+def evaluate_schematic_rule(rule: SchematicRule, circuit: IRCircuit) -> QualityRuleResult:
+    if isinstance(rule, SchematicComponentRule):
+        component = circuit.components.get(rule.reference)
+        if component is None:
+            return _rule_result(rule, "fail", "component_missing")
+        matches = (
+            (not rule.allowed_lib_ids or component.lib_id in rule.allowed_lib_ids)
+            and (not rule.allowed_values or component.value in rule.allowed_values)
+            and (not rule.allowed_footprints or component.footprint in rule.allowed_footprints)
+        )
+        return (
+            _rule_result(rule, "pass", "matched")
+            if matches
+            else _rule_result(rule, "fail", "identity_mismatch")
+        )
+
+    net = circuit.nets.get(rule.net_name)
+    if net is None:
+        return _rule_result(rule, "fail", "net_missing")
+    connected_references = {reference for reference, _pin in net.connections}
+    if not set(rule.required_references).issubset(connected_references):
+        return _rule_result(rule, "fail", "net_membership_mismatch")
+    return _rule_result(rule, "pass", "matched")
+
+
+def evaluate_pcb_rule(rule: PcbRule, board_text: str) -> QualityRuleResult:
+    if isinstance(rule, BoardOutlineRule):
+        bounds = _outline_bounds_mm(board_text)
+        if bounds is None:
+            return _rule_result(rule, "fail", "outline_missing")
+        min_x, min_y, max_x, max_y = bounds
+        width = max_x - min_x
+        height = max_y - min_y
+        in_bounds = (
+            (rule.min_width_mm is None or width >= rule.min_width_mm)
+            and (rule.max_width_mm is None or width <= rule.max_width_mm)
+            and (rule.min_height_mm is None or height >= rule.min_height_mm)
+            and (rule.max_height_mm is None or height <= rule.max_height_mm)
+        )
+        return (
+            _rule_result(rule, "pass", "matched")
+            if in_bounds
+            else _rule_result(rule, "fail", "outline_bounds_mismatch")
+        )
+
+    footprints = _parse_board_footprint_blocks(board_text)
+    if isinstance(rule, PcbFootprintRule):
+        footprint = footprints.get(rule.reference)
+        if footprint is None:
+            return _rule_result(rule, "fail", "footprint_missing")
+        if footprint["name"] not in rule.allowed_footprints:
+            return _rule_result(rule, "fail", "identity_mismatch")
+        return _rule_result(rule, "pass", "matched")
+
+    references_on_net = {
+        reference
+        for reference, footprint in footprints.items()
+        if rule.net_name in footprint["net_names"]
+    }
+    if not references_on_net:
+        return _rule_result(rule, "fail", "net_missing")
+    if not set(rule.required_references).issubset(references_on_net):
+        return _rule_result(rule, "fail", "net_membership_mismatch")
+    return _rule_result(rule, "pass", "matched")
+
+
+def evaluate_attempt_rule(rule: AttemptValidationRule, attempt: AttemptRecord) -> QualityRuleResult:
+    validation = next(
+        (item for item in attempt.validations if item.kind == rule.validation_kind),
+        None,
+    )
+    if validation is None:
+        return _rule_result(rule, "fail", "validation_missing")
+    passed = (
+        validation.required
+        and validation.execution_completed
+        and validation.result_consumed
+        and validation.disposition in {"resolved", "accepted"}
+    )
+    return (
+        _rule_result(rule, "pass", "matched")
+        if passed
+        else _rule_result(rule, "fail", "validation_failed")
+    )
+
+
+def evaluate_artifact_rule(rule: ArtifactRule, attempt_root: Path) -> QualityRuleResult:
+    root = attempt_root.resolve()
+    relative = Path(*PurePosixPath(rule.path).parts)
+    candidate = root / relative
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return _rule_result(rule, "fail", "artifact_missing")
+    if candidate.is_symlink():
+        return _rule_result(rule, "fail", "artifact_missing")
+    if rule.kind == "file":
+        if not resolved.is_file():
+            return _rule_result(rule, "fail", "artifact_missing")
+        if resolved.stat().st_size == 0:
+            return _rule_result(rule, "fail", "artifact_empty")
+    elif not resolved.is_dir():
+        return _rule_result(rule, "fail", "artifact_missing")
+    elif next(resolved.iterdir(), None) is None:
+        return _rule_result(rule, "fail", "artifact_empty")
+    return _rule_result(rule, "pass", "matched")
+
+
+def _load_json_mapping(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("quality evidence file must contain one JSON object")
+    validate_sanitized_evidence(payload)
+    return payload
+
+
+def _failed_result(rule: RuleModel, reason: QualityReasonCode) -> QualityRuleResult:
+    return _rule_result(rule, "fail", reason)
+
+
+def _build_quality_score(
+    contract: BoardQualityContract,
+    attempt: AttemptRecord,
+    results: list[QualityRuleResult],
+) -> BoardQualityScore:
+    passed = sum(result.status == "pass" for result in results)
+    total = len(results)
+    return BoardQualityScore(
+        board_id=contract.board_id,
+        benchmark_version=contract.benchmark_version,
+        attempt_id=attempt.attempt_id,
+        source_revision=attempt.source_revision,
+        required_rule_count=total,
+        passed_required_rule_count=passed,
+        quality_score_percent=round((passed / total) * 100.0, 2),
+        overall_pass=passed == total,
+        results=tuple(results),
+    )
+
+
+def score_reference_board_attempt(bundle_root: Path, attempt_id: str) -> BoardQualityScore:
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}", attempt_id) is None:
+        raise ValueError("attempt id must be canonical")
+    root = bundle_root.resolve(strict=True)
+    attempt_dir = root / "attempts" / attempt_id
+    attempt = parse_attempt_record(_load_json_mapping(attempt_dir / "attempt.json"))
+    benchmark = parse_benchmark_contract(_load_json_mapping(root / "benchmark.json"))
+    quality = parse_quality_contract(_load_json_mapping(root / "quality-gates.json"))
+
+    identity_matches = (
+        attempt.attempt_id == attempt_id
+        and quality.board_id == root.parent.name
+        and quality.benchmark_version == root.name
+        and attempt.benchmark_id == benchmark.benchmark_id
+        and attempt.benchmark_version == benchmark.benchmark_version
+        and quality.benchmark_version == benchmark.benchmark_version
+    )
+    if not identity_matches:
+        return _build_quality_score(
+            quality,
+            attempt,
+            [_failed_result(rule, "evidence_identity_mismatch") for rule in quality.rules],
+        )
+
+    schematic_path = attempt_dir / "schematic.kicad_sch"
+    board_path = attempt_dir / "board.kicad_pcb"
+    needs_schematic = any(
+        isinstance(rule, (SchematicComponentRule, SchematicNetRule)) for rule in quality.rules
+    )
+    needs_board = any(
+        isinstance(rule, (PcbFootprintRule, PcbNetRule, BoardOutlineRule)) for rule in quality.rules
+    )
+
+    circuit: IRCircuit | None = None
+    if needs_schematic and schematic_path.is_file() and not schematic_path.is_symlink():
+        try:
+            circuit = parse_schematic(schematic_path, load_pin_metadata=False)
+        except (OSError, RuntimeError, ValueError):
+            circuit = None
+
+    board_text: str | None = None
+    if needs_board and board_path.is_file() and not board_path.is_symlink():
+        try:
+            board_text = board_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            board_text = None
+
+    results: list[QualityRuleResult] = []
+    for rule in quality.rules:
+        if isinstance(rule, (SchematicComponentRule, SchematicNetRule)):
+            result = (
+                _failed_result(rule, "evidence_missing")
+                if circuit is None
+                else evaluate_schematic_rule(rule, circuit)
+            )
+        elif isinstance(rule, (PcbFootprintRule, PcbNetRule, BoardOutlineRule)):
+            result = (
+                _failed_result(rule, "evidence_missing")
+                if board_text is None
+                else evaluate_pcb_rule(rule, board_text)
+            )
+        elif isinstance(rule, AttemptValidationRule):
+            result = evaluate_attempt_rule(rule, attempt)
+        else:
+            result = evaluate_artifact_rule(rule, attempt_dir)
+        results.append(result)
+    return _build_quality_score(quality, attempt, results)

--- a/src/kicad_mcp/evals/reference_corpus.py
+++ b/src/kicad_mcp/evals/reference_corpus.py
@@ -12,6 +12,12 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from .evidence_sanitization import validate_sanitized_evidence
+from .reference_board_quality import (
+    BoardQualityContract,
+    parse_quality_contract,
+    parse_quality_score,
+    score_reference_board_attempt,
+)
 from .task_outcome_scoring import (
     TaskOutcomeScoringError,
     TaskOutcomeSummary,
@@ -32,6 +38,8 @@ REFERENCE_IDENTIFIER_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
 SPECIFICATION_FILE = "specification.md"
 ORIGINAL_PROMPT_FILE = "original-prompt.md"
 BENCHMARK_FILE = "benchmark.json"
+QUALITY_GATES_FILE = "quality-gates.json"
+QUALITY_SCORE_FILE = "board-quality-score.json"
 ATTEMPT_MANIFEST_FILE = "attempt-manifest.json"
 ATTEMPT_RECORD_FILE = "attempt.json"
 AGENT_LOG_FILE = "agent-log.jsonl"
@@ -127,7 +135,7 @@ def _sha256_file(path: Path) -> str:
 
 def compute_reference_inputs_digest(root: Path) -> str:
     """Return the deterministic digest for canonical reference-board inputs."""
-    input_files = (SPECIFICATION_FILE, ORIGINAL_PROMPT_FILE, BENCHMARK_FILE)
+    input_files = (SPECIFICATION_FILE, ORIGINAL_PROMPT_FILE, BENCHMARK_FILE, QUALITY_GATES_FILE)
     tree_digest = hashlib.sha256()
     for name in input_files:
         path = root / name
@@ -306,10 +314,10 @@ def _resolve_bundle_root(root: Path) -> Path:
 
 def _load_reference_contracts(
     root: Path,
-) -> tuple[ReferenceBoardManifest, BenchmarkContract]:
+) -> tuple[ReferenceBoardManifest, BenchmarkContract, BoardQualityContract]:
     for name in (SPECIFICATION_FILE, ORIGINAL_PROMPT_FILE):
         _require_sanitized_text_file(root / name, name)
-    for name in (BENCHMARK_FILE, ATTEMPT_MANIFEST_FILE):
+    for name in (BENCHMARK_FILE, QUALITY_GATES_FILE, ATTEMPT_MANIFEST_FILE):
         _require_regular_file(root / name, name)
 
     try:
@@ -319,9 +327,12 @@ def _load_reference_contracts(
         contract = parse_benchmark_contract(
             _read_json_object(root / BENCHMARK_FILE, BENCHMARK_FILE)
         )
+        quality = parse_quality_contract(
+            _read_json_object(root / QUALITY_GATES_FILE, QUALITY_GATES_FILE)
+        )
     except ValidationError as exc:
         raise ReferenceCorpusError(
-            "reference-board manifest or benchmark contract is invalid"
+            "reference-board manifest, benchmark, or quality contract is invalid"
         ) from exc
 
     if (manifest.benchmark_id, manifest.benchmark_version) != (
@@ -331,11 +342,17 @@ def _load_reference_contracts(
         raise ReferenceCorpusError(
             "reference manifest benchmark identity does not match benchmark.json"
         )
+    if (quality.board_id, quality.benchmark_version) != (
+        manifest.board_id,
+        manifest.benchmark_version,
+    ):
+        raise ReferenceCorpusError("quality gate identity does not match reference manifest")
     if compute_reference_inputs_digest(root) != manifest.reference_inputs_digest:
         raise ReferenceCorpusError(
-            "reference input digest does not match specification, prompt, and benchmark"
+            "reference input digest does not match specification, prompt, "
+            "benchmark, and quality gates"
         )
-    return manifest, contract
+    return manifest, contract, quality
 
 
 def _validate_attempt_directory_index(root: Path, manifest: ReferenceBoardManifest) -> None:
@@ -356,10 +373,44 @@ def _validate_attempt_directory_index(root: Path, manifest: ReferenceBoardManife
         raise ReferenceCorpusError("manifest attempt directories do not match filesystem attempts")
 
 
+def _validate_success_quality_score(
+    root: Path,
+    attempt_dir: Path,
+    quality: BoardQualityContract,
+    record: AttemptRecord,
+) -> None:
+    if record.classification != "success":
+        return
+    score_path = attempt_dir / QUALITY_SCORE_FILE
+    _require_regular_file(score_path, QUALITY_SCORE_FILE)
+    try:
+        score = parse_quality_score(_read_json_object(score_path, QUALITY_SCORE_FILE))
+    except ValidationError as exc:
+        raise ReferenceCorpusError("board-quality-score.json is invalid") from exc
+
+    if (score.board_id, score.benchmark_version, score.attempt_id, score.source_revision) != (
+        quality.board_id,
+        quality.benchmark_version,
+        record.attempt_id,
+        record.source_revision,
+    ):
+        raise ReferenceCorpusError("quality score identity does not match attempt evidence")
+    expected_rules = [(rule.id, rule.type) for rule in quality.rules]
+    actual_rules = [(result.id, result.type) for result in score.results]
+    if actual_rules != expected_rules:
+        raise ReferenceCorpusError("quality score rule set does not match quality-gates.json")
+    if not score.overall_pass:
+        raise ReferenceCorpusError("quality score must pass for declared success")
+    recomputed = score_reference_board_attempt(root, record.attempt_id)
+    if score != recomputed:
+        raise ReferenceCorpusError("quality score does not match deterministic scorer output")
+
+
 def _load_reference_attempt(
     root: Path,
     manifest_entry: ReferenceAttemptEntry,
     contract: BenchmarkContract,
+    quality: BoardQualityContract,
 ) -> AttemptRecord:
     attempt_dir = root / manifest_entry.directory
     if attempt_dir.is_symlink() or not attempt_dir.is_dir():
@@ -379,6 +430,7 @@ def _load_reference_attempt(
     _parse_agent_log(attempt_dir / AGENT_LOG_FILE, record.attempt_id)
     _validate_required_validation_evidence(contract, record)
     _validate_success_artifacts(attempt_dir, contract, record)
+    _validate_success_quality_score(root, attempt_dir, quality, record)
     if compute_attempt_evidence_digest(attempt_dir) != manifest_entry.evidence_digest:
         raise ReferenceCorpusError(
             f"attempt {manifest_entry.attempt_id} evidence digest does not match filesystem"
@@ -389,10 +441,10 @@ def _load_reference_attempt(
 def validate_reference_board_bundle(root: Path) -> ValidatedReferenceBoardBundle:
     """Validate one complete reference-board publication bundle fail closed."""
     root = _resolve_bundle_root(root)
-    manifest, contract = _load_reference_contracts(root)
+    manifest, contract, quality = _load_reference_contracts(root)
     _validate_attempt_directory_index(root, manifest)
     records = [
-        _load_reference_attempt(root, manifest_entry, contract)
+        _load_reference_attempt(root, manifest_entry, contract, quality)
         for manifest_entry in manifest.attempts
     ]
 

--- a/tests/unit/test_reference_board_quality.py
+++ b/tests/unit/test_reference_board_quality.py
@@ -393,3 +393,110 @@ def test_committed_reference_board_quality_contracts_are_valid(
     outline = next(rule for rule in contract.rules if isinstance(rule, BoardOutlineRule))
     assert (contract.board_id, contract.benchmark_version) == (board_id, "v1")
     assert (outline.max_width_mm, outline.max_height_mm) == (max_width, max_height)
+
+
+def test_quality_contract_validators_reject_invalid_models() -> None:
+    from kicad_mcp.evals.reference_board_quality import (
+        ArtifactRule,
+        BoardOutlineRule,
+        BoardQualityContract,
+        SchematicComponentRule,
+    )
+
+    with pytest.raises(ValidationError):
+        SchematicComponentRule(id="u1", type="schematic_component", reference="U1")
+    with pytest.raises(ValidationError):
+        BoardOutlineRule(id="width", type="board_outline", min_width_mm=2.0, max_width_mm=1.0)
+    with pytest.raises(ValidationError):
+        BoardOutlineRule(id="height", type="board_outline", min_height_mm=2.0, max_height_mm=1.0)
+    with pytest.raises(ValidationError):
+        ArtifactRule(id="escape", type="artifact", path="../proof.txt", kind="file")
+
+    rule = ArtifactRule(id="proof", type="artifact", path="proof.txt", kind="file")
+    with pytest.raises(ValidationError):
+        BoardQualityContract(board_id="board-a", benchmark_version="v1", rules=(rule, rule))
+
+
+def test_quality_score_validator_rejects_inconsistent_summary_fields() -> None:
+    from kicad_mcp.evals.reference_board_quality import BoardQualityScore
+
+    base = {
+        "board_id": "board-a",
+        "benchmark_version": "v1",
+        "attempt_id": "attempt-001",
+        "source_revision": "a" * 40,
+        "required_rule_count": 2,
+        "passed_required_rule_count": 1,
+        "quality_score_percent": 50.0,
+        "overall_pass": False,
+        "results": [
+            {"id": "a", "type": "artifact", "status": "pass", "reason_code": "matched"},
+            {
+                "id": "b",
+                "type": "artifact",
+                "status": "fail",
+                "reason_code": "artifact_missing",
+            },
+        ],
+    }
+    overrides = (
+        {"passed_required_rule_count": 3},
+        {"required_rule_count": 3},
+        {"passed_required_rule_count": 0},
+        {"quality_score_percent": 49.0},
+        {"overall_pass": True},
+    )
+    for update in overrides:
+        payload = dict(base)
+        payload.update(update)
+        with pytest.raises(ValidationError):
+            BoardQualityScore.model_validate(payload)
+
+
+def test_pcb_rules_fail_closed_on_missing_or_mismatched_evidence() -> None:
+    from kicad_mcp.evals.reference_board_quality import (
+        BoardOutlineRule,
+        PcbFootprintRule,
+        PcbNetRule,
+        evaluate_pcb_rule,
+    )
+
+    root = Path(__file__).parents[1] / "fixtures/benchmark_projects"
+    minimal = (root / "pass_minimal_mcu_board/demo.kicad_pcb").read_text(encoding="utf-8")
+    dirty = (root / "fail_dirty_transfer_wrong_pad_nets/demo.kicad_pcb").read_text(encoding="utf-8")
+    missing_footprint = evaluate_pcb_rule(
+        PcbFootprintRule(
+            id="missing", type="pcb_footprint", reference="Z99", allowed_footprints=("x",)
+        ),
+        minimal,
+    )
+    mismatched_footprint = evaluate_pcb_rule(
+        PcbFootprintRule(
+            id="mismatch", type="pcb_footprint", reference="U1", allowed_footprints=("x",)
+        ),
+        minimal,
+    )
+    missing_net = evaluate_pcb_rule(
+        PcbNetRule(id="missing-net", type="pcb_net", net_name="NO_SUCH_NET"), minimal
+    )
+    mismatched_net = evaluate_pcb_rule(
+        PcbNetRule(id="mismatch-net", type="pcb_net", net_name="VIN", required_references=("Z99",)),
+        dirty,
+    )
+    missing_outline = evaluate_pcb_rule(
+        BoardOutlineRule(id="outline", type="board_outline", max_width_mm=50.0),
+        "(kicad_pcb (version 20240108))",
+    )
+    assert (
+        missing_footprint.reason_code,
+        mismatched_footprint.reason_code,
+        missing_net.reason_code,
+        mismatched_net.reason_code,
+        missing_outline.reason_code,
+    ) == (
+        "footprint_missing",
+        "identity_mismatch",
+        "net_missing",
+        "net_membership_mismatch",
+        "outline_missing",
+    )

--- a/tests/unit/test_reference_board_quality.py
+++ b/tests/unit/test_reference_board_quality.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+
+def _minimal_contract() -> dict[str, object]:
+    return {
+        "schema_version": "pcb-reference-board-quality.v1",
+        "board_id": "esp32-c6-usbc",
+        "benchmark_version": "v1",
+        "rules": [
+            {
+                "id": "component-u1",
+                "type": "schematic_component",
+                "reference": "U1",
+                "allowed_lib_ids": ["RF_Module:ESP32-C6-MINI-1"],
+            }
+        ],
+    }
+
+
+def test_quality_contract_parses_strict_reviewed_rule() -> None:
+    from kicad_mcp.evals.reference_board_quality import parse_quality_contract
+
+    contract = parse_quality_contract(_minimal_contract())
+    assert contract.board_id == "esp32-c6-usbc"
+    assert contract.benchmark_version == "v1"
+    assert contract.rules[0].id == "component-u1"
+    assert contract.rules[0].required is True
+
+
+def test_quality_contract_rejects_unknown_fields_and_rule_types() -> None:
+    from kicad_mcp.evals.reference_board_quality import parse_quality_contract
+
+    payload = _minimal_contract()
+    payload["unexpected"] = True
+    with pytest.raises(ValidationError):
+        parse_quality_contract(payload)
+
+    payload = _minimal_contract()
+    rules = list(payload["rules"])
+    rules[0] = {"id": "bad", "type": "shell_command", "command": "echo nope"}
+    payload["rules"] = rules
+    with pytest.raises(ValidationError):
+        parse_quality_contract(payload)
+
+
+def test_quality_score_render_is_deterministic_and_sanitized() -> None:
+    from kicad_mcp.evals.reference_board_quality import (
+        BoardQualityScore,
+        QualityRuleResult,
+        render_quality_score,
+    )
+
+    score = BoardQualityScore(
+        board_id="esp32-c6-usbc",
+        benchmark_version="v1",
+        attempt_id="attempt-001",
+        source_revision="a" * 40,
+        required_rule_count=2,
+        passed_required_rule_count=1,
+        quality_score_percent=50.0,
+        overall_pass=False,
+        results=(
+            QualityRuleResult(id="a", type="artifact", status="pass", reason_code="matched"),
+            QualityRuleResult(
+                id="b", type="artifact", status="fail", reason_code="artifact_missing"
+            ),
+        ),
+    )
+    rendered = render_quality_score(score)
+    assert rendered == render_quality_score(score)
+    assert json.loads(rendered)["overall_pass"] is False
+    assert "C:\\Users" not in rendered
+
+
+def test_schematic_rules_use_semantic_parser_fixture() -> None:
+    from pathlib import Path
+
+    from kicad_mcp.evals.reference_board_quality import (
+        SchematicComponentRule,
+        SchematicNetRule,
+        evaluate_schematic_rule,
+    )
+    from kicad_mcp.ir.from_kicad import parse_schematic
+
+    path = (
+        Path(__file__).parents[1]
+        / "fixtures/benchmark_projects/fail_sismosmart_like_label_only/demo.kicad_sch"
+    )
+    circuit = parse_schematic(path, load_pin_metadata=False)
+    component = evaluate_schematic_rule(
+        SchematicComponentRule(
+            id="u1",
+            type="schematic_component",
+            reference="U1",
+            allowed_lib_ids=("RF_Module:ESP32-S3-WROOM-1",),
+        ),
+        circuit,
+    )
+    net = evaluate_schematic_rule(
+        SchematicNetRule(id="vbus", type="schematic_net", net_name="VBUS"), circuit
+    )
+    assert (component.status, component.reason_code) == ("pass", "matched")
+    assert (net.status, net.reason_code) == ("pass", "matched")
+
+
+def test_pcb_rules_reuse_existing_footprint_and_outline_parsers() -> None:
+    from pathlib import Path
+
+    from kicad_mcp.evals.reference_board_quality import (
+        BoardOutlineRule,
+        PcbFootprintRule,
+        PcbNetRule,
+        evaluate_pcb_rule,
+    )
+
+    root = Path(__file__).parents[1] / "fixtures/benchmark_projects"
+    minimal = (root / "pass_minimal_mcu_board/demo.kicad_pcb").read_text(encoding="utf-8")
+    footprint = evaluate_pcb_rule(
+        PcbFootprintRule(
+            id="u1",
+            type="pcb_footprint",
+            reference="U1",
+            allowed_footprints=("Package_QFP:TQFP-48",),
+        ),
+        minimal,
+    )
+    outline = evaluate_pcb_rule(
+        BoardOutlineRule(
+            id="outline",
+            type="board_outline",
+            min_width_mm=29.0,
+            max_width_mm=31.0,
+            min_height_mm=19.0,
+            max_height_mm=21.0,
+        ),
+        minimal,
+    )
+    dirty = (root / "fail_dirty_transfer_wrong_pad_nets/demo.kicad_pcb").read_text(encoding="utf-8")
+    net = evaluate_pcb_rule(
+        PcbNetRule(id="vin", type="pcb_net", net_name="VIN", required_references=("R1",)),
+        dirty,
+    )
+    assert (footprint.status, outline.status, net.status) == ("pass", "pass", "pass")
+
+
+def _quality_attempt():
+    from kicad_mcp.evals.task_outcomes import (
+        AttemptRecord,
+        StageEvidence,
+        TimingEvidence,
+        ValidationEvidence,
+    )
+
+    return AttemptRecord(
+        attempt_id="attempt-001",
+        task_id="board-v1",
+        task_class="pcb-authoring",
+        task_contract_version="v1",
+        benchmark_id="pcb-reference-suite",
+        benchmark_version="v1",
+        source_revision="a" * 40,
+        kicad_version="10.0.6",
+        toolchain_contract="toolchain-v1",
+        mcp_profile="pcb_layout",
+        operating_mode="write",
+        starting_state_digest="sha256:" + "b" * 64,
+        timing=TimingEvidence(
+            started_at="2026-09-04T00:00:00+03:00", ended_at="2026-09-04T00:01:00+03:00"
+        ),
+        classification="success",
+        retry_count=0,
+        start_state="clean",
+        manual_repair=False,
+        stages=(StageEvidence(stage="drc", outcome="passed"),),
+        validations=(
+            ValidationEvidence(
+                kind="drc",
+                required=True,
+                execution_attempted=True,
+                execution_completed=True,
+                result_consumed=True,
+                disposition="resolved",
+            ),
+        ),
+    )
+
+
+def test_attempt_validation_rule_uses_canonical_attempt_evidence() -> None:
+    from kicad_mcp.evals.reference_board_quality import AttemptValidationRule, evaluate_attempt_rule
+
+    attempt = _quality_attempt()
+    passed = evaluate_attempt_rule(
+        AttemptValidationRule(id="drc", type="attempt_validation", validation_kind="drc"), attempt
+    )
+    failed = evaluate_attempt_rule(
+        AttemptValidationRule(id="erc", type="attempt_validation", validation_kind="erc"), attempt
+    )
+    assert (passed.status, passed.reason_code) == ("pass", "matched")
+    assert (failed.status, failed.reason_code) == ("fail", "validation_missing")
+
+
+def test_artifact_rule_requires_nonempty_regular_artifact(tmp_path) -> None:
+    from kicad_mcp.evals.reference_board_quality import ArtifactRule, evaluate_artifact_rule
+
+    (tmp_path / "report.txt").write_text("ok", encoding="utf-8")
+    (tmp_path / "empty.txt").write_text("", encoding="utf-8")
+    (tmp_path / "plots").mkdir()
+    assert (
+        evaluate_artifact_rule(
+            ArtifactRule(id="report", type="artifact", path="report.txt", kind="file"), tmp_path
+        ).status
+        == "pass"
+    )
+    empty = evaluate_artifact_rule(
+        ArtifactRule(id="empty", type="artifact", path="empty.txt", kind="file"), tmp_path
+    )
+    missing = evaluate_artifact_rule(
+        ArtifactRule(id="missing", type="artifact", path="missing.txt", kind="file"), tmp_path
+    )
+    empty_directory = evaluate_artifact_rule(
+        ArtifactRule(id="plots", type="artifact", path="plots", kind="directory"), tmp_path
+    )
+    (tmp_path / "plots" / "summary.json").write_text("{}", encoding="utf-8")
+    directory = evaluate_artifact_rule(
+        ArtifactRule(id="plots", type="artifact", path="plots", kind="directory"), tmp_path
+    )
+    assert (
+        empty.reason_code,
+        missing.reason_code,
+        empty_directory.reason_code,
+        directory.status,
+    ) == ("artifact_empty", "artifact_missing", "artifact_empty", "pass")
+
+
+def _write_scoring_bundle(tmp_path, *, board_id: str = "board-a", rules: list[dict[str, object]]):
+    import kicad_mcp.evals as evals
+
+    root = tmp_path / "board-a" / "v1"
+    attempt_dir = root / "attempts" / "attempt-001"
+    attempt_dir.mkdir(parents=True)
+    requirements = {stage: "not_applicable" for stage in evals.ALL_TASK_STAGES}
+    requirements["drc"] = "required"
+    contract = evals.BenchmarkContract(
+        benchmark_id="pcb-reference-suite",
+        benchmark_version="v1",
+        tasks=(
+            evals.TaskContract(
+                task_id="board-v1",
+                task_class="pcb-authoring",
+                version="v1",
+                stage_requirements=requirements,
+            ),
+        ),
+        evidence_sufficiency=evals.EvidenceSufficiencyContract(
+            minimum_valid_attempts=1,
+            minimum_valid_attempts_by_task_class={"pcb-authoring": 1},
+            minimum_recovery_required_mutations=0,
+            minimum_drc_required_tasks=1,
+            minimum_manufacturing_release_tasks=0,
+        ),
+    )
+    (root / "benchmark.json").write_text(
+        evals.render_benchmark_contract(contract), encoding="utf-8"
+    )
+    (attempt_dir / "attempt.json").write_text(
+        evals.render_attempt_record(_quality_attempt()), encoding="utf-8"
+    )
+    (root / "quality-gates.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "pcb-reference-board-quality.v1",
+                "board_id": board_id,
+                "benchmark_version": "v1",
+                "rules": rules,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root, attempt_dir
+
+
+def test_score_reference_board_attempt_fails_closed_on_identity_mismatch(tmp_path) -> None:
+    from kicad_mcp.evals.reference_board_quality import score_reference_board_attempt
+
+    root, attempt_dir = _write_scoring_bundle(
+        tmp_path,
+        board_id="wrong-board",
+        rules=[{"id": "proof", "type": "artifact", "path": "proof.txt", "kind": "file"}],
+    )
+    (attempt_dir / "proof.txt").write_text("ok", encoding="utf-8")
+    score = score_reference_board_attempt(root, "attempt-001")
+    assert score.overall_pass is False
+    assert score.results[0].reason_code == "evidence_identity_mismatch"
+
+
+def test_score_reference_board_attempt_reports_missing_design_evidence(tmp_path) -> None:
+    from kicad_mcp.evals.reference_board_quality import score_reference_board_attempt
+
+    root, _attempt_dir = _write_scoring_bundle(
+        tmp_path,
+        rules=[
+            {
+                "id": "u1",
+                "type": "schematic_component",
+                "reference": "U1",
+                "allowed_lib_ids": ["RF_Module:ESP32-C6-MINI-1"],
+            }
+        ],
+    )
+    score = score_reference_board_attempt(root, "attempt-001")
+    assert score.overall_pass is False
+    assert score.results[0].reason_code == "evidence_missing"
+
+
+def test_score_reference_board_attempt_requires_every_required_rule(tmp_path) -> None:
+    from kicad_mcp.evals.reference_board_quality import score_reference_board_attempt
+
+    root, attempt_dir = _write_scoring_bundle(
+        tmp_path,
+        rules=[
+            {"id": "present", "type": "artifact", "path": "present.txt", "kind": "file"},
+            {"id": "missing", "type": "artifact", "path": "missing.txt", "kind": "file"},
+        ],
+    )
+    (attempt_dir / "present.txt").write_text("ok", encoding="utf-8")
+    score = score_reference_board_attempt(root, "attempt-001")
+    assert score.overall_pass is False
+    assert score.passed_required_rule_count == 1
+    assert score.required_rule_count == 2
+    assert score.quality_score_percent == 50.0
+
+
+def test_score_reference_board_cli_writes_only_canonical_report(tmp_path) -> None:
+    import subprocess
+    import sys
+
+    root, attempt_dir = _write_scoring_bundle(
+        tmp_path,
+        rules=[{"id": "proof", "type": "artifact", "path": "proof.txt", "kind": "file"}],
+    )
+    (attempt_dir / "proof.txt").write_text("ok", encoding="utf-8")
+    repo_root = Path(__file__).parents[2]
+    command = [
+        sys.executable,
+        str(repo_root / "scripts/score_reference_board_attempt.py"),
+        str(root),
+        "attempt-001",
+    ]
+    passed = subprocess.run(command, cwd=repo_root, check=False, capture_output=True, text=True)
+    output = attempt_dir / "board-quality-score.json"
+    assert passed.returncode == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["overall_pass"] is True
+
+    (attempt_dir / "proof.txt").unlink()
+    failed = subprocess.run(command, cwd=repo_root, check=False, capture_output=True, text=True)
+    assert failed.returncode == 1
+    assert json.loads(output.read_text(encoding="utf-8"))["overall_pass"] is False
+
+
+def test_score_reference_board_attempt_rejects_noncanonical_attempt_id(tmp_path) -> None:
+    from kicad_mcp.evals.reference_board_quality import score_reference_board_attempt
+
+    root, _attempt_dir = _write_scoring_bundle(
+        tmp_path,
+        rules=[{"id": "proof", "type": "artifact", "path": "proof.txt", "kind": "file"}],
+    )
+    with pytest.raises(ValueError, match="attempt id"):
+        score_reference_board_attempt(root, "../attempt-001")
+
+
+@pytest.mark.parametrize(
+    ("board_id", "max_width", "max_height"),
+    [
+        ("esp32-c6-usbc", 50.0, 32.0),
+        ("stm32f072-usbc", 60.0, 36.0),
+        ("rp2350-usbc", 58.0, 34.0),
+    ],
+)
+def test_committed_reference_board_quality_contracts_are_valid(
+    board_id: str, max_width: float, max_height: float
+) -> None:
+    from kicad_mcp.evals.reference_board_quality import BoardOutlineRule, parse_quality_contract
+
+    root = Path(__file__).parents[2] / "docs" / "evidence" / "reference-boards" / board_id / "v1"
+    payload = json.loads((root / "quality-gates.json").read_text(encoding="utf-8"))
+    contract = parse_quality_contract(payload)
+    outline = next(rule for rule in contract.rules if isinstance(rule, BoardOutlineRule))
+    assert (contract.board_id, contract.benchmark_version) == (board_id, "v1")
+    assert (outline.max_width_mm, outline.max_height_mm) == (max_width, max_height)

--- a/tests/unit/test_reference_corpus.py
+++ b/tests/unit/test_reference_corpus.py
@@ -259,13 +259,24 @@ def _write_success_artifacts(attempt_dir: Path) -> None:
 
 
 def _write_bundle(tmp_path: Path, attempt_payload: dict[str, Any] | None = None) -> Path:
-    root = tmp_path / "reference-board"
-    root.mkdir()
+    root = tmp_path / "stm32-usbc-reference" / "v1"
+    root.mkdir(parents=True)
     (root / "specification.md").write_text("# Fixture specification\n", encoding="utf-8")
     (root / "original-prompt.md").write_text("Create the fixture board.\n", encoding="utf-8")
     contract = evals.BenchmarkContract.model_validate(_benchmark_payload())
     (root / "benchmark.json").write_text(
         evals.render_benchmark_contract(contract), encoding="utf-8"
+    )
+    (root / "quality-gates.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "pcb-reference-board-quality.v1",
+                "board_id": "stm32-usbc-reference",
+                "benchmark_version": "v1",
+                "rules": [{"id": "bom", "type": "artifact", "path": "BOM.csv", "kind": "file"}],
+            }
+        ),
+        encoding="utf-8",
     )
     attempt_dir = root / "attempts" / "attempt-001"
     attempt_dir.mkdir(parents=True)
@@ -273,6 +284,16 @@ def _write_bundle(tmp_path: Path, attempt_payload: dict[str, Any] | None = None)
     (attempt_dir / "attempt.json").write_text(evals.render_attempt_record(record), encoding="utf-8")
     _write_agent_log(attempt_dir / "agent-log.jsonl")
     _write_success_artifacts(attempt_dir)
+    from kicad_mcp.evals.reference_board_quality import (
+        render_quality_score,
+        score_reference_board_attempt,
+    )
+
+    if record.attempt_id == attempt_dir.name:
+        quality_score = score_reference_board_attempt(root, record.attempt_id)
+        (attempt_dir / "board-quality-score.json").write_text(
+            render_quality_score(quality_score), encoding="utf-8"
+        )
     evidence_digest = evals.compute_attempt_evidence_digest(attempt_dir)
     reference_inputs_digest = evals.compute_reference_inputs_digest(root)
     manifest = evals.ReferenceBoardManifest.model_validate(
@@ -283,6 +304,14 @@ def _write_bundle(tmp_path: Path, attempt_payload: dict[str, Any] | None = None)
         encoding="utf-8",
     )
     return root
+
+
+def _refresh_attempt_evidence_digest(root: Path) -> None:
+    manifest_path = root / "attempt-manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    attempt_dir = root / "attempts" / "attempt-001"
+    payload["attempts"][0]["evidence_digest"] = evals.compute_attempt_evidence_digest(attempt_dir)
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def test_reference_bundle_rejects_unsafe_original_prompt_text(tmp_path: Path) -> None:
@@ -631,3 +660,60 @@ def test_reference_bundle_cli_fails_closed_without_dumping_agent_log(
     assert "reference corpus validation failed" in captured.err
     assert log_text not in captured.err
     assert captured.out == ""
+
+
+def test_reference_bundle_success_requires_quality_score(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path)
+    score = root / "attempts" / "attempt-001" / "board-quality-score.json"
+    score.unlink()
+    _refresh_attempt_evidence_digest(root)
+
+    with pytest.raises(evals.ReferenceCorpusError, match="board-quality-score.json"):
+        evals.validate_reference_board_bundle(root)
+
+
+def test_reference_bundle_success_requires_passing_quality_score(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path)
+    score = root / "attempts" / "attempt-001" / "board-quality-score.json"
+    payload = json.loads(score.read_text(encoding="utf-8"))
+    payload["passed_required_rule_count"] = 0
+    payload["quality_score_percent"] = 0.0
+    payload["overall_pass"] = False
+    payload["results"][0]["status"] = "fail"
+    payload["results"][0]["reason_code"] = "artifact_missing"
+    score.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_attempt_evidence_digest(root)
+
+    with pytest.raises(evals.ReferenceCorpusError, match="quality score.*pass"):
+        evals.validate_reference_board_bundle(root)
+
+
+def test_reference_bundle_quality_gate_contract_is_reference_input(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path)
+    quality_path = root / "quality-gates.json"
+    payload = json.loads(quality_path.read_text(encoding="utf-8"))
+    payload["rules"][0]["path"] = "manufacturing-report.md"
+    quality_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(evals.ReferenceCorpusError, match="reference input digest"):
+        evals.validate_reference_board_bundle(root)
+
+
+def test_reference_bundle_rejects_forged_passing_quality_report(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path)
+    quality_path = root / "quality-gates.json"
+    quality = json.loads(quality_path.read_text(encoding="utf-8"))
+    quality["rules"][0]["path"] = "missing-quality-proof.txt"
+    quality_path.write_text(json.dumps(quality), encoding="utf-8")
+
+    manifest_path = root / "attempt-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["reference_inputs_digest"] = evals.compute_reference_inputs_digest(root)
+    attempt_dir = root / "attempts" / "attempt-001"
+    manifest["attempts"][0]["evidence_digest"] = evals.compute_attempt_evidence_digest(
+        attempt_dir
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(evals.ReferenceCorpusError, match="deterministic scorer"):
+        evals.validate_reference_board_bundle(root)

--- a/tests/unit/test_reference_corpus.py
+++ b/tests/unit/test_reference_corpus.py
@@ -710,9 +710,7 @@ def test_reference_bundle_rejects_forged_passing_quality_report(tmp_path: Path) 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["reference_inputs_digest"] = evals.compute_reference_inputs_digest(root)
     attempt_dir = root / "attempts" / "attempt-001"
-    manifest["attempts"][0]["evidence_digest"] = evals.compute_attempt_evidence_digest(
-        attempt_dir
-    )
+    manifest["attempts"][0]["evidence_digest"] = evals.compute_attempt_evidence_digest(attempt_dir)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(evals.ReferenceCorpusError, match="deterministic scorer"):


### PR DESCRIPTION
﻿## Summary

- add a strict `pcb-reference-board-quality.v1` contract and deterministic per-attempt scorer
- reuse maintained schematic/PCB parsers for component, net, footprint, and outline checks
- add ERC/DRC and artifact quality rules plus a canonical scoring CLI
- require successful reference-corpus attempts to publish a matching, passing `board-quality-score.json`
- recompute stored quality reports during publication validation to reject forged/stale passing reports
- include `quality-gates.json` in the reference-input digest and quality reports in attempt evidence
- add reviewed v1 quality contracts for ESP32-C6 USB-C, STM32F072 USB-C/RS-485, and RP2350 USB-C

The three v1 contracts intentionally encode only objective requirements already present in the written specifications. They do not invent reference designators/net names and do not claim SI/PI/EMC sign-off.

Progresses #730. This does **not** close #730: the real autonomous attempt corpus, full manufacturing evidence, independent reruns, and published benchmark results remain follow-up work.

## Verification

- Ruff: pass
- strict mypy on scorer/publication/CLI: pass
- focused scorer + reference-corpus + task-outcome suite: 120 passed locally
- architecture boundary checker: pass
- `git diff main...HEAD --check`: pass
- gitleaks: no leaks found

### Local Windows note

Three existing corpus tests that create symlinks were excluded locally because this Windows host lacks symlink creation privilege (`WinError 1314`). The fail-closed symlink validation code remains covered by the existing tests and should run in CI/on a host with symlink support.

The local venv also warns that its configured KiCad 11 CLI path is absent; the semantic parser/scorer tests pass and this PR does not depend on invoking KiCad export commands.
