### PR TITLE
ci(repo): tolerate npm registry propagation during verification

### DIFF
--- a/scripts/verify-npm-release.mjs
+++ b/scripts/verify-npm-release.mjs
@@ -7,7 +7,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 
 const DEFAULT_REGISTRY_URL = "https://registry.npmjs.org";
-const DEFAULT_RETRIES = 6;
+const DEFAULT_RETRIES = 36;
 const DEFAULT_RETRY_DELAY_MS = 10_000;
 const TRUSTED_REGISTRY_ORIGIN = new URL(DEFAULT_REGISTRY_URL).origin;
 
@@ -138,7 +138,11 @@ export async function verifyPublishedNpmDigest({
   validatePublishedTarballMetadata(rawTarballUrl);
 
   const tarballUrl = packageTarballUrl(packageName, version);
-  const tarball = await fetchBytes(tarballUrl);
+  const tarball = await retry(
+    () => fetchBytes(tarballUrl),
+    retries,
+    retryDelayMs,
+  );
   const tarballName = basename(new URL(tarballUrl).pathname);
   let expected = checksums.get(tarballName);
   if (expected === undefined) {

--- a/tests/js/verify-npm-release-security.test.mjs
+++ b/tests/js/verify-npm-release-security.test.mjs
@@ -77,6 +77,83 @@ test("published digest verification rejects a cross-origin tarball before fetchi
   }
 });
 
+test("published digest verification retries a temporarily unavailable registry tarball", async () => {
+  const directory = temporaryDirectory();
+  const checksumsPath = join(directory, "SHA256SUMS.txt");
+  const payload = new TextEncoder().encode("eventually available tarball");
+  const digest = createHash("sha256").update(payload).digest("hex");
+  writeFileSync(checksumsPath, `${digest}  kicad-mcp-pro-${VERSION}.tgz\n`);
+
+  const originalFetch = globalThis.fetch;
+  let tarballAttempts = 0;
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (!url.endsWith(".tgz")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ dist: { tarball: packageTarballUrl(PACKAGE, VERSION) } }),
+      };
+    }
+    tarballAttempts += 1;
+    if (tarballAttempts === 1) return { ok: false, status: 404 };
+    return { ok: true, status: 200, arrayBuffer: async () => payload.buffer };
+  };
+
+  try {
+    await verifyPublishedNpmDigest({
+      packageName: PACKAGE,
+      version: VERSION,
+      checksumsPath,
+      outputDir: join(directory, "out"),
+      retries: 2,
+      retryDelayMs: 0,
+    });
+    assert.equal(tarballAttempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("default retry budget tolerates a registry tarball propagation window longer than six attempts", async () => {
+  const directory = temporaryDirectory();
+  const checksumsPath = join(directory, "SHA256SUMS.txt");
+  const payload = new TextEncoder().encode("slowly propagated tarball");
+  const digest = createHash("sha256").update(payload).digest("hex");
+  writeFileSync(checksumsPath, `${digest}  kicad-mcp-pro-${VERSION}.tgz\n`);
+
+  const originalFetch = globalThis.fetch;
+  let tarballAttempts = 0;
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (!url.endsWith(".tgz")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ dist: { tarball: packageTarballUrl(PACKAGE, VERSION) } }),
+      };
+    }
+    tarballAttempts += 1;
+    if (tarballAttempts <= 6) return { ok: false, status: 404 };
+    return { ok: true, status: 200, arrayBuffer: async () => payload.buffer };
+  };
+
+  try {
+    await verifyPublishedNpmDigest({
+      packageName: PACKAGE,
+      version: VERSION,
+      checksumsPath,
+      outputDir: join(directory, "out"),
+      retryDelayMs: 0,
+    });
+    assert.equal(tarballAttempts, 7);
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("basename fallback warning does not log registry-controlled names", async () => {
   const directory = temporaryDirectory();
   const checksumsPath = join(directory, "SHA256SUMS.txt");


### PR DESCRIPTION
## Summary

- retry npm registry tarball downloads using the existing bounded retry helper
- expand the default retry budget from 6 to 36 attempts at 10s intervals for npm CDN propagation
- keep checksum/trust failures fail-closed and non-retried

## Incident evidence

The 3.34.3 npm publish succeeded, but immediate post-publish tarball verification received HTTP 404 because npm package metadata became visible before the tarball CDN. The tarball later became available and was independently verified byte-for-byte against the GitHub Release asset with SHA256 `65cec33811479ce157a505ab2d0dd8d18c4875c8a1fbf2f19a0a2bc422d60e5e`. Rerun attempt 2 of publish run `34459294431` then succeeded without republishing.

## Verification

- RED: transient tarball 404 regression test failed before production change
- RED: >6-attempt propagation regression test failed with the old retry budget
- GREEN: `node --test tests/js/verify-npm-release-security.test.mjs` (6/6)
- Node syntax checks green
- live verifier against npm 3.34.3 produced the matching SHA256
- `git diff --check` green
- independent read-only review: no actionable findings

Full repository gates are delegated to protected PR CI because the workstation has uv 0.12.10 while the repository pins uv 0.11.31; the global toolchain was not modified.