### PR TITLE
fix(evals): bind reference manufacturing approval

### DIFF
--- a/docs/development/reference-board-corpus.md
+++ b/docs/development/reference-board-corpus.md
@@ -77,6 +77,31 @@ prompt, and required successful text artifacts use the same secret/private-path 
 publish raw provider responses, environment dumps, credentials, secret-bearing strings,
 unrelated absolute user paths, or arbitrary nested provider/debug payloads.
 
+## Human manufacturing approval handoff
+
+Reference-board agents do not bypass the production manufacturing human gate. The schematic
+and PCB phases remain autonomous, but the manufacturing phase starts only after a reviewer has
+approved the exact project state. The runner looks for the fixed project-local file
+`reference-manufacturing-approval.json`; arbitrary approval paths are not accepted by the
+benchmark harness.
+
+The approval object uses schema `pcb-reference-manufacturing-approval.v1` and binds the reviewer
+to the board id, benchmark version, attempt id, exact source revision, and a deterministic SHA-256
+over the KiCad schematic/PCB/project/rule files. It also carries the production-required
+`approved_by`, `approved_at_utc`, and `approval_scope=manufacturing_release` fields. If the file is
+missing, symlinked, malformed, belongs to another attempt/source revision, or the design changed
+after review, the manufacturing phase fails before the provider session starts. The same approved
+project-file SHA-256 manifest is revalidated by the manufacturing export service immediately before
+artifact generation, so state drift during the provider session also fails closed.
+
+The runner also requires the runtime `src/`, `scripts/`, `pyproject.toml`, and `uv.lock` state to be
+clean before accepting the source revision as exact. On a valid handoff it adds only the fixed
+relative approval path to the manufacturing prompt and records a sanitized
+`human_manufacturing_approval` workflow event containing the reviewer, source revision, approval
+time, and approved project-state digest. The manufacturing profile does not
+expose design-mutation tools, so a post-approval design change requires a new review rather than
+reusing stale approval evidence.
+
 ## Validate before publication
 
 Run the validator from a clean checkout with the repository's pinned environment:

--- a/scripts/run_reference_board_agent.py
+++ b/scripts/run_reference_board_agent.py
@@ -1,14 +1,20 @@
 import argparse
 import json
+from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 
 from kicad_mcp.evals.reference_agent_runner import (
     ReferenceAgentPhase,
     ReferenceAgentWorkspace,
+    append_reference_manufacturing_approval_instruction,
     build_mcp_config,
     catalog_mcp_tools,
     discover_reference_kicad_cli,
+    discover_reference_source_revision,
     load_phase_prompt,
+    load_reference_manufacturing_approval,
+    reference_manufacturing_approval_event,
     reviewed_mcp_tools,
     run_claude_session,
     write_agent_log,
@@ -43,6 +49,15 @@ def main(argv: list[str] | None = None) -> int:
     prompt = load_phase_prompt(workspace, phase)
     workspace.scratch_dir.mkdir(parents=True, exist_ok=True)
     workspace.project_dir.mkdir(parents=True, exist_ok=True)
+    manufacturing_approval = None
+    manufacturing_handoff_at = None
+    if phase.name == "manufacturing":
+        source_revision = discover_reference_source_revision(workspace.checkout_dir)
+        manufacturing_approval = load_reference_manufacturing_approval(
+            workspace, source_revision=source_revision
+        )
+        manufacturing_handoff_at = datetime.now(UTC)
+        prompt = append_reference_manufacturing_approval_instruction(prompt, manufacturing_approval)
     settings_path = workspace.phase_settings_path(phase)
     mcp_config_path = workspace.phase_mcp_config_path(phase)
     settings_path.write_text("{}\n", encoding="utf-8")
@@ -62,6 +77,11 @@ def main(argv: list[str] | None = None) -> int:
         catalog_mcp_tools=catalog_tools,
         allowed_mcp_tools=execution_tools,
     )
