### PR TITLE
fix(evals): shorten protected live release gate

### DIFF
--- a/.github/workflows/live-model-assurance.yml
+++ b/.github/workflows/live-model-assurance.yml
@@ -18,6 +18,7 @@ jobs:
       mode: ${{ steps.policy.outputs.mode }}
       reason: ${{ steps.policy.outputs.reason }}
       required_configurations: ${{ steps.policy.outputs.required_configurations }}
+      smoke_configurations: ${{ steps.policy.outputs.smoke_configurations }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -51,7 +52,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        configuration: ${{ fromJSON(needs.classify.outputs.required_configurations) }}
+        configuration: ${{ fromJSON(needs.classify.outputs.smoke_configurations) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/.github/workflows/live-model-release-gate.yml
+++ b/.github/workflows/live-model-release-gate.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       repeats:
-        description: Full-corpus repetitions per configuration, bounded from 3 to 5.
+        description: Full-corpus repetitions for the NVIDIA baseline provider, bounded from 2 to 3.
         type: number
-        default: 3
+        default: 2
         required: true
 
 permissions:
@@ -27,14 +27,14 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_REF_VALUE" = "refs/heads/main"
-          test "$REPEATS" -ge 3
-          test "$REPEATS" -le 5
+          test "$REPEATS" -ge 2
+          test "$REPEATS" -le 3
 
   smoke:
     name: Live model smoke (${{ matrix.configuration }})
     needs: guard
     runs-on: ubuntu-24.04
-    timeout-minutes: 50
+    timeout-minutes: 18
     environment: live-model-evals
     strategy:
       fail-fast: true
@@ -92,7 +92,7 @@ jobs:
           )
           PY
           set +e
-          timeout --signal=TERM --kill-after=30s 45m \
+          timeout --signal=TERM --kill-after=30s 15m \
             uv run --all-extras python scripts/run_live_model_eval.py \
               --config evals/live/configurations.yaml \
               --configuration "$CONFIGURATION_ID" \
@@ -146,7 +146,7 @@ jobs:
   benchmark:
     needs: smoke
     runs-on: ubuntu-24.04
-    timeout-minutes: 240
+    timeout-minutes: 90
     environment: live-model-evals
     strategy:
       fail-fast: false
@@ -154,7 +154,6 @@ jobs:
       matrix:
         configuration:
           - nvidia-nemotron-3-5-lightning-30b-a3b
-          - opencode-cli-mimo-v2-5-free
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -164,28 +163,14 @@ jobs:
           enable-cache: false
           version-file: uv.toml
       - run: uv sync --all-extras --frozen
-      - name: Install pinned OpenCode CLI
-        if: startsWith(matrix.configuration, 'opencode-cli-')
-        env:
-          OPENCODE_CLI_VERSION: "1.18.10"
-        run: |
-          set -euo pipefail
-          npm ci --prefix evals/live --ignore-scripts --no-audit --no-fund
-          test "$(evals/live/node_modules/opencode-linux-x64/bin/opencode --version)" = "$OPENCODE_CLI_VERSION"
-          echo "$GITHUB_WORKSPACE/evals/live/node_modules/opencode-linux-x64/bin" >> "$GITHUB_PATH"
       - name: Run bounded live benchmark
         env:
           CONFIGURATION_ID: ${{ matrix.configuration }}
           NVIDIA_API_KEY: ${{ startsWith(matrix.configuration, 'nvidia-') && secrets.NVIDIA_API_KEY || '' }}
-          OPENCODE_ZEN_API_KEY: ${{ startsWith(matrix.configuration, 'opencode-cli-') && secrets.OPENCODE_ZEN_API_KEY || '' }}
           REPEATS: ${{ inputs.repeats }}
         run: |
           set -euo pipefail
-          case "$CONFIGURATION_ID" in
-            nvidia-*) test -n "$NVIDIA_API_KEY" ;;
-            opencode-cli-*) test -n "$OPENCODE_ZEN_API_KEY" ;;
-            *) echo "Unsupported blocking configuration: $CONFIGURATION_ID" >&2; exit 2 ;;
-          esac
+          test -n "$NVIDIA_API_KEY"
           mkdir -p artifacts/live-model-eval
           python - "$CONFIGURATION_ID" "$GITHUB_SHA" <<'PY'
           import json
@@ -205,7 +190,7 @@ jobs:
           )
           PY
           set +e
-          timeout --signal=TERM --kill-after=30s 225m \
+          timeout --signal=TERM --kill-after=30s 75m \
             uv run --all-extras python scripts/run_live_model_eval.py \
               --config evals/live/configurations.yaml \
               --configuration "$CONFIGURATION_ID" \

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -44,6 +44,12 @@ versioned `agent_contract_paths` at that release with the release candidate.
 - If the previous server release tag/history cannot be resolved, readiness fails closed.
   Release and publish workflows therefore check out full Git history (`fetch-depth: 0`).
 
+- Protected live evidence is intentionally asymmetric for runtime cost: NVIDIA Nemotron
+  Lightning and OpenCode MiMo must both pass the bounded smoke corpus, but only NVIDIA
+  Nemotron Lightning runs the full 65-case baseline benchmark. The standard full evidence
+  floor is two repetitions; MiMo remains available for manual diagnostics without adding
+  an hour-scale full benchmark to release readiness.
+
 This rule is based on the actual model-facing contract diff, not on whether the version is
 a patch, minor, or major release. Deterministic CI, security, packaging, metadata, and
 required-status checks remain mandatory in every case.

