### PR TITLE
ci: preserve bounded live gate completion

### DIFF
--- a/.github/workflows/live-model-release-gate.yml
+++ b/.github/workflows/live-model-release-gate.yml
@@ -147,7 +147,7 @@ jobs:
   benchmark:
     needs: smoke
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 240
     environment: live-model-evals
     strategy:
       fail-fast: false
@@ -207,29 +207,32 @@ jobs:
           )
           PY
           set +e
-          uv run --all-extras python scripts/run_live_model_eval.py \
-            --config evals/live/configurations.yaml \
-            --configuration "$CONFIGURATION_ID" \
-            --repeats "$REPEATS" \
-            --source-revision "$GITHUB_SHA" \
-            --output artifacts/live-model-eval/evidence.json
+          timeout --signal=TERM --kill-after=30s 225m \
+            uv run --all-extras python scripts/run_live_model_eval.py \
+              --config evals/live/configurations.yaml \
+              --configuration "$CONFIGURATION_ID" \
+              --repeats "$REPEATS" \
+              --source-revision "$GITHUB_SHA" \
+              --output artifacts/live-model-eval/evidence.json
           exit_code=$?
           set -e
           python - "$CONFIGURATION_ID" "$exit_code" <<'PY'
           import json
           import pathlib
           import sys
-          pathlib.Path("artifacts/live-model-eval/status.json").write_text(
-              json.dumps(
-                  {
-                      "configuration_id": sys.argv[1],
-                      "state": "completed",
-                      "runner_exit_code": int(sys.argv[2]),
-                  },
-                  sort_keys=True,
-              ) + "\n",
-              encoding="utf-8",
-          )
+          exit_code = int(sys.argv[2])
+          if exit_code not in (124, 137):
+              pathlib.Path("artifacts/live-model-eval/status.json").write_text(
+                  json.dumps(
+                      {
+                          "configuration_id": sys.argv[1],
+                          "state": "completed",
+                          "runner_exit_code": exit_code,
+                      },
+                      sort_keys=True,
+                  ) + "\n",
+                  encoding="utf-8",
+              )
           PY
       - name: Upload sanitized configuration evidence
         if: always()

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -407,7 +407,11 @@ def test_release_gate_workflow_is_main_only_protected_and_sequential() -> None:
     assert "live-model-smoke-${{ matrix.configuration }}-${{ github.run_id }}" in workflow
     assert "name: Enforce smoke result" in workflow
     assert "needs: smoke" in workflow
-    assert "timeout-minutes: 180" in workflow
+    # Slow blocking providers must have enough bounded wall-clock budget to finish
+    # all three repeats while still leaving time to upload fail-closed evidence.
+    assert "timeout-minutes: 240" in benchmark_block
+    assert "timeout --signal=TERM --kill-after=30s 225m" in benchmark_block
+    assert "if exit_code not in (124, 137):" in benchmark_block
     assert '"state": "running"' in workflow
     assert '"runner_exit_code": None' in workflow
     assert "Upload sanitized configuration evidence\n        if: always()" in workflow


### PR DESCRIPTION
## Summary
- increase the protected full-benchmark job wall-clock budget from 180 to 240 minutes after the Nemotron Ultra job was cancelled twice at the 3-hour boundary
- bound the evaluator itself to 225 minutes, leaving 15 minutes for sanitized artifact upload and aggregate handling
- preserve fail-closed semantics by leaving status as `running` on timeout/kill instead of marking incomplete evidence completed
- add regression assertions before the workflow change (RED -> GREEN)

## Evidence
- source/base: `abbced9e66e52feabc975c822b436e1a2569f726`
- protected run `34095531766` attempt 1 and bounded rerun attempt 2 both cancelled the same Nemotron Ultra benchmark at the 180-minute job boundary; no third blind rerun was started
- focused workflow/release tests: 51 passed
- `git diff --check`: pass
- fresh canonical-MSI OSV Scanner 2.4.0 on exact base reports the unchanged documented Tauri/GTK3/rust-unic advisory set; no genuinely new advisory

This does not change release thresholds, repeats, retries, model configurations, safety gates, redaction, completeness requirements, or baseline approval policy.