### PR TITLE
fix(discovery): reject ephemeral AppImage mount paths for kicad-cli

### DIFF
--- a/src/kicad_mcp/discovery.py
+++ b/src/kicad_mcp/discovery.py
@@ -97,6 +97,18 @@ def _candidate_cli_paths() -> list[Path]:
     ]
 
 
+# Prefixes under which a reported kicad-cli lives only for the lifetime of the
+# process that mounted it. An AppImage mounts itself at /tmp/.mount_<random>/ (or
+# under $XDG_RUNTIME_DIR) and unmounts on exit, so a path discovered there passes
+# exists() while KiCad is open and is dead the moment it closes.
+_EPHEMERAL_CLI_PREFIXES = ("/tmp/.mount_", "/run/user/")  # noqa: S108 - matched, never created
+
+
+def _is_ephemeral_cli_path(cli: Path) -> bool:
+    """Report whether ``cli`` lives under a mount that disappears with its owner."""
+    return str(cli).startswith(_EPHEMERAL_CLI_PREFIXES)
+
+
 def _discover_via_kipy() -> Path | None:
     try:
         from kipy.kicad import KiCad
@@ -111,7 +123,14 @@ def _discover_via_kipy() -> Path | None:
         else:
             kicad = KiCad(timeout_ms=1000)
         cli = Path(kicad.get_kicad_binary_path("kicad-cli"))
-        return cli if cli.exists() else None
+        if not cli.exists():
+            return None
+        if _is_ephemeral_cli_path(cli):
+            # Fall through to PATH/candidate discovery rather than caching a path
+            # that stops resolving as soon as the running KiCad exits.
+            logger.debug("kipy_cli_discovery_ephemeral", path=str(cli))
+            return None
+        return cli
     except Exception as exc:
         logger.debug("kipy_cli_discovery_failed", error=str(exc))
         return None

--- a/src/kicad_mcp/discovery.py
+++ b/src/kicad_mcp/discovery.py
@@ -106,7 +106,10 @@ _EPHEMERAL_CLI_PREFIXES = ("/tmp/.mount_", "/run/user/")  # noqa: S108 - matched
 
 def _is_ephemeral_cli_path(cli: Path) -> bool:
     """Report whether ``cli`` lives under a mount that disappears with its owner."""
-    return str(cli).startswith(_EPHEMERAL_CLI_PREFIXES)
+    # These prefixes are POSIX paths; compare against the POSIX form so a
+    # WindowsPath (backslash-separated str()) still matches when kipy reports
+    # a path that was captured on a POSIX host.
+    return cli.as_posix().startswith(_EPHEMERAL_CLI_PREFIXES)
 
 
 def _discover_via_kipy() -> Path | None:

--- a/tests/unit/test_discovery_additional.py
+++ b/tests/unit/test_discovery_additional.py
@@ -138,3 +138,69 @@ def test_get_cli_capabilities_and_recent_projects_cover_fallbacks(
         "pcb": None,
         "schematic": None,
     }