--- a/docs/superpowers/plans/2026-09-09-short-live-release-gate.md
+++ b/docs/superpowers/plans/2026-09-09-short-live-release-gate.md
@@ -1,0 +1,437 @@
+# Short Live Release Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shorten contract-changing live release readiness by keeping two independent smoke providers while running the full corpus only on NVIDIA at a two-repeat evidence floor.
+
+**Architecture:** Release policy owns the two-provider smoke set, while the baseline owns the one-provider full-benchmark set. Workflows consume those sets according to purpose: routine/main smoke uses policy smoke configurations, the protected release gate smokes both providers, and only NVIDIA produces full benchmark evidence used for baseline promotion.
+
+**Tech Stack:** Python 3.13, PyYAML, pytest, GitHub Actions YAML, uv 0.11.31, Ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-short-live-release-gate-design.md`
+
+## Global Constraints
+
+- Required smoke providers are exactly `nvidia-nemotron-3-5-lightning-30b-a3b` and `opencode-cli-mimo-v2-5-free`.
+- `minimum_smoke_configurations` remains `2`; both provider paths are required.
+- The protected full benchmark configuration is exactly `nvidia-nemotron-3-5-lightning-30b-a3b`.
+- Baseline `minimum_repeats` becomes `2`.
+- Protected gate default repeats is `2`; dispatch accepts only `2..3`.
+- Smoke remains fail-closed and sequential.
+- No threshold, safety, telemetry, or per-case failure is suppressed.
+- OpenCode MiMo remains in `evals/live/configurations.yaml` for smoke/manual diagnostics.
+
+---
+
+### Task 1: Split smoke configuration policy from full baseline configurations
+
+**Files:**
+- Modify: `evals/live/release-policy.yaml`
+- Modify: `src/kicad_mcp/evals/release_policy.py`
+- Modify: `scripts/check_live_model_release_policy.py`
+- Test: `tests/unit/test_live_model_release_policy.py`
+
+**Interfaces:**
+- Consumes: existing strict policy YAML loader and `ReleasePolicyDecision` serialization.
+- Produces: `ReleasePolicyConfig.smoke_configurations: tuple[str, ...]`, `ReleasePolicyDecision.smoke_configurations: tuple[str, ...]`, and GitHub output `smoke_configurations=<json-array>`.
+
+- [ ] **Step 1: Write failing policy tests**
+
+Add tests that construct a policy with:
+
+```yaml
+minimum_smoke_configurations: 2
+smoke_configurations:
+  - alpha
+  - beta
+```
+
+and assert:
+
+```python
+assert policy.smoke_configurations == ("alpha", "beta")
+assert decision.smoke_configurations == ("alpha", "beta")
+```
+
+Also add explicit failures for duplicate smoke ids and `minimum_smoke_configurations > len(smoke_configurations)`.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+/tmp/kicad-uv-0.11.31/bin/uv run --all-extras python -m pytest -q \
+  tests/unit/test_live_model_release_policy.py
+```
+
+Expected: failures because the policy schema does not yet accept or expose `smoke_configurations`.
+
+- [ ] **Step 3: Implement strict smoke policy loading**
+
+Update `_POLICY_KEYS`, `ReleasePolicyConfig`, `ReleasePolicyDecision.as_dict()`, all decision constructors, and `load_release_policy()` so the policy requires a unique non-empty smoke list and validates:
+
+```python
+if minimum_smoke > len(smoke_configurations):
+    raise ReleasePolicyError(
+        "minimum_smoke_configurations cannot exceed smoke_configurations."
+    )
+```
+
+Preserve `required_configurations` on the decision as the full baseline configuration set.
+
+- [ ] **Step 4: Emit a separate GitHub output**
+
+In `scripts/check_live_model_release_policy.py`, write:
+
+```python
+"smoke_configurations": json.dumps(
+    list(decision.smoke_configurations), separators=(",", ":")
+),
+```
+
+while retaining the existing `required_configurations` output.
+
+- [ ] **Step 5: Set the committed smoke configuration list**
+
+Add to `evals/live/release-policy.yaml`:
+
+```yaml
+smoke_configurations:
+  - nvidia-nemotron-3-5-lightning-30b-a3b
+  - opencode-cli-mimo-v2-5-free
+```
+
+- [ ] **Step 6: Run policy tests and commit**
+
+Run the Task 1 pytest command again; expected PASS.
+
+Commit:
+
+```bash
+git add evals/live/release-policy.yaml src/kicad_mcp/evals/release_policy.py \
+  scripts/check_live_model_release_policy.py tests/unit/test_live_model_release_policy.py
+git commit -m "refactor(evals): separate smoke and benchmark provider sets"
+```
+
+---
+
+### Task 2: Make routine smoke assurance consume the policy smoke set
+
+**Files:**
+- Modify: `scripts/evaluate_live_model_smoke_assurance.py`
+- Modify: `.github/workflows/live-model-assurance.yml`
+- Test: `tests/unit/test_live_model_release_policy.py`
+- Test: `tests/unit/test_live_model_smoke_assurance.py`
+
+**Interfaces:**
+- Consumes: `ReleasePolicyConfig.smoke_configurations` and GitHub output `smoke_configurations` from Task 1.
+- Produces: routine main-push smoke execution/evaluation over the two policy smoke providers independent of baseline full-benchmark configuration count.
+
+- [ ] **Step 1: Add RED tests for policy-owned smoke selection**
+
+Assert the assurance workflow exposes and consumes `smoke_configurations`:
+
+```python
+assert "smoke_configurations: ${{ steps.policy.outputs.smoke_configurations }}" in workflow
+assert "fromJSON(needs.classify.outputs.smoke_configurations)" in workflow
+```
+
+Add a script-level or unit test demonstrating smoke assurance receives `policy.smoke_configurations`, not `baseline.required_configurations`.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```bash
+/tmp/kicad-uv-0.11.31/bin/uv run --all-extras python -m pytest -q \
+  tests/unit/test_live_model_release_policy.py \
+  tests/unit/test_live_model_smoke_assurance.py
+```
+
+- [ ] **Step 3: Update smoke assurance script and workflow**
+
+Change `scripts/evaluate_live_model_smoke_assurance.py` to pass:
+
+```python
+required_configurations=policy.smoke_configurations
+```
+
+Update `live-model-assurance.yml` classify outputs and matrix to use `smoke_configurations`.
+
+- [ ] **Step 4: Re-run focused tests and commit**
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add scripts/evaluate_live_model_smoke_assurance.py \
+  .github/workflows/live-model-assurance.yml \
+  tests/unit/test_live_model_release_policy.py \
+  tests/unit/test_live_model_smoke_assurance.py
+git commit -m "fix(evals): keep two-provider routine smoke assurance"
+```
+
+---
+
+### Task 3: Reduce the full baseline to one provider and two repeats
+
+**Files:**
+- Modify: `evals/live/baselines.yaml`
+- Modify: `src/kicad_mcp/evals/release_gate.py`
+- Modify: `src/kicad_mcp/evals/release_policy.py`
+- Modify: `src/kicad_mcp/evals/baseline_promotion.py`
+- Test: `tests/unit/test_live_model_release_gate.py`
+- Test: `tests/unit/test_live_model_release_policy.py`
+- Test: `tests/unit/test_live_model_baseline_promotion.py`
+
+**Interfaces:**
+- Consumes: baseline `required_configurations` as full benchmark configurations.
+- Produces: valid one-provider baseline metadata and promotion at `minimum_repeats: 2`.
+
+- [ ] **Step 1: Add RED tests for one full configuration**
+
+Add/adjust tests so:
+
+```python
+baseline["required_configurations"] = ["alpha"]
+baseline["minimum_repeats"] = 2
+```
+
+is accepted by baseline metadata loading, aggregate gate evaluation, and baseline promotion when evidence is clean and has `repeats == 2`.
+
+Retain explicit tests that an empty required list and evidence with `repeats == 1` fail closed.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```bash
+/tmp/kicad-uv-0.11.31/bin/uv run --all-extras python -m pytest -q \
+  tests/unit/test_live_model_release_gate.py \
+  tests/unit/test_live_model_release_policy.py \
+  tests/unit/test_live_model_baseline_promotion.py
+```
+
+- [ ] **Step 3: Relax only the full-benchmark cardinality floor**
+
+Change validators from “at least two unique required configurations” to “at least one unique required configuration” in baseline metadata, release gate loading, and baseline promotion. Do not change smoke assurance’s two-provider floor.
+
+- [ ] **Step 4: Update committed pending baseline**
+
+Set:
+
+```yaml
+minimum_repeats: 2
+required_configurations:
+  - nvidia-nemotron-3-5-lightning-30b-a3b
+```
+
+Keep `approved: false`, null audit metadata, and `configurations: {}` until a fresh protected gate generates the candidate.
+
+- [ ] **Step 5: Re-run focused tests and commit**
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add evals/live/baselines.yaml src/kicad_mcp/evals/release_gate.py \
+  src/kicad_mcp/evals/release_policy.py src/kicad_mcp/evals/baseline_promotion.py \
+  tests/unit/test_live_model_release_gate.py tests/unit/test_live_model_release_policy.py \
+  tests/unit/test_live_model_baseline_promotion.py
+git commit -m "fix(evals): benchmark one provider at two repeats"
+```
+
+---
+
+### Task 4: Shorten the protected release-gate workflow
+
+**Files:**
+- Modify: `.github/workflows/live-model-release-gate.yml`
+- Test: `tests/unit/test_live_model_release_gate.py`
+
+**Interfaces:**
+- Consumes: two smoke configuration ids and one full baseline configuration id.
+- Produces: a protected run with two sequential smokes, one NVIDIA full benchmark, and aggregate/candidate generation from that benchmark.
+
+- [ ] **Step 1: Add RED workflow-shape tests**
+
+Split smoke and benchmark blocks and assert:
+
+```python
+assert smoke_block.count("nvidia-nemotron-3-5-lightning-30b-a3b") == 1
+assert smoke_block.count("opencode-cli-mimo-v2-5-free") == 1
+assert benchmark_block.count("nvidia-nemotron-3-5-lightning-30b-a3b") == 1
+assert "opencode-cli-mimo-v2-5-free" not in benchmark_block
+assert "default: 2" in workflow
+assert 'test "$REPEATS" -ge 2' in workflow
+assert 'test "$REPEATS" -le 3' in workflow
+```
+
+Also assert smoke is bounded at 15m/18m and benchmark at 75m/90m.
+
+- [ ] **Step 2: Run release-gate tests and verify RED**
+
+Run:
+
+```bash
+/tmp/kicad-uv-0.11.31/bin/uv run --all-extras python -m pytest -q \
+  tests/unit/test_live_model_release_gate.py
+```
+
+- [ ] **Step 3: Update workflow matrices and bounds**
+
+Keep smoke matrix:
+
+```yaml
+configuration:
+  - nvidia-nemotron-3-5-lightning-30b-a3b
+  - opencode-cli-mimo-v2-5-free
+```
+
+Change benchmark matrix to:
+
+```yaml
+configuration:
+  - nvidia-nemotron-3-5-lightning-30b-a3b
+```
+
+Change repeats default/guard to `2..3`, smoke timeout to `15m` inside `18` minutes, and benchmark timeout to `75m` inside `90` minutes.
+
+- [ ] **Step 4: Run release-gate tests and commit**
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add .github/workflows/live-model-release-gate.yml tests/unit/test_live_model_release_gate.py
+git commit -m "ci(evals): shorten protected live release gate"
+```
+
+---
+
+### Task 5: Update documentation and verify the complete policy contract
+
+**Files:**
+- Modify: `evals/README.md`
+- Modify: `docs/development/release-process.md`
+- Test: all relevant unit suites
+
+**Interfaces:**
+- Consumes: Tasks 1–4 behavior.
+- Produces: operator documentation matching the shortened gate.
+
+- [ ] **Step 1: Update gate documentation**
+
+Document that both NVIDIA and MiMo must pass smoke, only NVIDIA runs the full corpus, the standard full evidence floor is two repeats, and MiMo remains available for manual diagnostics.
+
+- [ ] **Step 2: Run the focused eval suites**
+
+Run:
+
+```bash
+/tmp/kicad-uv-0.11.31/bin/uv run --all-extras python -m pytest -q \
+  tests/unit/test_live_model_release_gate.py \
+  tests/unit/test_live_model_release_policy.py \
+  tests/unit/test_live_model_baseline_promotion.py \
+  tests/unit/test_live_model_smoke_assurance.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run workflow and static validation**
+
+Run the repository workflow-policy checker plus:
+
+```bash
+/tmp/kicad-uv-0.11.31/bin/uv run --all-extras ruff check \
+  src/kicad_mcp/evals/release_policy.py \
+  src/kicad_mcp/evals/release_gate.py \
+  src/kicad_mcp/evals/baseline_promotion.py \
+  scripts/check_live_model_release_policy.py \
+  scripts/evaluate_live_model_smoke_assurance.py \
+  tests/unit/test_live_model_release_gate.py \
+  tests/unit/test_live_model_release_policy.py \
+  tests/unit/test_live_model_baseline_promotion.py \
+  tests/unit/test_live_model_smoke_assurance.py
+```
+
+and full-project mypy using the repository’s configured command.
+
+- [ ] **Step 4: Run full unit verification**
+
+Run the repository unit runner. Any unrelated timing-only benchmark failure must be reproduced on `origin/main` before being classified as pre-existing; do not weaken thresholds.
+
+- [ ] **Step 5: Run security scans**
+
+Run OSV-Scanner against the changed tree/lockfiles and Trivy HIGH/CRITICAL filesystem scanning. No new unreviewed advisory is acceptable.
+
+- [ ] **Step 6: Independent review, final diff check, and commit docs**
+
+Run read-only Codex review against `origin/main`, fix actionable findings, then:
+
+```bash
+git diff --check
+git status --short
+git add evals/README.md docs/development/release-process.md \
+  docs/superpowers/specs/2026-09-09-short-live-release-gate-design.md \
+  docs/superpowers/plans/2026-09-09-short-live-release-gate.md
+git commit -m "docs(evals): document shortened live release gate"
+```
+
+---
+
+### Task 6: Protected integration and fresh evidence
+
+**Files:**
+- No direct main edits.
+- Promotion follow-up modifies only `evals/live/baselines.yaml` from the generated candidate.
+
+**Interfaces:**
+- Consumes: verified feature branch and GitHub protected workflows.
+- Produces: merged gate policy, fresh protected candidate, promoted baseline, and a release-ready #849.
+
+- [ ] **Step 1: Push branch and open PR**
+
+Use title:
+
+```text
+fix(evals): shorten protected live release gate
+```
+
+PR body must explain that provider-diverse smoke remains mandatory while only NVIDIA supplies full baseline metrics.
+
+- [ ] **Step 2: Require CI/security/Sonar green**
+
+Wait for exact-head Required PR Gate, coverage, SonarCloud, CodeQL, Semgrep, dependency review, and platform tests. Do not bypass failures.
+
+- [ ] **Step 3: Merge through protected rules**
+
+Squash merge only after the exact PR head is green.
+
+- [ ] **Step 4: Dispatch one fresh Live Model Release Gate on new main**
+
+Use `repeats=2`. Do not start duplicate gates.
+
+- [ ] **Step 5: Validate candidate before promotion**
+
+Require:
+
+```text
+source_revision == merged main SHA
+workflow_run_id == fresh protected run id
+approved == true
+minimum_repeats == 2
+required_configurations == [nvidia-nemotron-3-5-lightning-30b-a3b]
+safety/quality/infrastructure/telemetry/per-case failures == []
+```
+
+- [ ] **Step 6: Promote generated baseline through a normal PR**
+
+Replace `evals/live/baselines.yaml` with the generated candidate exactly; do not hand-edit approval metadata. Run focused tests/CI and merge protected.
+
+- [ ] **Step 7: Re-evaluate release PR #849**
+
+Confirm release readiness no longer reports `baseline_unapproved`, wait for required checks, and merge only when protected release governance is green.