+    if manufacturing_approval is not None:
+        approval_event = reference_manufacturing_approval_event(
+            workspace, manufacturing_approval, handoff_at=manufacturing_handoff_at
+        )
+        summary = replace(summary, events=(approval_event, *summary.events))
     write_agent_log(workspace, summary, append=args.append_agent_log)
     print(
         json.dumps(

--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
 from collections.abc import Iterable, Mapping
@@ -15,12 +17,16 @@ from typing import Any, Literal
 from ..discovery import discover_kicad_cli, find_kicad_version
 from ..operating_modes import is_tool_allowed_in_mode
 from ..tools.router import tools_for_profile
+from .evidence_sanitization import EvidenceSanitizationError, validate_sanitized_evidence
 from .reference_corpus import ReferenceAgentLogEvent
 
 _MCP_PREFIX = "mcp__kicad__"
 _CLAUDE_EXECUTABLE = "claude"
 _CLAUDE_MODEL = "claude-sonnet-5"
 _INTERNAL_TOOLS = frozenset({"ToolSearch"})
+_MANUFACTURING_APPROVAL_FILE = "reference-manufacturing-approval.json"
+_REFERENCE_DESIGN_SUFFIXES = frozenset({".kicad_pro", ".kicad_sch", ".kicad_pcb", ".kicad_dru"})
+_REFERENCE_RUNTIME_PATHS = ("src", "scripts", "pyproject.toml", "uv.lock")
 
 
 class ReferenceAgentRunnerError(ValueError):
@@ -106,6 +112,11 @@ class ReferenceAgentWorkspace:
             project_dir=scratch / "project",
         )
 
+    @property
+    def manufacturing_approval_path(self) -> Path:
+        """Return the fixed project-local human approval evidence path."""
+        return self.project_dir / _MANUFACTURING_APPROVAL_FILE
+
     def phase_settings_path(self, phase: ReferenceAgentPhase) -> Path:
         return self.scratch_dir / f"{phase.name}-settings.json"
 
@@ -132,6 +143,51 @@ def _reference_kicad_candidates() -> tuple[Path, ...]:
         if candidate not in unique:
             unique.append(candidate)
     return tuple(unique)
+
+
+def discover_reference_source_revision(checkout_dir: Path) -> str:
+    """Return the exact Git commit used by one reference-agent runtime."""
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        raise ReferenceAgentRunnerError("reference source revision could not be resolved")
+    try:
+        completed = subprocess.run(
+            [git_executable, "rev-parse", "HEAD"],
+            cwd=checkout_dir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            shell=False,
+            check=False,
+        )
+    except OSError as exc:
+        raise ReferenceAgentRunnerError("reference source revision could not be resolved") from exc
+    revision = completed.stdout.strip()
+    if completed.returncode != 0 or not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise ReferenceAgentRunnerError("reference source revision could not be resolved")
+    status = subprocess.run(
+        [
+            git_executable,
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--",
+            *_REFERENCE_RUNTIME_PATHS,
+        ],
+        cwd=checkout_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        shell=False,
+        check=False,
+    )
+    if status.returncode != 0:
+        raise ReferenceAgentRunnerError("reference runtime source status could not be resolved")
+    if status.stdout.strip():
+        raise ReferenceAgentRunnerError("reference runtime source checkout is dirty")
+    return revision
 
 
 def discover_reference_kicad_cli() -> Path:
@@ -269,6 +325,178 @@ def reviewed_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
     if not reviewed <= catalog:
         raise ReferenceAgentRunnerError("reviewed execution tools exceed phase catalog")
     return reviewed
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceManufacturingApproval:
+    """Human approval bound to one exact reference-board project state."""
+
+    approved_by: str
+    approved_at_utc: datetime
+    source_revision: str
+    project_state_digest: str
+    approved_project_files: tuple[tuple[str, str], ...]
+
+
+def _sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _reference_project_files(workspace: ReferenceAgentWorkspace) -> tuple[tuple[str, str], ...]:
+    """Return the exact approved design-file manifest for one project state."""
+    root = workspace.project_dir
+    if root.is_symlink() or not root.is_dir():
+        raise ReferenceAgentRunnerError("reference project state directory is missing")
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ReferenceAgentRunnerError("reference project state must not contain symlinks")
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root).as_posix()
+        if path.suffix in _REFERENCE_DESIGN_SUFFIXES or relative == ".kicad-mcp/project_spec.json":
+            files.append(path)
+    if not any(path.suffix == ".kicad_sch" for path in files) or not any(
+        path.suffix == ".kicad_pcb" for path in files
+    ):
+        raise ReferenceAgentRunnerError("reference project state requires schematic and PCB files")
+    return tuple(
+        (path.relative_to(root).as_posix(), _sha256_path(path))
+        for path in sorted(files, key=lambda item: item.relative_to(root).as_posix())
+    )
+
+
+def compute_reference_project_state_digest(workspace: ReferenceAgentWorkspace) -> str:
+    """Bind approval to deterministic schematic/PCB/design-rule project state."""
+    files = _reference_project_files(workspace)
+    tree = hashlib.sha256()
+    for relative, digest in files:
+        tree.update(relative.encode("utf-8"))
+        tree.update(b"\0")
+        tree.update(digest.encode("ascii"))
+        tree.update(b"\n")
+    return f"sha256:{tree.hexdigest()}"
+
+
+def load_reference_manufacturing_approval(
+    workspace: ReferenceAgentWorkspace, *, source_revision: str
+) -> ReferenceManufacturingApproval:
+    """Load and fail-closed validate the fixed human approval handoff."""
+    path = workspace.manufacturing_approval_path
+    if path.is_symlink() or not path.is_file():
+        raise ReferenceAgentRunnerError("manufacturing approval evidence is missing")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReferenceAgentRunnerError("manufacturing approval evidence is invalid") from exc
+    if not isinstance(payload, dict):
+        raise ReferenceAgentRunnerError("manufacturing approval evidence must be an object")
+    expected_identity = {
+        "schema_version": "pcb-reference-manufacturing-approval.v1",
+        "approval_scope": "manufacturing_release",
+        "board_id": workspace.board_id,
+        "benchmark_version": workspace.version,
+        "attempt_id": workspace.attempt_id,
+        "source_revision": source_revision,
+    }
+    for key, expected in expected_identity.items():
+        if payload.get(key) != expected:
+            label = "source revision" if key == "source_revision" else f"{key} identity"
+            raise ReferenceAgentRunnerError(f"manufacturing approval {label} does not match")
+    approved_by = payload.get("approved_by")
+    if not isinstance(approved_by, str) or not approved_by.strip() or len(approved_by) > 128:
+        raise ReferenceAgentRunnerError("manufacturing approval reviewer is invalid")
+    try:
+        validate_sanitized_evidence(approved_by)
+    except EvidenceSanitizationError as exc:
+        raise ReferenceAgentRunnerError("manufacturing approval reviewer is invalid") from exc
+    approved_at_raw = payload.get("approved_at_utc")
+    if not isinstance(approved_at_raw, str):
+        raise ReferenceAgentRunnerError("manufacturing approval timestamp is invalid")
+    try:
+        approved_at = datetime.fromisoformat(approved_at_raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ReferenceAgentRunnerError("manufacturing approval timestamp is invalid") from exc
+    if approved_at.utcoffset() is None:
+        raise ReferenceAgentRunnerError("manufacturing approval timestamp must be timezone-aware")
+    actual_files = _reference_project_files(workspace)
+    raw_files = payload.get("approved_project_files")
+    if not isinstance(raw_files, list):
+        raise ReferenceAgentRunnerError("manufacturing approval approved project files are invalid")
+    approved_files: list[tuple[str, str]] = []
+    for item in raw_files:
+        if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+            raise ReferenceAgentRunnerError(
+                "manufacturing approval approved project files are invalid"
+            )
+        relative = item.get("path")
+        digest = item.get("sha256")
+        if not isinstance(relative, str) or not isinstance(digest, str):
+            raise ReferenceAgentRunnerError(
+                "manufacturing approval approved project files are invalid"
+            )
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ReferenceAgentRunnerError(
+                "manufacturing approval approved project files are invalid"
+            )
+        approved_files.append((relative, digest))
+    if tuple(approved_files) != actual_files:
+        raise ReferenceAgentRunnerError(
+            "manufacturing approval project state approved project files do not match"
+        )
+    actual_digest = compute_reference_project_state_digest(workspace)
+    if payload.get("project_state_digest") != actual_digest:
+        raise ReferenceAgentRunnerError("manufacturing approval project state does not match")
+    return ReferenceManufacturingApproval(
+        approved_by=approved_by.strip(),
+        approved_at_utc=approved_at,
+        source_revision=source_revision,
+        project_state_digest=actual_digest,
+        approved_project_files=actual_files,
+    )
+
+
+def append_reference_manufacturing_approval_instruction(
+    prompt: str, approval: ReferenceManufacturingApproval
+) -> str:
+    """Tell the manufacturing agent how to consume already-reviewed approval evidence."""
+    return (
+        prompt.rstrip()
+        + "\n\n## Reviewed manufacturing approval\n"
+        + "A human reviewer approved this exact project state for manufacturing export. "
+        + f"The bound project-state digest is {approval.project_state_digest}. "
+        + "Call export_manufacturing_package with "
+        + f'approval_evidence_path="{_MANUFACTURING_APPROVAL_FILE}". '
+        + "Do not modify the design after approval; stop if any design change is required.\n"
+    )
+
+
+def reference_manufacturing_approval_event(
+    workspace: ReferenceAgentWorkspace,
+    approval: ReferenceManufacturingApproval,
+    *,
+    handoff_at: datetime | None = None,
+) -> ReferenceAgentLogEvent:
+    """Return sanitized provenance for the human approval handoff."""
+    timestamp = handoff_at or datetime.now(UTC)
+    return ReferenceAgentLogEvent(
+        attempt_id=workspace.attempt_id,
+        sequence=1,
+        timestamp=timestamp,
+        event_type="workflow",
+        name="human_manufacturing_approval",
+        status="completed",
+        details={
+            "approved_by": approval.approved_by,
+            "approved_at_utc": approval.approved_at_utc.isoformat(),
+            "source_revision": approval.source_revision,
+            "project_state_digest": approval.project_state_digest,
+        },
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/kicad_mcp/export/manufacturing_package.py
+++ b/src/kicad_mcp/export/manufacturing_package.py
@@ -20,6 +20,9 @@ VariantExport = Callable[[str | None], str]
 _MISSING_APPROVAL_EVIDENCE = (
     "Manufacturing package export is hard-blocked until approval_evidence_path is supplied."
 )
+_APPROVED_PROJECT_SUFFIXES = frozenset({".kicad_pro", ".kicad_sch", ".kicad_pcb", ".kicad_dru"})
+_APPROVED_PROJECT_SPEC = ".kicad-mcp/project_spec.json"
+_REFERENCE_APPROVAL_FILENAME = "reference-manufacturing-approval.json"
 
 
 @dataclass(frozen=True)
@@ -65,6 +68,15 @@ class ExportManufacturingPackageService:
                 ]
             )
         evidence_path, evidence_payload = evidence
