### PR TITLE
test: specify assign footprint eval contract

### DIFF
--- a/evals/tool_selection/cases.yaml
+++ b/evals/tool_selection/cases.yaml
@@ -645,7 +645,7 @@ cases:
   category: mutation
   safety: write
   expected_behavior: tool_calls
-  prompt: Assign the specified 0603 footprint to R1.
+  prompt: Assign the Resistor_SMD:R_0603_1608Metric footprint to R1.
   expected_tools:
   - lib_assign_footprint
   max_calls: 2

--- a/tests/unit/test_tool_selection_eval.py
+++ b/tests/unit/test_tool_selection_eval.py
@@ -148,3 +148,12 @@ def test_load_cases_requires_tool_list_items_to_be_strings(tmp_path: Path) -> No
 
     with pytest.raises(EvalDatasetError, match="forbidden_tools.*string"):
         load_cases(bad)
+
+
+def test_assign_footprint_case_supplies_required_tool_arguments() -> None:
+    cases = {case.id: case for case in load_cases(CASES_PATH)}
+    prompt = cases["assign_footprint"].prompt
+
+    assert "R1" in prompt
+    assert "Resistor_SMD" in prompt
+    assert "R_0603_1608Metric" in prompt


### PR DESCRIPTION
## Summary
- make the `assign_footprint` golden case provide the concrete `Resistor_SMD:R_0603_1608Metric` value required by `lib_assign_footprint(reference, library, footprint)`
- add a regression test that fails when the case omits the required footprint library/name

## Evidence
- TDD RED confirmed on exact base `cbe9213809dbc081a4046a8f88f712f61bfcdd87`: regression test fails against `Assign the specified 0603 footprint to R1.`
- GREEN confirmed after the one-line prompt correction
- focused eval/release suites: 190 tests passed
- progressive-disclosure profile snapshot OK
- toolsets.json OK
- tool contract lint passed
- `git diff --check` passed
- fresh OSV scan on canonical MSI reported only the documented Tauri/GTK3/rust-unic RustSec set; `GHSA-wrw7-89jp-8q8g` is the alias of `RUSTSEC-2024-0429`, no genuinely new advisory observed

## Release safety
This PR does not weaken thresholds, repeats, retries, safety gates, or baseline policy. Historical live-model evidence from source `2b18ef...` must not be reused to approve current main. Do not rerun the full protected multi-hour gate until this deterministic fix lands and current-main evidence recovery is justified.