--- a/docs/superpowers/specs/2026-09-09-short-live-release-gate-design.md
+++ b/docs/superpowers/specs/2026-09-09-short-live-release-gate-design.md
@@ -1,0 +1,91 @@
+# Short Live Release Gate Design
+
+## Context
+
+The protected Live Model Release Gate currently uses the same two configurations for both smoke coverage and full-corpus benchmarking. That preserves provider diversity, but it also makes every contract-changing release wait for a full OpenCode MiMo benchmark that has historically taken about an hour by itself.
+
+The release gate should preserve two independent provider paths for fast fail-closed checks without requiring both providers to run the expensive 65-case corpus.
+
+## Goals
+
+- Keep NVIDIA Nemotron Lightning and OpenCode MiMo as required smoke providers.
+- Run the full 65-case benchmark only on NVIDIA Nemotron Lightning.
+- Make two full-corpus repetitions the standard release evidence floor.
+- Preserve fail-closed safety, selection, infrastructure, telemetry, and per-case checks for full benchmark evidence.
+- Preserve MiMo as a versioned configuration that can still be run manually or diagnostically.
+- Keep baseline promotion auditable and tied to one protected workflow run and exact source revision.
+
+## Non-goals
+
+- Do not remove OpenCode MiMo from the configuration registry.
+- Do not weaken the smoke corpus or its refusal/confirmation/destructive-operation coverage.
+- Do not suppress provider, safety, selection, or telemetry failures.
+- Do not make release publishing bypass the live-model readiness policy.
+- Do not add a third blocking provider.
+
+## Architecture
+
+### Separate smoke and benchmark configuration sets
+
+`evals/live/release-policy.yaml` gains a versioned `smoke_configurations` list. It contains exactly the two independent smoke providers used by protected assurance:
+
+- `nvidia-nemotron-3-5-lightning-30b-a3b`
+- `opencode-cli-mimo-v2-5-free`
+
+`minimum_smoke_configurations` remains `2`, so both providers must succeed. Policy loading rejects duplicate/empty smoke ids and rejects a minimum greater than the configured smoke set.
+
+The baseline file continues to use `required_configurations`, but its meaning is narrowed to configurations that must produce full-corpus baseline metrics. For the shortened gate this list contains only:
+
+- `nvidia-nemotron-3-5-lightning-30b-a3b`
+
+This keeps baseline comparison and promotion focused on the one full benchmark while the policy separately preserves provider-diverse smoke coverage.
+
+### Release-policy outputs
+
+`ReleasePolicyDecision` exposes both sets:
+
+- `required_configurations`: full benchmark/baseline configurations.
+- `smoke_configurations`: provider-diverse smoke configurations.
+
+`check_live_model_release_policy.py` writes both JSON arrays to GitHub outputs. `live-model-assurance.yml` consumes `smoke_configurations` for routine main-push smoke. Existing release readiness output retains `required_configurations` for auditability of the full baseline set.
+
+### Protected full gate
+
+`.github/workflows/live-model-release-gate.yml` keeps the smoke matrix at two providers but reduces the benchmark matrix to NVIDIA only.
+
+Standard repetitions change from three to two. The workflow input defaults to `2` and allows only `2..3`, preventing accidental 4- or 5-repeat release runs while retaining an explicit deeper-evidence option.
+
+Smoke remains sequential and fail-fast. Its command is bounded at 15 minutes inside an 18-minute job. The NVIDIA full benchmark is bounded at 75 minutes inside a 90-minute job. Aggregate still runs only after smoke succeeds and consumes the single required full benchmark artifact.
+
+### Baseline promotion
+
+`evals/live/baselines.yaml` changes to `minimum_repeats: 2` and one full-benchmark `required_configuration`. Baseline loading, gate evaluation, release-policy metadata loading, and baseline promotion therefore accept one unique full-benchmark configuration while smoke assurance still requires the two policy smoke configurations.
+
+A successful aggregate may generate an approved baseline candidate only when the NVIDIA full evidence is complete, at or above two repeats, and contains no safety, quality, infrastructure, telemetry, or per-case failures. The candidate still records exact source revision, agent-contract digest, workflow run id, aggregate SHA-256, provider identity, metrics, and approval date.
+
+## Failure behavior
+
+- Either smoke provider fails or times out: full benchmark is skipped and the gate fails.
+- NVIDIA full benchmark fails, times out, is incomplete, or violates a threshold: aggregate fails and no promotable baseline is accepted.
+- MiMo full benchmark is not part of release readiness and therefore cannot delay a release after passing smoke.
+- Missing or malformed policy smoke configuration metadata fails closed during policy loading.
+- A baseline with zero full-benchmark configurations remains invalid.
+
+## Expected runtime
+
+Historical protected runs show the two smokes finishing in roughly five minutes total and NVIDIA three-repeat full benchmarking in roughly 20–30 minutes. With two repeats and no MiMo full benchmark, the normal protected path is expected to finish in roughly 20–25 minutes, with bounded headroom for provider variance.
+
+## Verification
+
+Required regression coverage includes:
+
+- policy accepts one full baseline configuration plus two smoke configurations;
+- policy rejects empty/duplicate/undersized smoke sets;
+- routine smoke assurance consumes the policy smoke set rather than the baseline full set;
+- release-gate workflow contains both smoke providers but only NVIDIA in the benchmark block;
+- standard gate repeats default to two and cannot exceed three;
+- baseline promotion and aggregate gate accept one required full configuration at two repeats;
+- one required full configuration below two repeats still fails closed;
+- docs accurately describe the shortened architecture.
+
+Final verification includes focused eval-policy/gate suites, workflow policy checks, full unit tests, Ruff, mypy, OSV-Scanner, Trivy, SonarCloud PR analysis, and protected GitHub CI before merge.

