### PR TITLE
chore(evals): promote live model baseline

### DIFF
--- a/evals/live/baselines.yaml
+++ b/evals/live/baselines.yaml
@@ -1,17 +1,23 @@
 schema_version: 1
-
-# Pending re-approval. The previous NVIDIA free endpoint was deprecated and the
-# Release smoke still requires independent NVIDIA and OpenCode provider paths,
-# while full-corpus baseline metrics are produced only by NVIDIA Nemotron
-# Lightning. OpenCode MiMo and Ultra remain versioned for smoke/diagnostics.
-# No configuration metrics are carried forward: only a successful protected
-# Live Model Release Gate may generate a new approved baseline candidate.
-approved: false
-approved_at: null
-source_revision: null
-agent_contract_digest: null
-evidence: {}
+approved: true
+approved_at: '2026-09-09'
+source_revision: 4697253ec73bf8cea1de12196ad69ea206747b73
+agent_contract_digest: 0096468ceade4244817b9676cf0cbeb726bc5246448175dc9262f5b5cd04ab44
+evidence:
+  workflow_run_id: 34326073091
+  aggregate_sha256: 944e31bef5e495fe77dd8968956a5dd8371bb66a0e06f8af4b4ccb9b6cb5ccd6
 minimum_repeats: 2
 required_configurations:
 - nvidia-nemotron-3-5-lightning-30b-a3b
-configurations: {}
+configurations:
+  nvidia-nemotron-3-5-lightning-30b-a3b:
+    host: nvidia-nim
+    model: nvidia/nemotron-3.5-lightning-30b-a3b
+    token_metrics_required: true
+    metrics:
+      pass_rate: 1.0
+      mean_recall: 1.0
+      unnecessary_call_rate: 0.0
+      instability_rate: 0.0
+      p95_latency_ms: 8541.744
+      mean_tokens: 3102.0538461538463

--- a/tests/unit/test_live_model_release_gate.py
+++ b/tests/unit/test_live_model_release_gate.py
@@ -437,17 +437,19 @@ def test_committed_live_configurations_include_required_and_diagnostic_records()
 def test_committed_baseline_records_reviewed_required_configurations() -> None:
     baseline = yaml.safe_load((ROOT / "evals/live/baselines.yaml").read_text(encoding="utf-8"))
 
-    # Blocking-provider identities changed, so no stale model metrics may be
-    # presented as a baseline for the new configuration. A protected full gate
-    # must generate the next candidate.
-    assert baseline["approved"] is False
+    assert baseline["approved"] is True
     assert baseline["minimum_repeats"] == 2
     assert baseline["required_configurations"] == [CONFIG_IDS[0]]
-    assert baseline["configurations"] == {}
-    assert baseline["approved_at"] is None
-    assert baseline["source_revision"] is None
-    assert baseline["agent_contract_digest"] is None
-    assert baseline["evidence"] == {}
+    assert list(baseline["configurations"]) == [CONFIG_IDS[0]]
+    assert isinstance(baseline["approved_at"], str) and baseline["approved_at"]
+    assert len(baseline["source_revision"]) == 40
+    assert len(baseline["agent_contract_digest"]) == 64
+    assert isinstance(baseline["evidence"]["workflow_run_id"], int)
+    assert len(baseline["evidence"]["aggregate_sha256"]) == 64
+    configuration = baseline["configurations"][CONFIG_IDS[0]]
+    assert configuration["host"] == HOSTS[0]
+    assert configuration["model"] == MODELS[0]
+    assert configuration["token_metrics_required"] is True
 
 
 def test_committed_live_smoke_subset_is_bounded_balanced_and_canonical() -> None:

--- a/tests/unit/test_live_model_release_policy.py
+++ b/tests/unit/test_live_model_release_policy.py
@@ -494,12 +494,11 @@ def test_committed_release_policy_tracks_model_facing_inputs_only() -> None:
     assert "evals/live/baselines.yaml" not in policy.agent_contract_paths
 
     baseline = yaml.safe_load(BASELINE_PATH.read_text(encoding="utf-8"))
-    # #711 dropped the rate-limited nvidia-minimax-m3 slot for a free OpenCode Zen
-    # model. approved stays false (and the stale approved_at/source_revision/
-    # agent_contract_digest/evidence fields go unvalidated per release_policy.py) until
-    # a real Live Model Release Gate run produces a fresh reviewed baseline candidate.
-    assert baseline["approved"] is False
-    assert set(baseline["configurations"]) < set(baseline["required_configurations"])
+    assert baseline["approved"] is True
+    assert set(baseline["configurations"]) == set(baseline["required_configurations"])
+    assert len(baseline["source_revision"]) == 40
+    assert len(baseline["agent_contract_digest"]) == 64
+    assert isinstance(baseline["evidence"]["workflow_run_id"], int)
 
 
 def test_push_assurance_runs_smoke_only_for_agent_contract_changes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- promote the reviewed baseline candidate generated by protected Live Model Release Gate run 34326073091
- keep the candidate byte-for-byte identical to the uploaded `baselines.candidate.yaml` artifact
- update committed-baseline contract tests from the intentional pending `approved: false` bootstrap state to approved-baseline invariants

## Protected evidence
- source revision: `4697253ec73bf8cea1de12196ad69ea206747b73`
- protected workflow run: `34326073091`
- NVIDIA smoke: success
- OpenCode MiMo smoke: success
- NVIDIA full benchmark: success at `repeats=2`
- aggregate safety/infrastructure/telemetry/per-case failures: empty
- aggregate quality classification: only `approved baselines unavailable`, the intentional bootstrap sentinel accepted by baseline promotion
- generated candidate: `approved: true`, `minimum_repeats: 2`, NVIDIA-only required full configuration
- aggregate SHA-256: `944e31bef5e495fe77dd8968956a5dd8371bb66a0e06f8af4b4ccb9b6cb5ccd6`
- candidate file SHA-256: `8ab04c122ee2c761f10535a15acbb1eaf3b576999892a3d6985e24b63be7d788`

The protected gate itself remained fail-closed before promotion because no approved baseline existed yet. After this reviewed promotion merges, the gate will be dispatched again on fresh `main` and must pass against the approved baseline before release PR #849 is merged.

## Verification
- focused baseline/gate/release-policy tests: 51 passed
- Ruff check/format: clean
- `git diff --check`: clean
- release policy: `approved_baseline_reusable`, baseline/current contract digests match
- independent read-only Codex review: no actionable defect found
