### PR TITLE
fix(library): report through-hole footprints as out of scope for IPC-7351

### DIFF
--- a/src/kicad_mcp/library/footprint_engineering.py
+++ b/src/kicad_mcp/library/footprint_engineering.py
@@ -13,6 +13,7 @@ from ..utils.footprint_validate import (
     FootprintCheck,
     check_footprint_documentation_layers,
     check_footprint_pad_count,
+    count_thru_hole_pads,
     parse_ipc_density,
     parse_smd_pads,
     validate_chip_footprint,
@@ -111,6 +112,15 @@ class LibraryFootprintEngineeringService:
             return f"Footprint file not found: {path}"
         text = path.read_text(encoding="utf-8", errors="ignore")
         pads = parse_smd_pads(text)
+        if not pads:
+            thru_hole = count_thru_hole_pads(text)
+            if thru_hole:
+                return (
+                    "Footprint IPC-7351B validation: NOT APPLICABLE\n"
+                    f"- This footprint has {thru_hole} through-hole pad(s) and no SMD pads. "
+                    "This check validates two-terminal SMD chip land geometry only, so it "
+                    "has nothing to measure here -- this is not a defect in the footprint."
+                )
         try:
             result = validate_chip_footprint(
                 size_code,

--- a/src/kicad_mcp/utils/footprint_validate.py
+++ b/src/kicad_mcp/utils/footprint_validate.py
@@ -183,6 +183,10 @@ _PAD_NUM_RE = re.compile(
     r'\(pad\s+"?(?P<num>[^"\s)]+)"?\s+(?:smd|thru_hole|connect)\b',
     re.IGNORECASE,
 )
+_THRU_HOLE_PAD_RE = re.compile(
+    r'\(pad\s+"?[^"\s)]+"?\s+(?:np_thru_hole|thru_hole)\b',
+    re.IGNORECASE,
+)
 
 
 def expected_pin_count_from_package(footprint_name: str) -> int | None:
@@ -200,6 +204,16 @@ def expected_pin_count_from_package(footprint_name: str) -> int | None:
     if pin_count is not None:
         return int(pin_count.group(1))
     return None
+
+
+def count_thru_hole_pads(footprint_text: str) -> int:
+    """Count through-hole pads, which :func:`parse_smd_pads` cannot see.
+
+    ``parse_smd_pads`` matches ``smd`` pads only, so a through-hole footprint
+    parses as zero pads. Callers use this to tell "no pads at all" apart from
+    "pads outside this validator's scope" and report the difference honestly.
+    """
+    return len(_THRU_HOLE_PAD_RE.findall(footprint_text))
 
 
 def count_numbered_pads(footprint_text: str) -> int:

--- a/tests/unit/test_footprint_validate.py
+++ b/tests/unit/test_footprint_validate.py
@@ -7,6 +7,7 @@ from kicad_mcp.utils.footprint_validate import (
     check_footprint_documentation_layers,
     check_footprint_pad_count,
     count_numbered_pads,
+    count_thru_hole_pads,
     expected_pin_count_from_package,
     parse_ipc_density,
     parse_smd_pads,
@@ -182,3 +183,20 @@ def test_generated_qfp_footprint_records_its_density() -> None:
 
 def test_parse_ipc_density_is_none_when_absent() -> None:
     assert parse_ipc_density(_pads_text(["1", "2"])) is None
+
+
+def test_count_thru_hole_pads_sees_what_parse_smd_pads_cannot() -> None:
+    # parse_smd_pads() matches `smd` only, so a through-hole footprint reads as
+    # zero pads. The THT counter is what lets callers tell "no pads" apart from
+    # "pads this parser does not cover".
+    text = _pads_text(["1", "2"], pad_type="thru_hole")
+    assert parse_smd_pads(text) == []
+    assert count_thru_hole_pads(text) == 2
+
+
+def test_count_thru_hole_pads_ignores_smd_pads() -> None:
+    assert count_thru_hole_pads(_pads_text(["1", "2"], pad_type="smd")) == 0
+
+
+def test_count_thru_hole_pads_counts_np_thru_hole() -> None:
+    assert count_thru_hole_pads(_pads_text(["1"], pad_type="np_thru_hole")) == 1

--- a/tests/unit/test_library_footprint_engineering_service.py
+++ b/tests/unit/test_library_footprint_engineering_service.py
@@ -199,3 +199,23 @@ def test_certify_footprint_reports_warn_for_missing_documentation_graphics(
 
     assert result.startswith("Footprint certification: WARN")
     assert "documentation-layers" in result
+
+
+def test_validate_footprint_reports_thru_hole_as_out_of_scope(tmp_path: Path) -> None:
+    # Regression for #865: a through-hole footprint used to fall through to the
+    # chip-pad-count check and return "found 0", which reads as a malformed
+    # footprint rather than an unsupported one.
+    service, _ = _service(tmp_path)
+    path = tmp_path / "tht.kicad_mod"
+    path.write_text(
+        '(footprint "X"\n'
+        '(pad "1" thru_hole circle (at 0 0) (size 1.5 1.5) (drill 0.8) (layers "*.Cu"))\n'
+        '(pad "2" thru_hole circle (at 2 0) (size 1.5 1.5) (drill 0.8) (layers "*.Cu"))\n'
+        ")\n",
+        encoding="utf-8",
+    )
+
+    result = service.validate_footprint_ipc7351(str(path), "0805")
+
+    assert "through-hole" in result
+    assert "found 0" not in result


### PR DESCRIPTION
Fixes #865.

## Problem

`parse_smd_pads()` matches `smd` pads only, so a through-hole footprint parses as zero pads and `lib_validate_footprint_ipc7351` returned:

```
Footprint IPC-7351B validation: FAIL
- Expected 2 SMD pads for chip 0805, found 0. Not a recognizable two-terminal chip land pattern.
  - pad count 0 != 2
```

That reads as "your footprint is malformed" when the truth is that the check does not cover through-hole at all. A caller with a THT library gets a confident, wrong-sounding `FAIL`.

## Change

The issue offered two options; this takes the **narrower** one.

I did *not* widen `_PAD_RE` to accept `thru_hole`. IPC-7351B chip land geometry is an SMD land pattern, and feeding THT pads through it would apply an inapplicable nominal — trading a confusing message for a wrong verdict, which is worse.

Instead the scope is detected and stated:

- `count_thru_hole_pads()` in `utils/footprint_validate.py`, beside the existing pad counters, matching `thru_hole` and `np_thru_hole`. Pure and unit-testable, per the architecture seam.
- The service returns `NOT APPLICABLE` with the pad count and an explicit "this is not a defect in the footprint" when there are no SMD pads but there are THT ones.

This follows CONTRIBUTING's honesty rule for partial capabilities: *"if a capability is heuristic, approximate, or partial, say so in the tool name, docstring, and verdict — never claim a precision the code does not deliver."* The docstring already scoped this to chip passives; only the runtime verdict did not.

The guard is behind `if not pads`, so no footprint that parses any SMD pad changes behaviour.

## Tests

Written before the production change, per `AGENTS.md` working rule 3:

- `tests/unit/test_footprint_validate.py` — three tests for `count_thru_hole_pads()`, including one asserting the asymmetry directly (`parse_smd_pads(text) == []` while `count_thru_hole_pads(text) == 2`), plus `np_thru_hole` coverage and an SMD negative case.
- `tests/unit/test_library_footprint_engineering_service.py` — regression test at the service seam asserting the verdict says "through-hole" and no longer says "found 0".

The service test was confirmed failing against unmodified `main`, reproducing the exact message quoted above.

## Validation

`scripts/hook_pre_push.py --base upstream/main` selected and passed every check for the touched files:

```
pre-push: ruff-format
pre-push: ruff-lint
pre-push: mypy-changed
pre-push: targeted-tests
```

No MCP tool contract change — the tool's name, signature and registration are untouched, only its verdict string in a case that previously produced a wrong verdict — so `docs:tools` / `metadata:check` regeneration does not apply. Happy to regenerate if you would rather the changed verdict be captured in a snapshot.

**Not run locally:** `task ci` and the pnpm gates. This machine has Node 18 and no pnpm/corepack against the repo's Node 24 + pnpm 11 requirement. The change is pure Python, so the Python gates above are the applicable ones, but I would rather name what I did not run than imply a green `task ci`. `uv sync --all-extras --frozen` was run at the pinned uv 0.11.31 from `uv.toml`.

## DCO

Commit is signed off (`git commit -s`).