+        approved_files_error = self._verify_approved_project_files(evidence_path, evidence_payload)
+        if approved_files_error is not None:
+            return "\n".join(
+                [
+                    approved_files_error,
+                    "- Manufacturing export stopped before artifact generation.",
+                    "- Obtain fresh human approval for the current project state.",
+                ]
+            )
 
         await report_progress(25, 100, "Exporting Gerbers...")
         results = [
@@ -131,6 +143,82 @@ class ExportManufacturingPackageService:
         if missing:
             return "Manufacturing evidence is missing: " + ", ".join(missing)
         return path, dict(payload)
+
+    def _verify_approved_project_files(
+        self, evidence_path: Path, payload: dict[str, Any]
+    ) -> str | None:
+        """Revalidate reference file-level approval bindings at the export boundary."""
+        bound_reference_approval = evidence_path.name == _REFERENCE_APPROVAL_FILENAME
+        raw_files = payload.get("approved_project_files")
+        expected_state = payload.get("project_state_digest")
+        if bound_reference_approval and (raw_files is None or expected_state is None):
+            return "Manufacturing reference approval requires bound project state evidence."
+        if raw_files is None:
+            return None
+        if not isinstance(raw_files, list) or not raw_files:
+            return "Manufacturing evidence approved project files are invalid."
+        seen: set[str] = set()
+        approved_files: list[tuple[str, str]] = []
+        for item in raw_files:
+            if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+                return "Manufacturing evidence approved project files are invalid."
+            relative = item.get("path")
+            expected = item.get("sha256")
+            if not isinstance(relative, str) or not isinstance(expected, str):
+                return "Manufacturing evidence approved project files are invalid."
+            invalid_digest = len(expected) != 64 or any(
+                character not in "0123456789abcdef" for character in expected
+            )
+            if relative in seen or invalid_digest:
+                return "Manufacturing evidence approved project files are invalid."
+            seen.add(relative)
+            approved_files.append((relative, expected))
+
+        current_files = self._current_approved_project_files()
+        if isinstance(current_files, str):
+            return current_files
+        approved_paths = tuple(relative for relative, _digest in approved_files)
+        current_paths = tuple(relative for relative, _digest in current_files)
+        if approved_paths != current_paths:
+            return "Manufacturing evidence approved project state digest mismatch."
+        if tuple(approved_files) != current_files:
+            return "Manufacturing evidence approved project file digest mismatch."
+
+        if expected_state is not None:
+            if not isinstance(expected_state, str) or not expected_state.startswith("sha256:"):
+                return "Manufacturing evidence approved project state digest is invalid."
+            tree = hashlib.sha256()
+            for relative, digest in current_files:
+                tree.update(relative.encode("utf-8"))
+                tree.update(b"\0")
+                tree.update(digest.encode("ascii"))
+                tree.update(b"\n")
+            if expected_state != f"sha256:{tree.hexdigest()}":
+                return "Manufacturing evidence approved project state digest mismatch."
+        return None
+
+    def _current_approved_project_files(self) -> tuple[tuple[str, str], ...] | str:
+        try:
+            root = self.resolve_project_path(".")
+        except ValueError:
+            return "Manufacturing evidence project root is invalid."
+        if root.is_symlink() or not root.is_dir():
+            return "Manufacturing evidence project root is invalid."
+        files: list[Path] = []
+        for path in root.rglob("*"):
+            relative = path.relative_to(root).as_posix()
+            relevant = (
+                path.suffix in _APPROVED_PROJECT_SUFFIXES or relative == _APPROVED_PROJECT_SPEC
+            )
+            if not relevant:
+                continue
+            if path.is_symlink() or not path.is_file():
+                return "Manufacturing evidence approved project file is invalid."
+            files.append(path)
+        return tuple(
+            (path.relative_to(root).as_posix(), self._file_sha256(path))
+            for path in sorted(files, key=lambda item: item.relative_to(root).as_posix())
+        )
 
     @staticmethod
     def _file_sha256(path: Path) -> str:

--- a/tests/unit/test_export_manufacturing_package_service.py
+++ b/tests/unit/test_export_manufacturing_package_service.py
@@ -241,3 +241,81 @@ async def test_package_omits_unsupported_optional_manufacturing_formats(tmp_path
         (tmp_path / "output" / "manufacturing_release_report.json").read_text(encoding="utf-8")
     )
     assert all("not supported" not in item for item in report["export_results"])
+
+
+@pytest.mark.anyio
+async def test_package_revalidates_approved_project_file_digests_at_export_boundary(
+    tmp_path: Path,
+) -> None:
+    import hashlib
+
+    service, calls, _output_root = _service(tmp_path)
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text("approved-state\n", encoding="utf-8")
+    approval = _approval_payload() | {
+        "approved_project_files": [
+            {
+                "path": "board.kicad_pcb",
+                "sha256": hashlib.sha256(board.read_bytes()).hexdigest(),
+            }
+        ]
+    }
+    evidence_path = tmp_path / "approval.json"
+    evidence_path.write_text(json.dumps(approval), encoding="utf-8")
+    board.write_text("changed-after-approval\n", encoding="utf-8")
+
+    result, _progress, _rendered = await _run_export(
+        service, approval_evidence_path="approval.json"
+    )
+
+    assert "approved project file digest mismatch" in result
+    assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))
+
+
+@pytest.mark.anyio
+async def test_package_rejects_project_file_added_after_bound_approval(tmp_path: Path) -> None:
+    import hashlib
+
+    service, calls, _output_root = _service(tmp_path)
+    board = tmp_path / "board.kicad_pcb"
+    schematic = tmp_path / "board.kicad_sch"
+    board.write_text("board\n", encoding="utf-8")
+    schematic.write_text("schematic\n", encoding="utf-8")
+    approved_files = [
+        {"path": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+        for path in (board, schematic)
+    ]
+    tree = hashlib.sha256()
+    for item in approved_files:
+        tree.update(item["path"].encode("utf-8"))
+        tree.update(b"\0")
+        tree.update(item["sha256"].encode("ascii"))
+        tree.update(b"\n")
+    approval = _approval_payload() | {
+        "approved_project_files": approved_files,
+        "project_state_digest": f"sha256:{tree.hexdigest()}",
+    }
+    evidence_path = tmp_path / "approval.json"
+    evidence_path.write_text(json.dumps(approval), encoding="utf-8")
+    (tmp_path / "unreviewed.kicad_dru").write_text("rules\n", encoding="utf-8")
+
+    result, _progress, _rendered = await _run_export(
+        service, approval_evidence_path="approval.json"
+    )
+
+    assert "approved project state digest mismatch" in result
+    assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))
+
+
+@pytest.mark.anyio
+async def test_reference_approval_filename_requires_project_state_bindings(tmp_path: Path) -> None:
+    service, calls, _output_root = _service(tmp_path)
+    evidence_path = tmp_path / "reference-manufacturing-approval.json"
+    evidence_path.write_text(json.dumps(_approval_payload()), encoding="utf-8")
+
+    result, _progress, _rendered = await _run_export(
+        service, approval_evidence_path="reference-manufacturing-approval.json"
+    )
+
+    assert "reference approval requires bound project state" in result
+    assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))

