### PR TITLE
fix(eval): pin reference-agent MCP runtime

### DIFF
--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -413,6 +413,9 @@ def build_mcp_config(
                 "command": sys.executable,
                 "args": ["-m", "kicad_mcp.server"],
                 "env": {
+                    "PYTHONPATH": str(workspace.checkout_dir / "src"),
+                    "KICAD_MCP_TRANSPORT": "stdio",
+                    "KICAD_MCP_PROTOCOL_LANE": "stable",
                     "KICAD_MCP_PROJECT_DIR": str(workspace.project_dir),
                     "KICAD_MCP_PROFILE": phase.profile,
                     "KICAD_MCP_OPERATING_MODE": phase.mode,

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -190,6 +190,9 @@ def test_build_mcp_config_pins_phase_and_current_python(tmp_path) -> None:
     assert server["command"] == sys.executable
     assert server["args"] == ["-m", "kicad_mcp.server"]
     assert server["env"] == {
+        "PYTHONPATH": str(workspace.checkout_dir / "src"),
+        "KICAD_MCP_TRANSPORT": "stdio",
+        "KICAD_MCP_PROTOCOL_LANE": "stable",
         "KICAD_MCP_PROJECT_DIR": str(workspace.project_dir),
         "KICAD_MCP_PROFILE": "pcb_layout",
         "KICAD_MCP_OPERATING_MODE": "write",


### PR DESCRIPTION
## Summary

- pin reference-board MCP subprocess imports to the exact checkout `src` tree
- force `KICAD_MCP_TRANSPORT=stdio` and stable protocol lane for isolated benchmark runs
- prevent a host-global `kicad-mcp-pro` install or user transport config from changing recorded benchmark runtime semantics

## Root cause

A clean STM32 reference-board attempt on current `main` recorded source revision 3.34.3, but the generated MCP config launched `/usr/local/bin/python3 -m kicad_mcp.server` without a checkout import path. On the physical host this resolved the globally installed `kicad-mcp-pro 3.22.0`, so Claude reported the sole `kicad` MCP server as failed before task execution. Running current checkout source also showed that user configuration could select a non-stdio transport unless explicitly pinned.

The failed run will be retained separately as an infrastructure-invalid attempt rather than discarded from #730 history.

## Verification

- RED: `test_build_mcp_config_pins_phase_and_current_python` failed on missing checkout `PYTHONPATH` / transport pins
- GREEN: focused reference-agent/corpus/quality suite: 102 tests passed
- direct generated-runtime integration starts `kicad-mcp-pro version=3.34.3 transport=stdio`
- Ruff: clean
- Python compile check: clean
- `git diff --check`: clean
- independent read-only review: no actionable findings

Relates to #730 and #729.