--- a/evals/README.md
+++ b/evals/README.md
@@ -427,15 +427,17 @@ integrity failures, tool-selection quality failures, safety or forbidden calls, 
 call-limit violations always block. Provider availability is therefore not mislabeled
 as model quality, while safety remains fail-closed.
 
-The full 65-case, minimum-three-repeat workflow remains mandatory when a release changes
-the agent contract and reusable approved evidence is unavailable—for example after a new
-model or host, prompt/matcher/safety change, tool catalog or schema change,
-adapter/retry/timeout change, corpus or threshold change, or baseline promotion. Baseline
-expiry by itself does not block a release whose agent contract is unchanged from the
-previous published server release. A compact approved baseline is generated only from a
-sanitized aggregate with complete evidence
-for every required configuration and no safety, quality, infrastructure, telemetry,
-or per-case failure:
+The protected full-gate workflow remains mandatory when a release changes the agent
+contract and reusable approved evidence is unavailable—for example after a new model or
+host, prompt/matcher/safety change, tool catalog or schema change, adapter/retry/timeout
+change, or corpus or threshold change. Baseline expiry by itself does
+not block a release whose agent contract is unchanged from the previous published server
+release. Provider-diverse smoke and full-corpus baseline evidence are intentionally
+separate: both NVIDIA Nemotron Lightning and OpenCode MiMo must pass the bounded smoke
+corpus, while only NVIDIA Nemotron Lightning supplies the 65-case full benchmark used for
+baseline metrics. A compact approved baseline is generated only from a sanitized aggregate
+with complete NVIDIA evidence and no safety, quality, infrastructure, telemetry, or
+per-case failure:
 
 ```bash
 uv run --all-extras python scripts/generate_live_model_baseline.py \
@@ -450,23 +452,27 @@ run ID, aggregate artifact SHA-256, host/model identities, reviewed metrics, and
 approval date. The baseline change is reviewed and merged through a normal pull
 request; no workflow writes directly to the repository.
 
-`.github/workflows/live-model-release-gate.yml` runs one reviewed NVIDIA NIM record
-and one sandboxed OpenCode CLI record sequentially from protected `main`. The protected
-environment supplies `NVIDIA_API_KEY` or `OPENCODE_ZEN_API_KEY` only to the bounded
-step that validates the selected configuration. Before any full-corpus work, each
-configuration must pass one bounded `live-smoke` repetition selected from the same
-canonical corpus.
+`.github/workflows/live-model-release-gate.yml` runs one reviewed NVIDIA NIM smoke and
+one sandboxed OpenCode CLI smoke sequentially from protected `main`. The protected
+environment supplies `NVIDIA_API_KEY` or `OPENCODE_ZEN_API_KEY` only to the bounded step
+that validates the selected smoke configuration. Before any full-corpus work, both
+providers must pass one bounded `live-smoke` repetition selected from the same canonical
+corpus.
 The 11-case smoke set covers read-only, explicitly authorized write, export, publish,
-human-gated, confirmation, and refusal behavior. Its provider command is bounded at
-45 minutes inside a 50-minute job envelope, leaving cleanup time to upload sanitized
+human-gated, confirmation, and refusal behavior. Each smoke command is bounded at 15
+minutes inside an 18-minute job envelope, leaving cleanup time to upload sanitized
 checkpoint evidence and fail explicitly. A command timeout preserves the `running`
-checkpoint instead of rewriting insufficient evidence as a completed verdict. If any
-required configuration fails or times out, every 195-observation full benchmark is
-skipped.
+checkpoint instead of rewriting insufficient evidence as a completed verdict. If either
+provider fails or times out, the full benchmark is skipped.
 
-Only after all smoke configurations pass does the workflow run at least three
-full-corpus repetitions per configuration. Each matrix job always emits a small
-status record and uploads only sanitized evidence. The aggregate job distinguishes:
+Only after both smoke providers pass does the workflow run the NVIDIA Nemotron Lightning
+full corpus. The standard release evidence floor is two repetitions (130 observations);
+the protected dispatch permits at most three when explicitly requesting deeper evidence.
+The NVIDIA benchmark is bounded at 75 minutes inside a 90-minute job envelope. OpenCode
+MiMo remains versioned and can still be run through the manual/diagnostic live-eval path,
+but its hour-scale full benchmark no longer blocks releases after smoke passes. The full
+job always emits a small status record and uploads only sanitized evidence. The aggregate
+job distinguishes:
 
 - destructive/safety failures;
 - tool-selection and baseline quality regressions;

--- a/evals/live/baselines.yaml
+++ b/evals/live/baselines.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
 # Pending re-approval. The previous NVIDIA free endpoint was deprecated and the
-# blocking release evidence now uses two independent provider paths:
-# NVIDIA Nemotron Lightning and OpenCode MiMo. The flaky OpenCode Ultra
-# endpoint remains versioned for diagnostics but is no longer required.
+# Release smoke still requires independent NVIDIA and OpenCode provider paths,
+# while full-corpus baseline metrics are produced only by NVIDIA Nemotron
+# Lightning. OpenCode MiMo and Ultra remain versioned for smoke/diagnostics.
 # No configuration metrics are carried forward: only a successful protected
 # Live Model Release Gate may generate a new approved baseline candidate.
 approved: false
@@ -11,8 +11,7 @@ approved_at: null
 source_revision: null
 agent_contract_digest: null
 evidence: {}
-minimum_repeats: 3
+minimum_repeats: 2
 required_configurations:
 - nvidia-nemotron-3-5-lightning-30b-a3b
-- opencode-cli-mimo-v2-5-free
 configurations: {}

--- a/evals/live/release-policy.yaml
+++ b/evals/live/release-policy.yaml
@@ -3,6 +3,9 @@ baseline_max_age_days: 30
 release_pull_request_head: release-please--branches--main
 release_tag_pattern: mcp-server-v*
 minimum_smoke_configurations: 2
+smoke_configurations:
+  - nvidia-nemotron-3-5-lightning-30b-a3b
+  - opencode-cli-mimo-v2-5-free
 agent_contract_paths:
   - docs/tools-reference.generated.md
   - evals/tool_selection/**

--- a/scripts/check_live_model_release_policy.py
+++ b/scripts/check_live_model_release_policy.py
@@ -77,6 +77,9 @@ def _write_outputs(path: Path, decision: ReleasePolicyDecision) -> None:
         "required_configurations": json.dumps(
             list(decision.required_configurations), separators=(",", ":")
         ),
+        "smoke_configurations": json.dumps(
+            list(decision.smoke_configurations), separators=(",", ":")
+        ),
     }
     with path.open("a", encoding="utf-8", newline="\n") as handle:
         for key, value in values.items():

--- a/scripts/evaluate_live_model_smoke_assurance.py
+++ b/scripts/evaluate_live_model_smoke_assurance.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from kicad_mcp.evals.release_policy import load_baseline_metadata, load_release_policy
+from kicad_mcp.evals.release_policy import load_release_policy
 from kicad_mcp.evals.smoke_assurance import (
     evaluate_smoke_assurance,
     write_smoke_assurance_report,
@@ -30,14 +30,13 @@ def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
         policy = load_release_policy(args.policy)
-        baseline = load_baseline_metadata(args.baseline)
         evidence = sorted(args.evidence_root.glob("**/evidence.json"))
         statuses = sorted(args.evidence_root.glob("**/status.json"))
         report = evaluate_smoke_assurance(
             evidence,
             status_paths=statuses,
             require_status=True,
-            required_configurations=baseline.required_configurations,
+            required_configurations=policy.smoke_configurations,
             minimum_successful_configurations=policy.minimum_smoke_configurations,
             expected_source_revision=args.source_revision,
         )

--- a/src/kicad_mcp/evals/baseline_promotion.py
+++ b/src/kicad_mcp/evals/baseline_promotion.py
@@ -89,9 +89,7 @@ def generate_approved_baseline(
         raise BaselinePromotionError("Baseline template minimum_repeats must be >= 2.")
     required = _string_list(template.get("required_configurations"), "Required configurations")
     if len(required) < 1 or len(required) != len(set(required)):
-        raise BaselinePromotionError(
-            "Required configurations must contain at least one unique id."
-        )
+        raise BaselinePromotionError("Required configurations must contain at least one unique id.")
 
     classifications = _mapping(report.get("classifications"), "Aggregate classifications")
     safety = _string_list(classifications.get("safety_failures", []), "Safety failures")

--- a/src/kicad_mcp/evals/baseline_promotion.py
+++ b/src/kicad_mcp/evals/baseline_promotion.py
@@ -88,9 +88,9 @@ def generate_approved_baseline(
     ):
         raise BaselinePromotionError("Baseline template minimum_repeats must be >= 2.")
     required = _string_list(template.get("required_configurations"), "Required configurations")
-    if len(required) < 2 or len(required) != len(set(required)):
+    if len(required) < 1 or len(required) != len(set(required)):
         raise BaselinePromotionError(
-            "Required configurations must contain at least two unique ids."
+            "Required configurations must contain at least one unique id."
         )
 
     classifications = _mapping(report.get("classifications"), "Aggregate classifications")

--- a/src/kicad_mcp/evals/release_gate.py
+++ b/src/kicad_mcp/evals/release_gate.py
@@ -42,11 +42,11 @@ def _load_baseline(path: str | Path) -> dict[str, Any]:
     required = raw.get("required_configurations")
     if (
         not isinstance(required, list)
-        or len(required) < 2
+        or len(required) < 1
         or len(required) != len(set(required))
         or not all(isinstance(item, str) and item for item in required)
     ):
-        raise ValueError("Baseline file needs at least two unique required configurations.")
+        raise ValueError("Baseline file needs at least one unique required configuration.")
     minimum_repeats = raw.get("minimum_repeats")
     if isinstance(minimum_repeats, bool) or not isinstance(minimum_repeats, int):
         raise ValueError("minimum_repeats must be an integer.")
@@ -146,7 +146,7 @@ def evaluate_release_gate(
     cases_path: str | Path,
     thresholds_path: str | Path,
 ) -> dict[str, Any]:
-    """Evaluate three or more sanitized configuration reports against approved baselines."""
+    """Evaluate required sanitized configuration reports against approved baselines."""
     baseline = _load_baseline(baseline_path)
     required = cast(list[str], baseline["required_configurations"])
     report = _empty_report(required)

--- a/src/kicad_mcp/evals/release_policy.py
+++ b/src/kicad_mcp/evals/release_policy.py
@@ -193,8 +193,6 @@ def load_baseline_metadata(path: str | Path) -> BaselineMetadata:
     if not isinstance(approved, bool):
         raise ReleasePolicyError("Baseline approved must be boolean.")
     required = _string_list(raw.get("required_configurations"), "required_configurations")
-    if len(required) < 2:
-        raise ReleasePolicyError("Baseline needs at least two required configurations.")
     _mapping(raw.get("configurations", {}), "Baseline configurations")
 
     approved_at: date | None = None

--- a/src/kicad_mcp/evals/release_policy.py
+++ b/src/kicad_mcp/evals/release_policy.py
@@ -155,13 +155,9 @@ def load_release_policy(path: str | Path) -> ReleasePolicyConfig:
     minimum_smoke = raw.get("minimum_smoke_configurations")
     if isinstance(minimum_smoke, bool) or not isinstance(minimum_smoke, int) or minimum_smoke < 1:
         raise ReleasePolicyError("minimum_smoke_configurations must be an integer >= 1.")
-    smoke_configurations = _string_list(
-        raw.get("smoke_configurations"), "smoke_configurations"
-    )
+    smoke_configurations = _string_list(raw.get("smoke_configurations"), "smoke_configurations")
     if minimum_smoke > len(smoke_configurations):
-        raise ReleasePolicyError(
-            "minimum_smoke_configurations cannot exceed smoke_configurations."
-        )
+        raise ReleasePolicyError("minimum_smoke_configurations cannot exceed smoke_configurations.")
     paths = _string_list(raw.get("agent_contract_paths"), "agent_contract_paths")
     for pattern in paths:
         if pattern.startswith("/") or ".." in Path(pattern).parts:

--- a/src/kicad_mcp/evals/release_policy.py
+++ b/src/kicad_mcp/evals/release_policy.py
@@ -30,6 +30,7 @@ _POLICY_KEYS = frozenset(
         "release_pull_request_head",
         "release_tag_pattern",
         "minimum_smoke_configurations",
+        "smoke_configurations",
         "agent_contract_paths",
     }
 )
@@ -60,6 +61,7 @@ class ReleasePolicyConfig:
     release_pull_request_head: str
     release_tag_pattern: str
     minimum_smoke_configurations: int
+    smoke_configurations: tuple[str, ...]
     agent_contract_paths: tuple[str, ...]
 
 
@@ -86,6 +88,7 @@ class ReleasePolicyDecision:
     current_contract_digest: str
     baseline_contract_digest: str | None
     required_configurations: tuple[str, ...]
+    smoke_configurations: tuple[str, ...]
     release_base_ref: str | None
     release_contract_changed: bool | None
 
@@ -97,6 +100,7 @@ class ReleasePolicyDecision:
             "current_contract_digest": self.current_contract_digest,
             "baseline_contract_digest": self.baseline_contract_digest,
             "required_configurations": list(self.required_configurations),
+            "smoke_configurations": list(self.smoke_configurations),
             "release_base_ref": self.release_base_ref,
             "release_contract_changed": self.release_contract_changed,
         }
@@ -151,6 +155,13 @@ def load_release_policy(path: str | Path) -> ReleasePolicyConfig:
     minimum_smoke = raw.get("minimum_smoke_configurations")
     if isinstance(minimum_smoke, bool) or not isinstance(minimum_smoke, int) or minimum_smoke < 1:
         raise ReleasePolicyError("minimum_smoke_configurations must be an integer >= 1.")
+    smoke_configurations = _string_list(
+        raw.get("smoke_configurations"), "smoke_configurations"
+    )
+    if minimum_smoke > len(smoke_configurations):
+        raise ReleasePolicyError(
+            "minimum_smoke_configurations cannot exceed smoke_configurations."
+        )
     paths = _string_list(raw.get("agent_contract_paths"), "agent_contract_paths")
     for pattern in paths:
         if pattern.startswith("/") or ".." in Path(pattern).parts:
@@ -161,6 +172,7 @@ def load_release_policy(path: str | Path) -> ReleasePolicyConfig:
         release_pull_request_head=release_head.strip(),
         release_tag_pattern=release_tag_pattern,
         minimum_smoke_configurations=minimum_smoke,
+        smoke_configurations=smoke_configurations,
         agent_contract_paths=paths,
     )
 
@@ -372,6 +384,7 @@ def evaluate_push_assurance(
         current_contract_digest=current_digest,
         baseline_contract_digest=baseline.agent_contract_digest,
         required_configurations=baseline.required_configurations,
+        smoke_configurations=policy.smoke_configurations,
         release_base_ref=None,
         release_contract_changed=None,
     )
@@ -394,6 +407,7 @@ def evaluate_noop_assurance(
         current_contract_digest=compute_agent_contract_digest(repo_root, policy, ref=ref),
         baseline_contract_digest=baseline.agent_contract_digest,
         required_configurations=baseline.required_configurations,
+        smoke_configurations=policy.smoke_configurations,
         release_base_ref=None,
         release_contract_changed=None,
     )
@@ -423,6 +437,7 @@ def evaluate_release_readiness(
             current_contract_digest=current_digest,
             baseline_contract_digest=baseline.agent_contract_digest,
             required_configurations=baseline.required_configurations,
+            smoke_configurations=policy.smoke_configurations,
             release_base_ref=release_base_ref,
             release_contract_changed=False,
         )
@@ -435,6 +450,7 @@ def evaluate_release_readiness(
             current_contract_digest=current_digest,
             baseline_contract_digest=None,
             required_configurations=baseline.required_configurations,
+            smoke_configurations=policy.smoke_configurations,
             release_base_ref=release_base_ref,
             release_contract_changed=True,
         )
@@ -453,6 +469,7 @@ def evaluate_release_readiness(
             current_contract_digest=current_digest,
             baseline_contract_digest=baseline_digest,
             required_configurations=baseline.required_configurations,
+            smoke_configurations=policy.smoke_configurations,
             release_base_ref=release_base_ref,
             release_contract_changed=True,
         )
@@ -464,6 +481,7 @@ def evaluate_release_readiness(
             current_contract_digest=current_digest,
             baseline_contract_digest=baseline_digest,
             required_configurations=baseline.required_configurations,
+            smoke_configurations=policy.smoke_configurations,
             release_base_ref=release_base_ref,
             release_contract_changed=True,
         )
@@ -475,6 +493,7 @@ def evaluate_release_readiness(
             current_contract_digest=current_digest,
             baseline_contract_digest=baseline_digest,
             required_configurations=baseline.required_configurations,
+            smoke_configurations=policy.smoke_configurations,
             release_base_ref=release_base_ref,
             release_contract_changed=True,
         )
@@ -485,6 +504,7 @@ def evaluate_release_readiness(
         current_contract_digest=current_digest,
         baseline_contract_digest=baseline_digest,
         required_configurations=baseline.required_configurations,
+        smoke_configurations=policy.smoke_configurations,
         release_base_ref=release_base_ref,
         release_contract_changed=True,
     )

--- a/tests/unit/test_live_model_baseline_promotion.py
+++ b/tests/unit/test_live_model_baseline_promotion.py
@@ -70,6 +70,7 @@ def _policy(path: Path) -> Path:
                 "release_pull_request_head": "release-please--branches--main",
                 "release_tag_pattern": "mcp-server-v*",
                 "minimum_smoke_configurations": 2,
+                "smoke_configurations": ["alpha", "beta"],
                 "agent_contract_paths": ["src/kicad_mcp/evals/**"],
             },
             sort_keys=False,
@@ -178,6 +179,37 @@ def test_generate_approved_baseline_from_clean_full_gate_evidence(tmp_path: Path
             "mean_tokens": 200.0,
         },
     }
+
+
+def test_generate_approved_baseline_accepts_one_required_configuration_at_two_repeats(
+    tmp_path: Path,
+) -> None:
+    repo, revision = _repo(tmp_path)
+    policy = _policy(tmp_path / "policy.yaml")
+    template = _baseline(tmp_path / "baseline.yaml")
+    template_payload = yaml.safe_load(template.read_text(encoding="utf-8"))
+    template_payload["minimum_repeats"] = 2
+    template_payload["required_configurations"] = ["alpha"]
+    template.write_text(yaml.safe_dump(template_payload, sort_keys=False), encoding="utf-8")
+    aggregate = _aggregate(tmp_path / "aggregate.json", revision)
+    aggregate_payload = json.loads(aggregate.read_text(encoding="utf-8"))
+    aggregate_payload["configurations"] = ["alpha"]
+    aggregate_payload["observed"] = {"alpha": aggregate_payload["observed"]["alpha"]}
+    aggregate_payload["observed"]["alpha"]["repeats"] = 2
+    aggregate.write_text(json.dumps(aggregate_payload), encoding="utf-8")
+
+    baseline = generate_approved_baseline(
+        aggregate_report_path=aggregate,
+        baseline_template_path=template,
+        policy_path=policy,
+        repo_root=repo,
+        workflow_run_id=987654,
+        approved_at=date(2026, 8, 2),
+    )
+
+    assert baseline["minimum_repeats"] == 2
+    assert baseline["required_configurations"] == ["alpha"]
+    assert list(baseline["configurations"]) == ["alpha"]
 
 
 def test_generate_approved_baseline_accepts_two_required_configurations(tmp_path: Path) -> None:

--- a/tests/unit/test_live_model_baseline_promotion.py
+++ b/tests/unit/test_live_model_baseline_promotion.py
@@ -212,6 +212,30 @@ def test_generate_approved_baseline_accepts_one_required_configuration_at_two_re
     assert list(baseline["configurations"]) == ["alpha"]
 
 
+def test_generate_approved_baseline_rejects_empty_required_configurations(tmp_path: Path) -> None:
+    repo, revision = _repo(tmp_path)
+    policy = _policy(tmp_path / "policy.yaml")
+    template = _baseline(tmp_path / "baseline.yaml")
+    template_payload = yaml.safe_load(template.read_text(encoding="utf-8"))
+    template_payload["minimum_repeats"] = 2
+    template_payload["required_configurations"] = []
+    template.write_text(yaml.safe_dump(template_payload, sort_keys=False), encoding="utf-8")
+    aggregate = _aggregate(tmp_path / "aggregate.json", revision)
+
+    with pytest.raises(
+        BaselinePromotionError,
+        match="Required configurations must contain at least one unique id",
+    ):
+        generate_approved_baseline(
+            aggregate_report_path=aggregate,
+            baseline_template_path=template,
+            policy_path=policy,
+            repo_root=repo,
+            workflow_run_id=987654,
+            approved_at=date(2026, 8, 2),
+        )
+
+
 def test_generate_approved_baseline_accepts_two_required_configurations(tmp_path: Path) -> None:
     repo, revision = _repo(tmp_path)
     policy = _policy(tmp_path / "policy.yaml")

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -241,9 +241,7 @@ def test_gate_rejects_one_repeat_when_baseline_requires_two(tmp_path: Path) -> N
     )
 
     assert report["passed"] is False
-    assert report["classifications"]["infrastructure_failures"] == [
-        f"{config_id}: repeats below 2"
-    ]
+    assert report["classifications"]["infrastructure_failures"] == [f"{config_id}: repeats below 2"]
 
 
 def test_gate_accepts_two_required_configurations(tmp_path: Path) -> None:

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -83,7 +83,9 @@ def _evidence(
     adapter_failures: int = 0,
     selection_failures: int = 0,
     executions: list[dict[str, object]] | None = None,
+    repeats: int = 3,
 ) -> dict[str, object]:
+    observations = 65 * repeats
     return {
         "schema_version": 1,
         "complete": True,
@@ -94,22 +96,22 @@ def _evidence(
             "adapter": "subprocess",
         },
         "source_revision": "a" * 40,
-        "repeats": 3,
+        "repeats": repeats,
         "limits": {},
         "usage": {
             "total_tool_calls": 120,
             "total_tokens": 35100,
             "total_cost_micros": 0,
-            "token_observations": 195 if token_coverage == 1.0 else 0,
+            "token_observations": observations if token_coverage == 1.0 else 0,
             "cost_observations": 0,
         },
         "summary": {
             "cases": 65,
-            "runs": 3,
-            "observations": 195,
-            "planned_observations": 195,
-            "completed_observations": 195 - adapter_failures,
-            "passed": round(195 * pass_rate),
+            "runs": repeats,
+            "observations": observations,
+            "planned_observations": observations,
+            "completed_observations": observations - adapter_failures,
+            "passed": round(observations * pass_rate),
             "pass_rate": pass_rate,
             "mean_recall": mean_recall,
             "behavior_match_rate": 1.0,
@@ -182,13 +184,66 @@ def test_gate_rejects_duplicate_required_configurations(tmp_path: Path) -> None:
     baseline["required_configurations"] = [first, first]
     baseline_path.write_text(yaml.safe_dump(baseline, sort_keys=False), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="two unique"):
+    with pytest.raises(ValueError, match="unique"):
         evaluate_release_gate(
             [],
             baseline_path=baseline_path,
             cases_path=CASES,
             thresholds_path=THRESHOLDS,
         )
+
+
+def test_gate_accepts_one_required_full_configuration_at_two_repeats(
+    tmp_path: Path,
+) -> None:
+    config_id = CONFIG_IDS[0]
+    evidence = _write_evidence(
+        tmp_path / "evidence",
+        [_evidence(config_id, MODELS[0], repeats=2)],
+    )
+    baseline_path = _baseline(tmp_path / "baselines.yaml")
+    baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
+    baseline["minimum_repeats"] = 2
+    baseline["required_configurations"] = [config_id]
+    baseline["configurations"] = {config_id: baseline["configurations"][config_id]}
+    baseline_path.write_text(yaml.safe_dump(baseline, sort_keys=False), encoding="utf-8")
+
+    report = evaluate_release_gate(
+        evidence,
+        baseline_path=baseline_path,
+        cases_path=CASES,
+        thresholds_path=THRESHOLDS,
+    )
+
+    assert report["passed"] is True
+    assert report["configurations"] == [config_id]
+    assert report["observed"][config_id]["repeats"] == 2
+
+
+def test_gate_rejects_one_repeat_when_baseline_requires_two(tmp_path: Path) -> None:
+    config_id = CONFIG_IDS[0]
+    evidence = _write_evidence(
+        tmp_path / "evidence",
+        [_evidence(config_id, MODELS[0], repeats=1)],
+    )
+    baseline_path = _baseline(tmp_path / "baselines.yaml")
+    baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
+    baseline["minimum_repeats"] = 2
+    baseline["required_configurations"] = [config_id]
+    baseline["configurations"] = {config_id: baseline["configurations"][config_id]}
+    baseline_path.write_text(yaml.safe_dump(baseline, sort_keys=False), encoding="utf-8")
+
+    report = evaluate_release_gate(
+        evidence,
+        baseline_path=baseline_path,
+        cases_path=CASES,
+        thresholds_path=THRESHOLDS,
+    )
+
+    assert report["passed"] is False
+    assert report["classifications"]["infrastructure_failures"] == [
+        f"{config_id}: repeats below 2"
+    ]
 
 
 def test_gate_accepts_two_required_configurations(tmp_path: Path) -> None:
@@ -388,7 +443,8 @@ def test_committed_baseline_records_reviewed_required_configurations() -> None:
     # presented as a baseline for the new configuration. A protected full gate
     # must generate the next candidate.
     assert baseline["approved"] is False
-    assert baseline["required_configurations"] == list(CONFIG_IDS[:2])
+    assert baseline["minimum_repeats"] == 2
+    assert baseline["required_configurations"] == [CONFIG_IDS[0]]
     assert baseline["configurations"] == {}
     assert baseline["approved_at"] is None
     assert baseline["source_revision"] is None

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -479,11 +479,15 @@ def test_committed_live_smoke_subset_is_bounded_balanced_and_canonical() -> None
     } <= ids
 
 
-def test_release_gate_workflow_requires_two_independent_blocking_configurations() -> None:
+def test_release_gate_workflow_smokes_two_providers_and_benchmarks_only_nvidia() -> None:
     workflow = (ROOT / ".github/workflows/live-model-release-gate.yml").read_text(encoding="utf-8")
+    smoke_block = workflow.split("  smoke:", 1)[1].split("  benchmark:", 1)[0]
+    benchmark_block = workflow.split("  benchmark:", 1)[1].split("  aggregate:", 1)[0]
 
-    assert workflow.count("nvidia-nemotron-3-5-lightning-30b-a3b") == 2
-    assert workflow.count("opencode-cli-mimo-v2-5-free") == 2
+    assert smoke_block.count("nvidia-nemotron-3-5-lightning-30b-a3b") == 1
+    assert smoke_block.count("opencode-cli-mimo-v2-5-free") == 1
+    assert benchmark_block.count("nvidia-nemotron-3-5-lightning-30b-a3b") == 1
+    assert "opencode-cli-mimo-v2-5-free" not in benchmark_block
     assert "opencode-cli-nemotron-3-ultra-free" not in workflow
 
 
@@ -507,24 +511,27 @@ def test_release_gate_workflow_is_main_only_protected_and_sequential() -> None:
     assert "needs: [smoke, benchmark]" in aggregate_block
     assert "if: ${{ always() && needs.smoke.result == 'success' }}" in aggregate_block
     assert "name: Cool down shared NVIDIA trial endpoint" not in workflow
-    assert "timeout-minutes: 50" in workflow
+    assert "timeout-minutes: 18" in smoke_block
     assert "--case-tag live-smoke" in workflow
     assert "--repeats 1" in workflow
-    assert "timeout --signal=TERM --kill-after=30s 45m" in smoke_block
+    assert "timeout --signal=TERM --kill-after=30s 15m" in smoke_block
     assert "if exit_code not in (124, 137):" in smoke_block
     assert "Upload sanitized smoke evidence\n        if: always()" in workflow
     assert "live-model-smoke-${{ matrix.configuration }}-${{ github.run_id }}" in workflow
     assert "name: Enforce smoke result" in workflow
     assert "needs: smoke" in workflow
-    # Slow blocking providers must have enough bounded wall-clock budget to finish
-    # all three repeats while still leaving time to upload fail-closed evidence.
-    assert "timeout-minutes: 240" in benchmark_block
-    assert "timeout --signal=TERM --kill-after=30s 225m" in benchmark_block
+    # The single full provider has bounded headroom for two standard repetitions.
+    assert "timeout-minutes: 90" in benchmark_block
+    assert "timeout --signal=TERM --kill-after=30s 75m" in benchmark_block
     assert "if exit_code not in (124, 137):" in benchmark_block
     assert '"state": "running"' in workflow
     assert '"runner_exit_code": None' in workflow
     assert "Upload sanitized configuration evidence\n        if: always()" in workflow
-    assert "default: 3" in workflow
+    assert "default: 2" in workflow
+    assert 'test "$REPEATS" -ge 2' in workflow
+    assert 'test "$REPEATS" -le 3' in workflow
+    assert 'test "$REPEATS" -ge 3' not in workflow
+    assert 'test "$REPEATS" -le 5' not in workflow
     for config_id in CONFIG_IDS[:2]:
         assert config_id in workflow
     assert CONFIG_IDS[2] not in workflow
@@ -552,24 +559,26 @@ def test_release_gate_workflow_is_main_only_protected_and_sequential() -> None:
             "OPENCODE_ZEN_API_KEY: ${{ startsWith(matrix.configuration, 'opencode-cli-') "
             "&& secrets.OPENCODE_ZEN_API_KEY || '' }}"
         )
-        == 2
+        == 1
     )
     assert "NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}" not in workflow
     assert "OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}" not in workflow
-    assert workflow.count("name: Install pinned OpenCode CLI") == 2
-    assert workflow.count('OPENCODE_CLI_VERSION: "1.18.10"') == 2
-    assert workflow.count("if: startsWith(matrix.configuration, 'opencode-cli-')") == 2
-    assert workflow.count("npm ci --prefix evals/live --ignore-scripts --no-audit --no-fund") == 2
+    assert workflow.count("name: Install pinned OpenCode CLI") == 1
+    assert workflow.count('OPENCODE_CLI_VERSION: "1.18.10"') == 1
+    assert workflow.count("if: startsWith(matrix.configuration, 'opencode-cli-')") == 1
+    assert workflow.count("npm ci --prefix evals/live --ignore-scripts --no-audit --no-fund") == 1
     assert (
         workflow.count(
             'test "$(evals/live/node_modules/opencode-linux-x64/bin/opencode --version)" '
             '= "$OPENCODE_CLI_VERSION"'
         )
-        == 2
+        == 1
     )
-    assert workflow.count('nvidia-*) test -n "$NVIDIA_API_KEY" ;;') == 2
-    assert workflow.count('opencode-cli-*) test -n "$OPENCODE_ZEN_API_KEY" ;;') == 2
-    assert workflow.count("Unsupported blocking configuration: $CONFIGURATION_ID") == 2
+    assert workflow.count('nvidia-*) test -n "$NVIDIA_API_KEY" ;;') == 1
+    assert workflow.count('opencode-cli-*) test -n "$OPENCODE_ZEN_API_KEY" ;;') == 1
+    assert workflow.count("Unsupported blocking configuration: $CONFIGURATION_ID") == 1
+    assert 'test -n "$NVIDIA_API_KEY"' in benchmark_block
+    assert "OPENCODE_ZEN_API_KEY" not in benchmark_block
     assert "evaluate_live_model_release_gate.py" in workflow
     assert "generate_live_model_baseline.py" in workflow
     assert "baselines.candidate.yaml" in workflow

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -144,14 +144,36 @@ def test_release_policy_rejects_duplicate_required_configurations(tmp_path: Path
         load_baseline_metadata(baseline_path)
 
 
-def test_release_policy_rejects_fewer_than_two_required_configurations(tmp_path: Path) -> None:
+def test_release_policy_rejects_empty_required_configurations(tmp_path: Path) -> None:
+    baseline_path = _baseline(tmp_path / "baseline.yaml", approved=False)
+    baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
+    baseline["required_configurations"] = []
+    baseline_path.write_text(yaml.safe_dump(baseline, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ReleasePolicyError, match="non-empty"):
+        load_baseline_metadata(baseline_path)
+
+
+def test_release_policy_accepts_one_required_full_configuration(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _tag_server_release(repo)
+    _commit_contract(repo, 2)
     baseline_path = _baseline(tmp_path / "baseline.yaml", approved=False)
     baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
     baseline["required_configurations"] = ["alpha"]
     baseline_path.write_text(yaml.safe_dump(baseline, sort_keys=False), encoding="utf-8")
 
-    with pytest.raises(ReleasePolicyError, match="at least two"):
-        load_baseline_metadata(baseline_path)
+    decision = evaluate_release_readiness(
+        repo_root=repo,
+        policy_path=_policy(tmp_path / "policy.yaml"),
+        baseline_path=baseline_path,
+        ref="HEAD",
+        today=date(2026, 8, 2),
+    )
+
+    assert decision.mode == "full"
+    assert decision.required_configurations == ("alpha",)
+    assert decision.smoke_configurations == ("alpha", "beta")
 
 
 def test_release_policy_accepts_two_required_configurations(tmp_path: Path) -> None:

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -93,6 +93,7 @@ def _policy(path: Path, *, max_age_days: int = 30) -> Path:
                 "release_pull_request_head": "release-please--branches--main",
                 "release_tag_pattern": "mcp-server-v*",
                 "minimum_smoke_configurations": 2,
+                "smoke_configurations": ["alpha", "beta"],
                 "agent_contract_paths": ["src/kicad_mcp/evals/**"],
             },
             sort_keys=False,
@@ -174,6 +175,7 @@ def test_release_policy_accepts_two_required_configurations(tmp_path: Path) -> N
     assert decision.reason == "baseline_unapproved"
     assert decision.release_base_ref == release_tag
     assert decision.required_configurations == ("alpha", "beta")
+    assert decision.smoke_configurations == ("alpha", "beta")
 
 
 def test_release_policy_requires_release_tag_pattern(tmp_path: Path) -> None:
@@ -185,6 +187,7 @@ def test_release_policy_requires_release_tag_pattern(tmp_path: Path) -> None:
                 "baseline_max_age_days": 30,
                 "release_pull_request_head": "release-please--branches--main",
                 "minimum_smoke_configurations": 2,
+                "smoke_configurations": ["alpha", "beta"],
                 "agent_contract_paths": ["src/kicad_mcp/evals/**"],
             },
             sort_keys=False,
@@ -203,6 +206,34 @@ def test_release_policy_rejects_empty_release_tag_pattern(tmp_path: Path) -> Non
     policy_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
 
     with pytest.raises(ReleasePolicyError, match="release_tag_pattern must be a non-empty string"):
+        load_release_policy(policy_path)
+
+
+def test_release_policy_loads_smoke_configurations(tmp_path: Path) -> None:
+    policy = load_release_policy(_policy(tmp_path / "policy.yaml"))
+
+    assert policy.smoke_configurations == ("alpha", "beta")
+
+
+def test_release_policy_rejects_duplicate_smoke_configurations(tmp_path: Path) -> None:
+    policy_path = _policy(tmp_path / "policy.yaml")
+    raw = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    raw["smoke_configurations"] = ["alpha", "alpha"]
+    policy_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ReleasePolicyError, match="smoke_configurations.*duplicates"):
+        load_release_policy(policy_path)
+
+
+def test_release_policy_rejects_minimum_above_smoke_configuration_count(
+    tmp_path: Path,
+) -> None:
+    policy_path = _policy(tmp_path / "policy.yaml")
+    raw = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    raw["minimum_smoke_configurations"] = 3
+    policy_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ReleasePolicyError, match="cannot exceed smoke_configurations"):
         load_release_policy(policy_path)
 
 
@@ -426,6 +457,10 @@ def test_committed_release_policy_tracks_model_facing_inputs_only() -> None:
     assert policy.release_pull_request_head == "release-please--branches--main"
     assert policy.release_tag_pattern == "mcp-server-v*"
     assert policy.minimum_smoke_configurations == 2
+    assert policy.smoke_configurations == (
+        "nvidia-nemotron-3-5-lightning-30b-a3b",
+        "opencode-cli-mimo-v2-5-free",
+    )
     assert "docs/tools-reference.generated.md" in policy.agent_contract_paths
     assert "evals/tool_selection/**" in policy.agent_contract_paths
     assert "evals/live/configurations.yaml" in policy.agent_contract_paths
@@ -538,6 +573,7 @@ def test_release_policy_cli_writes_machine_readable_outputs(tmp_path: Path) -> N
     assert values["mode"] == "full"
     assert values["reason"] == "baseline_unapproved"
     assert values["required_configurations"] == '["alpha","beta","gamma"]'
+    assert values["smoke_configurations"] == '["alpha","beta"]'
     assert values["release_base_ref"] == "mcp-server-v1.0.0"
     assert values["release_contract_changed"] == "true"
     assert len(values["current_contract_digest"]) == 64

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -643,9 +643,7 @@ def test_release_policy_cli_allows_unchanged_release_with_unapproved_baseline(
 
 
 def test_smoke_assurance_cli_uses_policy_smoke_configurations() -> None:
-    script = (ROOT / "scripts/evaluate_live_model_smoke_assurance.py").read_text(
-        encoding="utf-8"
-    )
+    script = (ROOT / "scripts/evaluate_live_model_smoke_assurance.py").read_text(encoding="utf-8")
 
     assert "required_configurations=policy.smoke_configurations" in script
     assert "required_configurations=baseline.required_configurations" not in script

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -620,6 +620,15 @@ def test_release_policy_cli_allows_unchanged_release_with_unapproved_baseline(
     assert values["release_contract_changed"] == "false"
 
 
+def test_smoke_assurance_cli_uses_policy_smoke_configurations() -> None:
+    script = (ROOT / "scripts/evaluate_live_model_smoke_assurance.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "required_configurations=policy.smoke_configurations" in script
+    assert "required_configurations=baseline.required_configurations" not in script
+
+
 def test_live_model_assurance_workflow_is_risk_based_and_secret_safe() -> None:
     workflow = (ROOT / ".github/workflows/live-model-assurance.yml").read_text(encoding="utf-8")
 
@@ -641,7 +650,9 @@ def test_live_model_assurance_workflow_is_risk_based_and_secret_safe() -> None:
     assert "timeout --signal=TERM --kill-after=30s 14m" in workflow
     assert '[ "$exit_code" -ne 124 ] && [ "$exit_code" -ne 137 ]' in workflow
     assert '"state": "running"' in workflow
-    assert "fromJSON(needs.classify.outputs.required_configurations)" in workflow
+    assert "smoke_configurations: ${{ steps.policy.outputs.smoke_configurations }}" in workflow
+    assert "fromJSON(needs.classify.outputs.smoke_configurations)" in workflow
+    assert "fromJSON(needs.classify.outputs.required_configurations)" not in workflow
     assert "evaluate_live_model_smoke_assurance.py" in workflow
     assert "name: Live Model Smoke Assurance" in workflow
     assert "name: Live Model Release Policy" in workflow

--- a/tests/unit/test_opencode_cli_mimo_candidate.py
+++ b/tests/unit/test_opencode_cli_mimo_candidate.py
@@ -9,10 +9,11 @@ from kicad_mcp.evals.live_runner import load_configurations
 ROOT = Path(__file__).resolve().parents[2]
 CONFIGURATIONS = ROOT / "evals/live/configurations.yaml"
 BASELINES = ROOT / "evals/live/baselines.yaml"
+RELEASE_POLICY = ROOT / "evals/live/release-policy.yaml"
 RELEASE_GATE = ROOT / ".github/workflows/live-model-release-gate.yml"
 
 
-def test_mimo_cli_configuration_is_current_bounded_key_scoped_and_blocking() -> None:
+def test_mimo_cli_configuration_is_current_bounded_key_scoped_and_smoke_blocking() -> None:
     configurations = load_configurations(CONFIGURATIONS)
     configuration = configurations["opencode-cli-mimo-v2-5-free"]
 
@@ -38,7 +39,12 @@ def test_mimo_cli_configuration_is_current_bounded_key_scoped_and_blocking() -> 
     assert "opencode-cli-mimo-v2-5-free" in release_gate
     assert "opencode-cli-deepseek-v4-flash-free" not in release_gate
 
+    release_policy = yaml.safe_load(RELEASE_POLICY.read_text(encoding="utf-8"))
+    smoke_required = release_policy["smoke_configurations"]
+    assert "opencode-cli-mimo-v2-5-free" in smoke_required
+    assert "opencode-cli-deepseek-v4-flash-free" not in smoke_required
+
     baselines = yaml.safe_load(BASELINES.read_text(encoding="utf-8"))
-    required = baselines["required_configurations"]
-    assert "opencode-cli-mimo-v2-5-free" in required
-    assert "opencode-cli-deepseek-v4-flash-free" not in required
+    full_required = baselines["required_configurations"]
+    assert "opencode-cli-mimo-v2-5-free" not in full_required
+    assert full_required == ["nvidia-nemotron-3-5-lightning-30b-a3b"]


### PR DESCRIPTION
## Summary

- keep NVIDIA Nemotron Lightning and OpenCode MiMo as mandatory provider-diverse smoke checks
- run the protected 65-case full benchmark only on NVIDIA Nemotron Lightning
- lower the standard full evidence floor from 3 repeats to 2, while allowing an explicit maximum of 3
- keep MiMo versioned for smoke/manual diagnostics without making its hour-scale full benchmark block releases
- preserve fail-closed safety, selection, infrastructure, telemetry, per-case, and baseline-promotion checks

## Verification

- focused live gate/policy/baseline/smoke tests: pass
- full `tests/unit`: pass
- `mypy src/kicad_mcp`: 310 source files clean
- Ruff check/format + `git diff --check`: pass
- workflow parser/actionlint: pass
- GitHub Actions policy + high-severity workflow security/zizmor: pass
- dependency lockfiles unchanged from `origin/main`; OSV findings are not introduced by this branch

## Release follow-up

After merge, dispatch exactly one protected `Live Model Release Gate` with `repeats=2`. Promote only the generated candidate tied to the merged main SHA, then re-evaluate release PR #849.