--- a/tests/unit/test_export_manufacturing_package_service.py
+++ b/tests/unit/test_export_manufacturing_package_service.py
@@ -319,3 +319,103 @@ async def test_reference_approval_filename_requires_project_state_bindings(tmp_p
 
     assert "reference approval requires bound project state" in result
     assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "approved_files, expected",
+    [
+        ([], "approved project files are invalid"),
+        (["bad"], "approved project files are invalid"),
+        ([{"path": 1, "sha256": "0" * 64}], "approved project files are invalid"),
+        ([{"path": "board.kicad_pcb", "sha256": "bad"}], "approved project files are invalid"),
+        (
+            [
+                {"path": "board.kicad_pcb", "sha256": "0" * 64},
+                {"path": "board.kicad_pcb", "sha256": "0" * 64},
+            ],
+            "approved project files are invalid",
+        ),
+    ],
+)
+async def test_package_rejects_malformed_bound_file_manifests(
+    tmp_path: Path, approved_files: object, expected: str
+) -> None:
+    service, calls, _output_root = _service(tmp_path)
+    evidence_path = tmp_path / "approval.json"
+    evidence_path.write_text(
+        json.dumps(_approval_payload() | {"approved_project_files": approved_files}),
+        encoding="utf-8",
+    )
+
+    result, _progress, _rendered = await _run_export(
+        service, approval_evidence_path="approval.json"
+    )
+
+    assert expected in result
+    assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))
+
+
+@pytest.mark.anyio
+async def test_package_rejects_invalid_bound_state_digest(tmp_path: Path) -> None:
+    import hashlib
+
+    service, calls, _output_root = _service(tmp_path)
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text("board\n", encoding="utf-8")
+    approved_files = [
+        {"path": board.name, "sha256": hashlib.sha256(board.read_bytes()).hexdigest()}
+    ]
+    evidence_path = tmp_path / "approval.json"
+    evidence_path.write_text(
+        json.dumps(
+            _approval_payload()
+            | {"approved_project_files": approved_files, "project_state_digest": "not-a-digest"}
+        ),
+        encoding="utf-8",
+    )
+
+    result, _progress, _rendered = await _run_export(
+        service, approval_evidence_path="approval.json"
+    )
+
+    assert "approved project state digest is invalid" in result
+    assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))
+
+
+@pytest.mark.anyio
+async def test_package_rejects_invalid_project_root_for_bound_manifest(tmp_path: Path) -> None:
+    import hashlib
+
+    service, calls, _output_root = _service(tmp_path)
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text("board\n", encoding="utf-8")
+    evidence_path = tmp_path / "approval.json"
+    evidence_path.write_text(
+        json.dumps(
+            _approval_payload()
+            | {
+                "approved_project_files": [
+                    {"path": board.name, "sha256": hashlib.sha256(board.read_bytes()).hexdigest()}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_resolver = service.resolve_project_path
+    object.__setattr__(
+        service,
+        "resolve_project_path",
+        lambda text: (
+            (_ for _ in ()).throw(ValueError("root unavailable"))
+            if text == "."
+            else original_resolver(text)
+        ),
+    )
+
+    result, _progress, _rendered = await _run_export(
+        service, approval_evidence_path="approval.json"
+    )
+
+    assert "project root is invalid" in result
+    assert all(not calls[name] for name in ("gerber", "drill", "bom", "pick", "ipc", "odb"))

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -732,3 +732,358 @@ def test_reference_agent_phase_rejects_unknown_name() -> None:
 
     with pytest.raises(ReferenceAgentRunnerError, match="unsupported reference-agent phase"):
         ReferenceAgentPhase.for_name("unknown")
+
+
+def _write_reference_manufacturing_approval(
+    workspace, *, source_revision: str, digest: str
+) -> None:
+    import json
+
+    workspace.project_dir.mkdir(parents=True, exist_ok=True)
+    workspace.manufacturing_approval_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "pcb-reference-manufacturing-approval.v1",
+                "approved_by": "benchmark-reviewer",
+                "approved_at_utc": "2026-09-10T16:00:00Z",
+                "approval_scope": "manufacturing_release",
+                "board_id": workspace.board_id,
+                "benchmark_version": workspace.version,
+                "attempt_id": workspace.attempt_id,
+                "source_revision": source_revision,
+                "project_state_digest": digest,
+                "approved_project_files": [
+                    {
+                        "path": path.relative_to(workspace.project_dir).as_posix(),
+                        "sha256": __import__("hashlib").sha256(path.read_bytes()).hexdigest(),
+                    }
+                    for path in sorted(workspace.project_dir.rglob("*"))
+                    if path.is_file()
+                    and (
+                        path.suffix in {".kicad_pro", ".kicad_sch", ".kicad_pcb", ".kicad_dru"}
+                        or path.relative_to(workspace.project_dir).as_posix()
+                        == ".kicad-mcp/project_spec.json"
+                    )
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_reference_manufacturing_approval_is_required_and_bound_to_project_state(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "a" * 40
+    digest = compute_reference_project_state_digest(workspace)
+
+    with pytest.raises(
+        ReferenceAgentRunnerError, match="manufacturing approval evidence is missing"
+    ):
+        load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+
+    _write_reference_manufacturing_approval(
+        workspace, source_revision=source_revision, digest=digest
+    )
+    approval = load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+    assert approval.project_state_digest == digest
+    assert approval.approved_by == "benchmark-reviewer"
+
+
+def test_reference_manufacturing_approval_rejects_source_or_state_drift(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    board = workspace.project_dir / "demo.kicad_pcb"
+    board.write_text("board-v1\n", encoding="utf-8")
+    source_revision = "b" * 40
+    digest = compute_reference_project_state_digest(workspace)
+    _write_reference_manufacturing_approval(
+        workspace, source_revision=source_revision, digest=digest
+    )
+
+    with pytest.raises(ReferenceAgentRunnerError, match="source revision"):
+        load_reference_manufacturing_approval(workspace, source_revision="c" * 40)
+
+    board.write_text("board-v2\n", encoding="utf-8")
+    with pytest.raises(ReferenceAgentRunnerError, match="project state"):
+        load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+
+
+def test_reference_manufacturing_prompt_uses_fixed_project_local_approval_path(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        append_reference_manufacturing_approval_instruction,
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "d" * 40
+    _write_reference_manufacturing_approval(
+        workspace,
+        source_revision=source_revision,
+        digest=compute_reference_project_state_digest(workspace),
+    )
+    approval = load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+    prompt = append_reference_manufacturing_approval_instruction("Manufacture.\n", approval)
+
+    assert 'approval_evidence_path="reference-manufacturing-approval.json"' in prompt
+    assert str(workspace.project_dir) not in prompt
+
+
+def test_reference_manufacturing_approval_event_is_sanitized(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+        reference_manufacturing_approval_event,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "e" * 40
+    _write_reference_manufacturing_approval(
+        workspace,
+        source_revision=source_revision,
+        digest=compute_reference_project_state_digest(workspace),
+    )
+    approval = load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+    event = reference_manufacturing_approval_event(workspace, approval)
+
+    assert event.event_type == "workflow"
+    assert event.name == "human_manufacturing_approval"
+    assert event.status == "completed"
+    assert event.details["source_revision"] == source_revision
+    assert event.details["project_state_digest"] == approval.project_state_digest
+
+
+def test_reference_agent_cli_manufacturing_fails_before_provider_without_human_approval(
+    tmp_path, monkeypatch
+) -> None:
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
+    spec = importlib.util.spec_from_file_location("reference_agent_manufacturing_missing", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    board = tmp_path / "docs/evidence/reference-boards/stm32f072-usbc/v1"
+    board.mkdir(parents=True)
+    (board / "original-prompt.md").write_text(
+        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
+        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n",
+        encoding="utf-8",
+    )
+    project = tmp_path / ".dev-tools/reference-agent-runs/stm32f072-usbc/v1/attempt-003/project"
+    project.mkdir(parents=True)
+    (project / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (project / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "discover_reference_source_revision", lambda _root: "f" * 40)
+    monkeypatch.setattr(module, "discover_reference_kicad_cli", lambda: tmp_path / "kicad-cli")
+
+    def fail_run(**_kwargs: object):
+        raise AssertionError("provider must not start before human manufacturing approval")
+
+    monkeypatch.setattr(module, "run_claude_session", fail_run)
+    with pytest.raises(ValueError, match="manufacturing approval evidence is missing"):
+        module.main(
+            ["--board-id", "stm32f072-usbc", "--attempt-number", "3", "--phase", "manufacturing"]
+        )
+
+
+def test_reference_agent_cli_manufacturing_consumes_bound_approval_and_logs_handoff(
+    tmp_path, monkeypatch
+) -> None:
+    import importlib.util
+
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunSummary,
+        ReferenceAgentWorkspace,
+        compute_reference_project_state_digest,
+    )
+
+    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
+    spec = importlib.util.spec_from_file_location("reference_agent_manufacturing_valid", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    board = tmp_path / "docs/evidence/reference-boards/stm32f072-usbc/v1"
+    board.mkdir(parents=True)
+    (board / "original-prompt.md").write_text(
+        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
+        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    workspace = ReferenceAgentWorkspace.for_reviewed_attempt(
+        checkout_dir=tmp_path, board_id="stm32f072-usbc", attempt_number=3
+    )
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "f" * 40
+    _write_reference_manufacturing_approval(
+        workspace,
+        source_revision=source_revision,
+        digest=compute_reference_project_state_digest(workspace),
+    )
+    monkeypatch.setattr(module, "discover_reference_source_revision", lambda _root: source_revision)
+    monkeypatch.setattr(module, "discover_reference_kicad_cli", lambda: tmp_path / "kicad-cli")
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs: object) -> ReferenceAgentRunSummary:
+        captured.update(kwargs)
+        return ReferenceAgentRunSummary(
+            events=(),
+            primary_model="claude-sonnet-5",
+            auxiliary_models=(),
+            provider="firstParty",
+            permission_denials=0,
+            terminal_reason="completed",
+            successful=True,
+        )
+
+    monkeypatch.setattr(module, "run_claude_session", fake_run)
+    assert (
+        module.main(
+            ["--board-id", "stm32f072-usbc", "--attempt-number", "3", "--phase", "manufacturing"]
+        )
+        == 0
+    )
+    assert 'approval_evidence_path="reference-manufacturing-approval.json"' in captured["prompt"]
+    events = [json.loads(line) for line in workspace.agent_log_path.read_text().splitlines()]
+    assert events[0]["name"] == "human_manufacturing_approval"
+    assert events[0]["details"]["source_revision"] == source_revision
+
+
+def test_reference_source_revision_rejects_dirty_runtime_source_but_not_evidence(tmp_path) -> None:
+    import shutil
+    import subprocess
+
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        discover_reference_source_revision,
+    )
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "src/runtime.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tmp_path / "scripts/runner.py").write_text("print('run')\n", encoding="utf-8")
+    git_executable = shutil.which("git")
+    assert git_executable is not None
+    subprocess.run([git_executable, "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [git_executable, "config", "user.email", "test@example.com"], cwd=tmp_path, check=True
+    )
+    subprocess.run([git_executable, "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    subprocess.run([git_executable, "add", "src", "scripts"], cwd=tmp_path, check=True)
+    subprocess.run([git_executable, "commit", "-qm", "fixture"], cwd=tmp_path, check=True)
+    revision = discover_reference_source_revision(tmp_path)
+    assert len(revision) == 40
+
+    evidence = tmp_path / "docs/evidence/reference-boards/board/v1/attempts/attempt-003"
+    evidence.mkdir(parents=True)
+    (evidence / "agent-log.jsonl").write_text("{}\n", encoding="utf-8")
+    assert discover_reference_source_revision(tmp_path) == revision
+
+    (tmp_path / "src/runtime.py").write_text("VALUE = 2\n", encoding="utf-8")
+    with pytest.raises(ReferenceAgentRunnerError, match="runtime source checkout is dirty"):
+        discover_reference_source_revision(tmp_path)
+
+
+def test_reference_manufacturing_approval_requires_exact_approved_file_manifest(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "9" * 40
+    _write_reference_manufacturing_approval(
+        workspace,
+        source_revision=source_revision,
+        digest=compute_reference_project_state_digest(workspace),
+    )
+    payload = json.loads(workspace.manufacturing_approval_path.read_text())
+    payload["approved_project_files"][0]["sha256"] = "0" * 64
+    workspace.manufacturing_approval_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ReferenceAgentRunnerError, match="approved project files"):
+        load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+
+
+def test_reference_manufacturing_approval_rejects_unsafe_reviewer_before_provider(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "7" * 40
+    _write_reference_manufacturing_approval(
+        workspace,
+        source_revision=source_revision,
+        digest=compute_reference_project_state_digest(workspace),
+    )
+    payload = json.loads(workspace.manufacturing_approval_path.read_text())
+    payload["approved_by"] = "/home/private/reviewer"
+    workspace.manufacturing_approval_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(ReferenceAgentRunnerError, match="reviewer is invalid"):
+        load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+
+
+def test_reference_manufacturing_approval_event_uses_handoff_time_not_approval_time(
+    tmp_path,
+) -> None:
+    from datetime import UTC, datetime
+
+    from kicad_mcp.evals.reference_agent_runner import (
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+        reference_manufacturing_approval_event,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "8" * 40
+    _write_reference_manufacturing_approval(
+        workspace,
+        source_revision=source_revision,
+        digest=compute_reference_project_state_digest(workspace),
+    )
+    approval = load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+    handoff_at = datetime(2026, 9, 10, 17, 0, tzinfo=UTC)
+    event = reference_manufacturing_approval_event(workspace, approval, handoff_at=handoff_at)
+    assert event.timestamp == handoff_at
+    assert event.details["approved_at_utc"] == "2026-09-10T16:00:00+00:00"

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -1087,3 +1087,140 @@ def test_reference_manufacturing_approval_event_uses_handoff_time_not_approval_t
     event = reference_manufacturing_approval_event(workspace, approval, handoff_at=handoff_at)
     assert event.timestamp == handoff_at
     assert event.details["approved_at_utc"] == "2026-09-10T16:00:00+00:00"
+
+
+def test_reference_source_revision_fail_closed_error_paths(tmp_path, monkeypatch) -> None:
+    import kicad_mcp.evals.reference_agent_runner as runner
+
+    monkeypatch.setattr(runner.shutil, "which", lambda _name: None)
+    with pytest.raises(runner.ReferenceAgentRunnerError, match="source revision"):
+        runner.discover_reference_source_revision(tmp_path)
+
+    monkeypatch.setattr(runner.shutil, "which", lambda _name: "/usr/bin/git")
+
+    def raise_oserror(*_args: object, **_kwargs: object) -> None:
+        raise OSError("boom")
+
+    monkeypatch.setattr(runner.subprocess, "run", raise_oserror)
+    with pytest.raises(runner.ReferenceAgentRunnerError, match="source revision"):
+        runner.discover_reference_source_revision(tmp_path)
+
+    class Result:
+        def __init__(self, returncode: int, stdout: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+
+    monkeypatch.setattr(runner.subprocess, "run", lambda *_args, **_kwargs: Result(1, "not-a-sha"))
+    with pytest.raises(runner.ReferenceAgentRunnerError, match="source revision"):
+        runner.discover_reference_source_revision(tmp_path)
+
+    calls = iter((Result(0, "a" * 40), Result(1, "")))
+    monkeypatch.setattr(runner.subprocess, "run", lambda *_args, **_kwargs: next(calls))
+    with pytest.raises(runner.ReferenceAgentRunnerError, match="runtime source status"):
+        runner.discover_reference_source_revision(tmp_path)
+
+
+def test_reference_project_state_fail_closed_structure_paths(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        compute_reference_project_state_digest,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    with pytest.raises(ReferenceAgentRunnerError, match="state directory is missing"):
+        compute_reference_project_state_digest(workspace)
+
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "nested").mkdir()
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    with pytest.raises(ReferenceAgentRunnerError, match="requires schematic and PCB"):
+        compute_reference_project_state_digest(workspace)
+
+    board = workspace.project_dir / "demo.kicad_pcb"
+    board.write_text("board\n", encoding="utf-8")
+    link = workspace.project_dir / "linked.kicad_dru"
+    try:
+        link.symlink_to(board.name)
+    except OSError:
+        pytest.skip("symlinks are not available")
+    with pytest.raises(ReferenceAgentRunnerError, match="must not contain symlinks"):
+        compute_reference_project_state_digest(workspace)
+
+
+def test_reference_manufacturing_approval_rejects_malformed_evidence_variants(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import (
+        ReferenceAgentRunnerError,
+        compute_reference_project_state_digest,
+        load_reference_manufacturing_approval,
+    )
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    workspace.project_dir.mkdir(parents=True)
+    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
+    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
+    source_revision = "6" * 40
+    digest = compute_reference_project_state_digest(workspace)
+
+    workspace.manufacturing_approval_path.write_text("{bad json\n", encoding="utf-8")
+    with pytest.raises(ReferenceAgentRunnerError, match="evidence is invalid"):
+        load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+
+    workspace.manufacturing_approval_path.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ReferenceAgentRunnerError, match="must be an object"):
+        load_reference_manufacturing_approval(workspace, source_revision=source_revision)
+
+    def valid_payload() -> dict[str, object]:
+        _write_reference_manufacturing_approval(
+            workspace, source_revision=source_revision, digest=digest
+        )
+        return json.loads(workspace.manufacturing_approval_path.read_text())
+
+    cases = [
+        ("reviewer", lambda p: p.__setitem__("approved_by", ""), "reviewer is invalid"),
+        ("timestamp-type", lambda p: p.__setitem__("approved_at_utc", 123), "timestamp is invalid"),
+        (
+            "timestamp-value",
+            lambda p: p.__setitem__("approved_at_utc", "not-a-date"),
+            "timestamp is invalid",
+        ),
+        (
+            "timestamp-naive",
+            lambda p: p.__setitem__("approved_at_utc", "2026-09-10T16:00:00"),
+            "timezone-aware",
+        ),
+        (
+            "files-type",
+            lambda p: p.__setitem__("approved_project_files", "bad"),
+            "approved project files",
+        ),
+        (
+            "files-item",
+            lambda p: p.__setitem__("approved_project_files", ["bad"]),
+            "approved project files",
+        ),
+        (
+            "files-value-type",
+            lambda p: p.__setitem__("approved_project_files", [{"path": 1, "sha256": "0" * 64}]),
+            "approved project files",
+        ),
+        (
+            "files-digest",
+            lambda p: p.__setitem__(
+                "approved_project_files", [{"path": "demo.kicad_pcb", "sha256": "bad"}]
+            ),
+            "approved project files",
+        ),
+        (
+            "tree-digest",
+            lambda p: p.__setitem__("project_state_digest", "sha256:" + "0" * 64),
+            "project state",
+        ),
+    ]
+    for _label, mutate, message in cases:
+        payload = valid_payload()
+        mutate(payload)
+        workspace.manufacturing_approval_path.write_text(
+            json.dumps(payload) + "\n", encoding="utf-8"
+        )
+        with pytest.raises(ReferenceAgentRunnerError, match=message):
+            load_reference_manufacturing_approval(workspace, source_revision=source_revision)


### PR DESCRIPTION
## Summary
- bind reference-board manufacturing approval to exact board/version/attempt/source and project file SHA manifest
- fail closed on dirty runtime source and stale/changed/added project files at export boundary
- preserve the production human manufacturing gate while keeping legacy approval paths backward-compatible
- record sanitized handoff evidence with monotonic event timing

## Verification
- reference runner/corpus/quality + manufacturing/export focused suite green
- Ruff check/format, compileall, git diff --check green
- independent review found no remaining actionable defects

Refs #730