### PR TITLE
fix(release): verify published KiCad PCM tag

### DIFF
--- a/.github/workflows/publish-kicad-pcm.yml
+++ b/.github/workflows/publish-kicad-pcm.yml
@@ -129,6 +129,7 @@ jobs:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
+          release_tag="$RELEASE_TAG"
           for attempt in $(seq 1 6); do
             rm -rf published-kicad-pcm
             mkdir -p published-kicad-pcm

--- a/tests/unit/test_kicad_pcm_release_workflow.py
+++ b/tests/unit/test_kicad_pcm_release_workflow.py
@@ -38,7 +38,9 @@ def test_pcm_release_workflow_verifies_source_builds_attests_and_rechecks_publis
     )
     assert 'gh release upload "$release_tag" release-assets/kicad-pcm/* --clobber' in workflow
     assert "Verify published PCM digest" in workflow
-    assert 'gh release download "$release_tag"' in workflow
+    verify_block = workflow.split("- name: Verify published PCM digest", 1)[1]
+    assert 'release_tag="$RELEASE_TAG"' in verify_block
+    assert 'gh release download "$release_tag"' in verify_block
     assert "for attempt in $(seq 1 6)" in workflow
     assert 'if [ "$attempt" -eq 6 ]; then' in workflow
     assert "sleep 5" in workflow


### PR DESCRIPTION
## Summary
- initialize the local release tag in the published PCM digest verification step
- add a regression contract test scoped to that verification block

## Evidence
- reproduced release run #34334571516 failure: `release_tag: unbound variable`
- independently downloaded `mcp-server-v3.34.1` PCM assets and verified SHA256SUMS successfully
- focused release workflow + hardening tests pass
- GitHub Actions policy, actionlint, workflow security and `git diff --check` pass

After merge, backfill `Publish KiCad PCM` with `tag=mcp-server-v3.34.1` to turn the release verification green.