+
+
+def _fake_kipy(monkeypatch, reported_path: Path) -> None:
+    """Install a fake kipy that reports ``reported_path`` as the kicad-cli location."""
+    fake_pkg = types.ModuleType("kipy")
+    fake_module = types.ModuleType("kipy.kicad")
+
+    class FakeKiCad:
+        def __init__(self, timeout_ms: int = 0) -> None:
+            self.timeout_ms = timeout_ms
+
+        def get_kicad_binary_path(self, name: str) -> str:
+            return str(reported_path)
+
+        def close(self) -> None:
+            return None
+
+    fake_module.KiCad = FakeKiCad  # type: ignore[attr-defined]
+    fake_pkg.kicad = fake_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kipy", fake_pkg)
+    monkeypatch.setitem(sys.modules, "kipy.kicad", fake_module)
+
+
+def test_is_ephemeral_cli_path_flags_appimage_mounts(tmp_path: Path) -> None:
+    ephemeral = "/tmp/.mount_kicadAbC123/usr/bin/kicad-cli"  # noqa: S108 - test data, not created
+    assert discovery._is_ephemeral_cli_path(Path(ephemeral))
+    assert discovery._is_ephemeral_cli_path(Path("/run/user/1000/.mount_x/usr/bin/kicad-cli"))
+    assert not discovery._is_ephemeral_cli_path(Path("/usr/bin/kicad-cli"))
+    assert not discovery._is_ephemeral_cli_path(tmp_path / "kicad-cli")
+
+
+def test_discover_via_kipy_rejects_ephemeral_appimage_mount(monkeypatch, tmp_path: Path) -> None:
+    """A running AppImage reports its own FUSE mount, which dies when KiCad exits."""
+    mount = tmp_path / ".mount_kicadZz9" / "usr" / "bin"
+    mount.mkdir(parents=True)
+    cli = mount / "kicad-cli"
+    cli.write_text("", encoding="utf-8")
+
+    _fake_kipy(monkeypatch, cli)
+    monkeypatch.setattr(discovery, "_EPHEMERAL_CLI_PREFIXES", (str(tmp_path),))
+
+    debug_events: list[str] = []
+    monkeypatch.setattr(discovery.logger, "debug", lambda event, **kw: debug_events.append(event))
+
+    assert discovery._discover_via_kipy() is None
+    assert "kipy_cli_discovery_ephemeral" in debug_events
+
+
+def test_discover_kicad_cli_falls_through_to_path_when_kipy_is_ephemeral(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The stable kicad-cli on PATH must win over a path inside a transient mount."""
+    stable = tmp_path / "stable" / "kicad-cli"
+    stable.parent.mkdir(parents=True)
+    stable.write_text("", encoding="utf-8")
+
+    mount = tmp_path / ".mount_kicadZz9" / "usr" / "bin"
+    mount.mkdir(parents=True)
+    ephemeral = mount / "kicad-cli"
+    ephemeral.write_text("", encoding="utf-8")
+
+    _fake_kipy(monkeypatch, ephemeral)
+    monkeypatch.setattr(discovery, "_EPHEMERAL_CLI_PREFIXES", (str(mount.parent),))
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: str(stable))
+
+    assert discovery.discover_kicad_cli() == stable

--- a/tests/unit/test_discovery_additional.py
+++ b/tests/unit/test_discovery_additional.py
@@ -161,6 +161,15 @@ def _fake_kipy(monkeypatch, reported_path: Path) -> None:
     monkeypatch.setitem(sys.modules, "kipy.kicad", fake_module)
 
 
+def test_discover_via_kipy_returns_none_when_reported_cli_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A kipy-reported path that no longer exists (stale cache, closed KiCad) is rejected."""
+    missing = tmp_path / "kicad-cli"
+    _fake_kipy(monkeypatch, missing)
+    assert discovery._discover_via_kipy() is None
+
+
 def test_is_ephemeral_cli_path_flags_appimage_mounts(tmp_path: Path) -> None:
     ephemeral = "/tmp/.mount_kicadAbC123/usr/bin/kicad-cli"  # noqa: S108 - test data, not created
     assert discovery._is_ephemeral_cli_path(Path(ephemeral))

--- a/tests/unit/test_discovery_additional.py
+++ b/tests/unit/test_discovery_additional.py
@@ -186,7 +186,7 @@ def test_discover_via_kipy_rejects_ephemeral_appimage_mount(monkeypatch, tmp_pat
     cli.write_text("", encoding="utf-8")
 
     _fake_kipy(monkeypatch, cli)
-    monkeypatch.setattr(discovery, "_EPHEMERAL_CLI_PREFIXES", (str(tmp_path),))
+    monkeypatch.setattr(discovery, "_EPHEMERAL_CLI_PREFIXES", (tmp_path.as_posix(),))
 
     debug_events: list[str] = []
     monkeypatch.setattr(discovery.logger, "debug", lambda event, **kw: debug_events.append(event))
@@ -209,7 +209,7 @@ def test_discover_kicad_cli_falls_through_to_path_when_kipy_is_ephemeral(
     ephemeral.write_text("", encoding="utf-8")
 
     _fake_kipy(monkeypatch, ephemeral)
-    monkeypatch.setattr(discovery, "_EPHEMERAL_CLI_PREFIXES", (str(mount.parent),))
+    monkeypatch.setattr(discovery, "_EPHEMERAL_CLI_PREFIXES", (mount.parent.as_posix(),))
     monkeypatch.setattr(discovery.shutil, "which", lambda name: str(stable))
 
     assert discovery.discover_kicad_cli() == stable


### PR DESCRIPTION
Fixes #863.

## Problem

`_discover_via_kipy()` asks the **running** KiCad for its own binary path over IPC. An AppImage answers with a path inside its own FUSE mount — `/tmp/.mount_<random>/usr/bin/kicad-cli` — which is created on launch and destroyed on exit, with a fresh random suffix each time.

The only validation was `cli.exists()`, which is true while KiCad is open. So discovery succeeded, the value looked correct, and every `kicad-cli`-backed tool broke the moment the user closed KiCad. Because `discover_kicad_cli()` returns the kipy result unconditionally, a perfectly good stable `kicad-cli` on `PATH` was never consulted.

The failure is awkward to diagnose because it cannot reproduce while KiCad is running, which is exactly when someone would try.

## Change

- Add `_EPHEMERAL_CLI_PREFIXES` and `_is_ephemeral_cli_path()` to `discovery.py`.
- `_discover_via_kipy()` now returns `None` for a path under such a prefix, so the existing `PATH` and candidate-path fallbacks get their turn, and logs `kipy_cli_discovery_ephemeral` so the operator's next question ("then which one *is* it using?") is answerable.

Deliberately narrow: it only declines to *cache* a transient path. It does not change the ordering of the fallbacks, touch the adapter seam, or affect hosts where kipy reports a stable path.

## Tests

Three new tests in `tests/unit/test_discovery_additional.py`, added before the production change per `AGENTS.md` working rule 3:

- `test_is_ephemeral_cli_path_flags_appimage_mounts` — the predicate itself.
- `test_discover_via_kipy_rejects_ephemeral_appimage_mount` — a fake kipy reporting a mount path, asserting `None` and the debug event.
- `test_discover_kicad_cli_falls_through_to_path_when_kipy_is_ephemeral` — the regression that matters: the stable `PATH` binary wins.

All three were confirmed failing against unmodified `main` before the fix was applied.

## Validation

`scripts/hook_pre_push.py --base upstream/main` selected and passed every check for the touched files:

```
pre-push: ruff-format     2 files already formatted
pre-push: ruff-lint       All checks passed!
pre-push: mypy-changed    Success: no issues found in 1 source file
pre-push: targeted-tests  30 passed
```

Two `# noqa: S108` are needed, because the literal `/tmp/.mount_` prefix is matched, never created. I verified each suppression is load-bearing by removing it and confirming S108 fires again, rather than assuming placement was correct.

**Not run locally:** `task ci` and the pnpm gates (`format:check`, `lint`, `typecheck`, `test:unit`). This machine has Node 18 and no pnpm/corepack against the repo's Node 24 + pnpm 11 requirement. The change is pure Python, so the Python gates above are the applicable ones, but I would rather say what I did not run than imply a green `task ci`. `uv sync --all-extras --frozen` was run at the pinned uv 0.11.31 from `uv.toml`.

## DCO

Commit is signed off (`git commit -s`).
