### PR TITLE
fix(lib): require real footprint documentation geometry

### DIFF
--- a/src/kicad_mcp/utils/footprint_validate.py
+++ b/src/kicad_mcp/utils/footprint_validate.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from .footprint_gen import DensityLevel, chip_pad_geometry
+from .sexpr import _extract_block
 
 FootprintVerdict = Literal["PASS", "WARN", "FAIL"]
 
@@ -308,9 +309,48 @@ def parse_ipc_density(footprint_text: str) -> str | None:
     return (match.group(1) or match.group(2)).upper()
 
 
-_COURTYARD_RE = re.compile(r"[FB]\.CrtYd", re.IGNORECASE)
-_FAB_RE = re.compile(r"[FB]\.Fab", re.IGNORECASE)
-_SILK_RE = re.compile(r"[FB]\.SilkS", re.IGNORECASE)
+_FOOTPRINT_GEOMETRY_TOKENS = frozenset(
+    {"fp_line", "fp_rect", "fp_circle", "fp_arc", "fp_poly", "fp_curve"}
+)
+_SEXPR_TOKEN_RE = re.compile(r"\(\s*([a-z_][a-z0-9_]*)\b", re.IGNORECASE)
+_DOCUMENTATION_LAYER_RE = re.compile(
+    r'\(layer\s+"?(?P<layer>[FB]\.(?:CrtYd|Fab|SilkS))"?\s*\)', re.IGNORECASE
+)
+
+
+def _footprint_geometry_layers(footprint_text: str) -> set[str]:
+    """Return documentation layers used by actual footprint geometry elements."""
+    layers: set[str] = set()
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(footprint_text):
+        char = footprint_text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            index += 1
+            continue
+        if char == "(":
+            token_match = _SEXPR_TOKEN_RE.match(footprint_text, index)
+            if token_match and token_match.group(1).lower() in _FOOTPRINT_GEOMETRY_TOKENS:
+                block, length = _extract_block(footprint_text, index)
+                if block and length:
+                    layer_match = _DOCUMENTATION_LAYER_RE.search(block)
+                    if layer_match:
+                        layers.add(layer_match.group("layer").lower())
+                    index += length
+                    continue
+        index += 1
+    return layers
 
 
 def check_footprint_documentation_layers(footprint_text: str) -> FootprintCheck:
@@ -319,9 +359,10 @@ def check_footprint_documentation_layers(footprint_text: str) -> FootprintCheck:
     No courtyard is a blocking ``FAIL`` (KiCad uses it for placement clearance);
     a missing fab or silkscreen outline ``WARN``s. All three present ``PASS``es.
     """
-    has_courtyard = bool(_COURTYARD_RE.search(footprint_text))
-    has_fab = bool(_FAB_RE.search(footprint_text))
-    has_silk = bool(_SILK_RE.search(footprint_text))
+    geometry_layers = _footprint_geometry_layers(footprint_text)
+    has_courtyard = bool({"f.crtyd", "b.crtyd"} & geometry_layers)
+    has_fab = bool({"f.fab", "b.fab"} & geometry_layers)
+    has_silk = bool({"f.silks", "b.silks"} & geometry_layers)
 
     findings: list[str] = []
     if not has_fab:

--- a/tests/unit/test_footprint_validate.py
+++ b/tests/unit/test_footprint_validate.py
@@ -148,6 +148,40 @@ def test_documentation_layers_pass_when_all_present() -> None:
     assert result.verdict == "PASS"
 
 
+def test_documentation_layers_accept_supported_geometry_primitives() -> None:
+    geometry = (
+        '(fp_curve (pts (xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1)) (layer "F.CrtYd"))\n'
+        '(fp_rect (start -1 -1) (end 1 1) (layer "F.Fab"))\n'
+        '(fp_circle (center 0 0) (end 1 0) (layer "F.SilkS"))\n'
+    )
+
+    result = check_footprint_documentation_layers(geometry)
+
+    assert result.verdict == "PASS"
+
+
+def test_documentation_layers_ignore_layer_names_in_descriptive_text() -> None:
+    fake = '(footprint "X" (descr "mentions F.CrtYd and F.Fab and F.SilkS in prose"))'
+
+    result = check_footprint_documentation_layers(fake)
+
+    assert result.verdict == "FAIL"
+    assert any("courtyard" in finding for finding in result.findings)
+
+
+def test_documentation_layers_ignore_non_geometry_items_on_documentation_layers() -> None:
+    text_only = (
+        '(fp_text reference "REF**" (at 0 0) (layer "F.SilkS"))\n'
+        '(fp_text user "F.Fab" (at 0 0) (layer "F.Fab"))\n'
+        '(fp_text user "F.CrtYd" (at 0 0) (layer "F.CrtYd"))\n'
+    )
+
+    result = check_footprint_documentation_layers(text_only)
+
+    assert result.verdict == "FAIL"
+    assert any("courtyard" in finding for finding in result.findings)
+
+
 def test_documentation_layers_fail_without_courtyard() -> None:
     no_courtyard = (
         '(fp_line (start -1 -1) (end 1 -1) (layer "F.Fab"))\n'

--- a/tests/unit/test_library_footprint_engineering_service.py
+++ b/tests/unit/test_library_footprint_engineering_service.py
@@ -184,6 +184,22 @@ def test_certify_footprint_reports_fail_for_missing_required_pads(tmp_path: Path
     assert "pad-count" in result
 
 
+def test_certify_footprint_rejects_documentation_layer_names_without_geometry(
+    tmp_path: Path,
+) -> None:
+    service, _ = _service(tmp_path)
+    path = tmp_path / "substring-only.kicad_mod"
+    path.write_text(
+        '(footprint "X" (descr "mentions F.CrtYd and F.Fab and F.SilkS in prose"))\n',
+        encoding="utf-8",
+    )
+
+    result = service.certify_footprint("substring-only.kicad_mod")
+
+    assert result.startswith("Footprint certification: FAIL")
+    assert "no courtyard-layer" in result
+
+
 def test_certify_footprint_reports_warn_for_missing_documentation_graphics(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- stop treating raw `F.CrtYd` / `F.Fab` / `F.SilkS` substrings as documentation graphics
- only count layer assignments inside actual footprint geometry primitives (`fp_line`, `fp_rect`, `fp_circle`, `fp_arc`, `fp_poly`, `fp_curve`)
- keep text/description/tag content and `fp_text` from satisfying the geometry gate
- add direct validator and `lib_certify_footprint` service regressions

## Root cause
`check_footprint_documentation_layers()` searched the complete `.kicad_mod` text with three layer-name regexes, so prose or non-geometry items could make all three booleans true without any outline geometry.

## Verification
- exact #864 reproduction: now `FAIL` with missing courtyard/fab/silk findings
- 43 focused footprint/service/registration/architecture tests pass
- `mypy src/kicad_mcp`: 310 source files clean
- Ruff check/format and `git diff --check` clean
- independent read-only review: no actionable defect

Fixes #864
