### PR TITLE
ci: isolate Ubuntu package setup from Chrome apt drift

### DIFF
--- a/.github/workflows/dev-bootstrap.yml
+++ b/.github/workflows/dev-bootstrap.yml
@@ -122,6 +122,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}
           sudo add-apt-repository -y ppa:kicad/kicad-10.0-releases
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends kicad

--- a/.github/workflows/gui-ci.yml
+++ b/.github/workflows/gui-ci.yml
@@ -71,7 +71,9 @@ jobs:
       - name: Install test dependencies
         run: uv sync --group dev --frozen
       - name: Install Playwright browsers
-        run: uv run playwright install --with-deps chromium
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}
+          uv run playwright install --with-deps chromium
       - name: Run dashboard E2E tests
         run: E2E=1 uv run pytest tests/e2e/test_web_dashboard.py -v
 
@@ -89,6 +91,7 @@ jobs:
       - name: Install Linux Tauri dependencies
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Cargo check Tauri bridge

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Install Linux Tauri dependencies
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 

--- a/.github/workflows/kicad-live-e2e.yml
+++ b/.github/workflows/kicad-live-e2e.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Install KiCad 10.0.x CLI
         run: |
           set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}
           sudo add-apt-repository -y ppa:kicad/kicad-10.0-releases
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends kicad
@@ -104,6 +105,7 @@ jobs:
         run: |
           set -uo pipefail
           exec 3>>"$GITHUB_OUTPUT"
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}
           sudo add-apt-repository -y ppa:kicad/kicad-dev-nightly || {
             echo "available=false" >&3
             echo "KiCad nightly PPA is not available on this runner."

--- a/tests/unit/test_ubuntu_apt_workflow_hardening.py
+++ b/tests/unit/test_ubuntu_apt_workflow_hardening.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APT_GUARD = "sudo rm -f /etc/apt/sources.list.d/google-chrome.{list,sources}"
+
+CASES = [
+    ("dev-bootstrap.yml", "Install KiCad 10.0.6 CLI", "sudo add-apt-repository"),
+    ("gui-ci.yml", "Install Playwright browsers", "playwright install --with-deps chromium"),
+    ("gui-ci.yml", "Install Linux Tauri dependencies", "sudo apt-get update"),
+    ("gui-release.yml", "Install Linux Tauri dependencies", "sudo apt-get update"),
+    ("kicad-live-e2e.yml", "Install KiCad 10.0.x CLI", "sudo add-apt-repository"),
+    ("kicad-live-e2e.yml", "Install KiCad nightly preview CLI", "sudo add-apt-repository"),
+]
+
+
+def _named_step(workflow: str, step_name: str) -> str:
+    text = (ROOT / ".github" / "workflows" / workflow).read_text(encoding="utf-8")
+    marker = f"- name: {step_name}"
+    start = text.index(marker)
+    next_step = text.find("\n      - name:", start + len(marker))
+    return text[start : next_step if next_step != -1 else len(text)]
+
+
+def test_ubuntu_package_steps_ignore_unrelated_google_chrome_repository() -> None:
+    for workflow, step_name, package_command in CASES:
+        block = _named_step(workflow, step_name)
+        assert APT_GUARD in block, f"{workflow}: {step_name} lacks apt source guard"
+        assert block.index(APT_GUARD) < block.index(package_command)


### PR DESCRIPTION
## Summary
- disable the unrelated preinstalled Google Chrome APT source before Ubuntu package setup
- cover dev bootstrap, GUI CI, GUI release, and KiCad live E2E
- add a regression contract requiring the guard before each vulnerable package command

## Root cause
Multiple independent Ubuntu jobs on `main` and the 3.34.2 GUI release failed before project code ran because `dl.google.com/linux/chrome` served a `Packages.gz` whose SHA256 did not match its Release metadata. The repository does not need that APT source for these jobs.

## Verification
- regression test observed RED before workflow changes
- focused workflow/release unit suite passes
- Ruff clean / format clean
- `git diff --check` clean
- GitHub Actions policy passes for all workflows
- actionlint passes
- zizmor high severity: no findings
- independent read-only review: no functional regression found

This is CI/release hardening only; it does not change package behavior or move existing release tags.
