### PR TITLE
fix(evals): make reference manufacturing reproducible

### DIFF
--- a/docs/development/reference-board-corpus.md
+++ b/docs/development/reference-board-corpus.md
@@ -77,30 +77,34 @@ prompt, and required successful text artifacts use the same secret/private-path 
 publish raw provider responses, environment dumps, credentials, secret-bearing strings,
 unrelated absolute user paths, or arbitrary nested provider/debug payloads.
 
-## Human manufacturing approval handoff
+## Benchmark manufacturing reproducibility boundary
 
-Reference-board agents do not bypass the production manufacturing human gate. The schematic
-and PCB phases remain autonomous, but the manufacturing phase starts only after a reviewer has
-approved the exact project state. The runner looks for the fixed project-local file
-`reference-manufacturing-approval.json`; arbitrary approval paths are not accepted by the
-benchmark harness.
+Reference-board benchmarks do **not** turn autonomous evidence generation into a production
+manufacturing release. The production `export_manufacturing_package()` path remains human-gated
+and is not exposed to the benchmark manufacturing agent. The benchmark instead launches the
+opt-in `kicad_mcp.evals.reference_mcp_server` over stdio with an exact discovery **and execution**
+allowlist. Hidden production tools cannot be invoked by name through that server.
 
-The approval object uses schema `pcb-reference-manufacturing-approval.v1` and binds the reviewer
-to the board id, benchmark version, attempt id, exact source revision, and a deterministic SHA-256
-over the KiCad schematic/PCB/project/rule files. It also carries the production-required
-`approved_by`, `approved_at_utc`, and `approval_scope=manufacturing_release` fields. If the file is
-missing, symlinked, malformed, belongs to another attempt/source revision, or the design changed
-after review, the manufacturing phase fails before the provider session starts. The same approved
-project-file SHA-256 manifest is revalidated by the manufacturing export service immediately before
-artifact generation, so state drift during the provider session also fails closed.
+The benchmark surface exposes validation/inspection tools plus two fixed orchestration tools:
+`reference_generate_manufacturing_snapshot()` and
+`reference_compare_manufacturing_snapshots()`. Each generation starts from a fresh fixed output
+location and produces a non-empty BOM plus Gerber and drill files through the same KiCad CLI export
+services used by the product. Export failures, missing required outputs, symlinks, stale manifests,
+or post-generation byte changes fail closed. Direct low-level export tools are not exposed to the
+agent, so evidence cannot be written outside the two reviewed generation roots.
 
-The runner also requires the runtime `src/`, `scripts/`, `pyproject.toml`, and `uv.lock` state to be
-clean before accepting the source revision as exact. On a valid handoff it adds only the fixed
-relative approval path to the manufacturing prompt and records a sanitized
-`human_manufacturing_approval` workflow event containing the reviewer, source revision, approval
-time, and approved project-state digest. The manufacturing profile does not
-expose design-mutation tools, so a post-approval design change requires a new review rather than
-reusing stale approval evidence.
+The comparator always preserves the SHA-256 manifest digest for each raw generation. If raw bytes
+match, the result is `byte_identical`. KiCad CLI embeds wall-clock creation timestamps in otherwise
+stable Gerber, drill, and Gerber-job outputs, so rule set `kicad-cli-timestamps-v1` may classify two
+raw-different generations as `normalized_equivalent` only when the files identify KiCad as the
+generator and all differences disappear after replacing those exact creation-time metadata fields.
+BOM data and manufacturing geometry/coordinates are never normalized. Any other byte difference
+remains `divergent`. Raw artifacts are never modified by comparison.
+
+The earlier state-bound `reference-manufacturing-approval.json` contract remains a valid hardening
+mechanism for human-gated production release workflows, but it is not required by this autonomous
+benchmark evidence phase because #730 measures artifact generation/reproducibility rather than
+production release authorization.
 
 ## Validate before publication
 

--- a/scripts/run_reference_board_agent.py
+++ b/scripts/run_reference_board_agent.py
@@ -1,20 +1,15 @@
 import argparse
 import json
-from dataclasses import replace
-from datetime import UTC, datetime
 from pathlib import Path
 
 from kicad_mcp.evals.reference_agent_runner import (
     ReferenceAgentPhase,
     ReferenceAgentWorkspace,
-    append_reference_manufacturing_approval_instruction,
+    append_reference_manufacturing_reproducibility_instruction,
     build_mcp_config,
     catalog_mcp_tools,
     discover_reference_kicad_cli,
-    discover_reference_source_revision,
     load_phase_prompt,
-    load_reference_manufacturing_approval,
-    reference_manufacturing_approval_event,
     reviewed_mcp_tools,
     run_claude_session,
     write_agent_log,
@@ -49,15 +44,8 @@ def main(argv: list[str] | None = None) -> int:
     prompt = load_phase_prompt(workspace, phase)
     workspace.scratch_dir.mkdir(parents=True, exist_ok=True)
     workspace.project_dir.mkdir(parents=True, exist_ok=True)
-    manufacturing_approval = None
-    manufacturing_handoff_at = None
     if phase.name == "manufacturing":
-        source_revision = discover_reference_source_revision(workspace.checkout_dir)
-        manufacturing_approval = load_reference_manufacturing_approval(
-            workspace, source_revision=source_revision
-        )
-        manufacturing_handoff_at = datetime.now(UTC)
-        prompt = append_reference_manufacturing_approval_instruction(prompt, manufacturing_approval)
+        prompt = append_reference_manufacturing_reproducibility_instruction(prompt)
     settings_path = workspace.phase_settings_path(phase)
     mcp_config_path = workspace.phase_mcp_config_path(phase)
     settings_path.write_text("{}\n", encoding="utf-8")
@@ -77,11 +65,6 @@ def main(argv: list[str] | None = None) -> int:
         catalog_mcp_tools=catalog_tools,
         allowed_mcp_tools=execution_tools,
     )
-    if manufacturing_approval is not None:
-        approval_event = reference_manufacturing_approval_event(
-            workspace, manufacturing_approval, handoff_at=manufacturing_handoff_at
-        )
-        summary = replace(summary, events=(approval_event, *summary.events))
     write_agent_log(workspace, summary, append=args.append_agent_log)
     print(
         json.dumps(

--- a/src/kicad_mcp/evals/reference_agent_runner.py
+++ b/src/kicad_mcp/evals/reference_agent_runner.py
@@ -19,6 +19,7 @@ from ..operating_modes import is_tool_allowed_in_mode
 from ..tools.router import tools_for_profile
 from .evidence_sanitization import EvidenceSanitizationError, validate_sanitized_evidence
 from .reference_corpus import ReferenceAgentLogEvent
+from .reference_mcp_server import REFERENCE_MANUFACTURING_TOOL_NAMES
 
 _MCP_PREFIX = "mcp__kicad__"
 _CLAUDE_EXECUTABLE = "claude"
@@ -304,6 +305,8 @@ _PCB_EXECUTION_TOOLS = (
 
 def catalog_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
     """Return the profile/mode catalog boundary visible to the benchmark agent."""
+    if phase.name == "manufacturing":
+        return frozenset(_MCP_PREFIX + tool for tool in REFERENCE_MANUFACTURING_TOOL_NAMES)
     return frozenset(
         _MCP_PREFIX + tool
         for tool in tools_for_profile(phase.profile)
@@ -319,7 +322,7 @@ def reviewed_mcp_tools(phase: ReferenceAgentPhase) -> frozenset[str]:
     elif phase.name == "pcb":
         tools = _PCB_EXECUTION_TOOLS
     else:
-        tools = tuple(tools_for_profile("release"))
+        tools = REFERENCE_MANUFACTURING_TOOL_NAMES
     reviewed = frozenset(_MCP_PREFIX + tool for tool in tools)
     catalog = catalog_mcp_tools(phase)
     if not reviewed <= catalog:
@@ -457,6 +460,20 @@ def load_reference_manufacturing_approval(
         source_revision=source_revision,
         project_state_digest=actual_digest,
         approved_project_files=actual_files,
+    )
+
+
+def append_reference_manufacturing_reproducibility_instruction(prompt: str) -> str:
+    """Bind the benchmark manufacturing phase to the fixed two-generation tools."""
+    return (
+        prompt.rstrip()
+        + "\n\n## Benchmark manufacturing reproducibility\n"
+        + "Do not call export_manufacturing_package; production release approval is outside "
+        + "this benchmark phase. Call reference_generate_manufacturing_snapshot exactly twice, "
+        + 'first with generation="generation-1" and then generation="generation-2". '
+        + "Then call reference_compare_manufacturing_snapshots and treat any divergent result "
+        + "as a failed manufacturing reproducibility stage. Do not modify the design between "
+        + "the two generations.\n"
     )
 
 
@@ -639,7 +656,14 @@ def build_mcp_config(
             "kicad": {
                 "type": "stdio",
                 "command": sys.executable,
-                "args": ["-m", "kicad_mcp.server"],
+                "args": [
+                    "-m",
+                    (
+                        "kicad_mcp.evals.reference_mcp_server"
+                        if phase.name == "manufacturing"
+                        else "kicad_mcp.server"
+                    ),
+                ],
                 "env": {
                     "PYTHONPATH": str(workspace.checkout_dir / "src"),
                     "KICAD_MCP_TRANSPORT": "stdio",

--- a/src/kicad_mcp/evals/reference_mcp_server.py
+++ b/src/kicad_mcp/evals/reference_mcp_server.py
@@ -1,0 +1,389 @@
+"""Benchmark-only MCP server for reference-board manufacturing reproducibility."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal, cast
+
+from ..config import get_config, reset_config
+from ..discovery import get_cli_capabilities
+from ..export.bom import ExportBomService
+from ..export.drill import ExportDrillService
+from ..export.gerber import ExportGerberService
+from ..server import KiCadFastMCP, _ensure_thread_aware_stdout, build_server
+from ..tools.export import (
+    _active_variant_args,
+    _bom_project_schematic_files,
+    _bom_schematic_component_rows,
+    _format_file_list,
+)
+from ..tools.export_support import _get_pcb_file, _get_sch_file, _run_cli_variants
+
+ReferenceSnapshotGeneration = Literal["generation-1", "generation-2"]
+
+_REFERENCE_SNAPSHOT_PARENT = "reference-manufacturing"
+_REFERENCE_MANIFEST_FILE = "artifact-manifest.json"
+_REFERENCE_COMPARISON_FILE = "comparison.json"
+REFERENCE_MANUFACTURING_NORMALIZATION_RULES_VERSION = "kicad-cli-timestamps-v1"
+
+_GERBER_CREATION_DATE_RE = re.compile(rb"^%TF\.CreationDate,[^\r\n]*\*%$")
+_GERBER_CREATED_BY_RE = re.compile(rb"^G04 Created by KiCad \(PCBNEW [^\r\n]*\) date [^\r\n]*\*$")
+_DRILL_CREATED_BY_RE = re.compile(rb"^; DRILL file KiCad [^\r\n]* date [^\r\n]*$")
+_DRILL_CREATION_DATE_RE = re.compile(rb"^; #@! TF\.CreationDate,[^\r\n]*$")
+_GBRJOB_CREATION_DATE_FIELD_RE = re.compile(rb"(\"CreationDate\"\s*:\s*\")[^\"\r\n]+(\")")
+
+
+REFERENCE_MANUFACTURING_TOOL_NAMES: tuple[str, ...] = (
+    "kicad_set_project",
+    "kicad_get_project_info",
+    "kicad_get_version",
+    "kicad_get_server_info",
+    "project_get_design_spec",
+    "pcb_get_board_summary",
+    "pcb_get_design_rules",
+    "pcb_get_stackup",
+    "validate_design",
+    "run_drc",
+    "run_erc",
+    "validate_footprints_vs_schematic",
+    "check_design_for_manufacture",
+    "dfm_run_manufacturer_check",
+    "project_quality_gate",
+    "manufacturing_quality_gate",
+    "get_board_stats",
+    "reference_generate_manufacturing_snapshot",
+    "reference_compare_manufacturing_snapshots",
+)
+
+
+def _reference_snapshot_root(generation: ReferenceSnapshotGeneration) -> Path:
+    if generation not in ("generation-1", "generation-2"):
+        raise ValueError("reference manufacturing generation is invalid")
+    parent = get_config().ensure_output_dir(_REFERENCE_SNAPSHOT_PARENT)
+    return parent / generation
+
+
+def _snapshot_subdir(root: Path, subdir: str | None) -> Path:
+    if subdir not in (None, "Gerbers"):
+        raise ValueError("reference manufacturing snapshot output subdirectory is invalid")
+    target = root if subdir is None else root / subdir
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _snapshot_export_services(root: Path) -> SimpleNamespace:
+    cfg = get_config()
+    gerber = ExportGerberService(
+        get_pcb_file=_get_pcb_file,
+        ensure_output_dir=lambda subdir: _snapshot_subdir(root, subdir),
+        get_gerber_command=lambda: get_cli_capabilities(cfg.kicad_cli).gerber_command,
+        active_variant_args=_active_variant_args,
+        run_cli_variants=_run_cli_variants,
+        format_file_list=_format_file_list,
+    )
+    drill = ExportDrillService(
+        get_pcb_file=_get_pcb_file,
+        ensure_output_dir=lambda subdir: _snapshot_subdir(root, subdir),
+        get_drill_command=lambda: get_cli_capabilities(cfg.kicad_cli).drill_command,
+        active_variant_args=_active_variant_args,
+        run_cli_variants=_run_cli_variants,
+        format_file_list=_format_file_list,
+    )
+    bom = ExportBomService(
+        get_sch_file=_get_sch_file,
+        ensure_output_dir=lambda: _snapshot_subdir(root, None),
+        active_variant_args=_active_variant_args,
+        run_cli_variants=_run_cli_variants,
+        read_preview=lambda _path: "",
+        project_schematic_files=_bom_project_schematic_files,
+        schematic_component_rows=_bom_schematic_component_rows,
+    )
+    return SimpleNamespace(gerber=gerber, drill=drill, bom=bom)
+
+
+def _sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _snapshot_file_entries(root: Path) -> list[dict[str, str | int]]:
+    entries: list[dict[str, str | int]] = []
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        if path.name == _REFERENCE_MANIFEST_FILE:
+            continue
+        if path.is_symlink():
+            raise ValueError("reference manufacturing snapshot must not contain symlinks")
+        if not path.is_file():
+            continue
+        entries.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "sha256": _sha256_path(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    return entries
+
+
+def _manifest_digest(entries: list[dict[str, str | int]]) -> str:
+    digest = hashlib.sha256()
+    for entry in entries:
+        digest.update(str(entry["path"]).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(entry["sha256"]).encode("ascii"))
+        digest.update(b"\n")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _normalize_kicad_timestamp_bytes(relative: str, data: bytes) -> bytes:
+    """Normalize only KiCad-generated timestamp metadata for comparison."""
+    suffix = Path(relative).suffix.casefold()
+    if suffix == ".gbrjob":
+        try:
+            payload = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return data
+        if not isinstance(payload, dict):
+            return data
+        header = payload.get("Header")
+        if not isinstance(header, dict):
+            return data
+        creation_date = header.get("CreationDate")
+        software = header.get("GenerationSoftware")
+        if not isinstance(creation_date, str) or not isinstance(software, dict):
+            return data
+        vendor = software.get("Vendor")
+        if not isinstance(vendor, str) or vendor.casefold() != "kicad":
+            return data
+        matches = tuple(_GBRJOB_CREATION_DATE_FIELD_RE.finditer(data))
+        if len(matches) != 1:
+            return data
+        match = matches[0]
+        return (
+            data[: match.start()]
+            + match.group(1)
+            + b"<normalized-kicad-creation-date>"
+            + match.group(2)
+            + data[match.end() :]
+        )
+
+    is_kicad_gerber = b"%TF.GenerationSoftware,KiCad," in data
+    is_kicad_drill = (
+        b"; #@! TF.GenerationSoftware,Kicad," in data
+        or b"; #@! TF.GenerationSoftware,KiCad," in data
+        or b"; DRILL file KiCad " in data
+    )
+    if not is_kicad_gerber and not is_kicad_drill:
+        return data
+
+    lines = data.splitlines(keepends=True)
+    normalized_lines: list[bytes] = []
+    for line in lines:
+        ending = b"\r\n" if line.endswith(b"\r\n") else (b"\n" if line.endswith(b"\n") else b"")
+        body = line[: -len(ending)] if ending else line
+        if is_kicad_gerber and _GERBER_CREATION_DATE_RE.fullmatch(body):
+            body = b"%TF.CreationDate,<normalized>*%"
+        elif is_kicad_gerber and _GERBER_CREATED_BY_RE.fullmatch(body):
+            prefix = body.rsplit(b" date ", 1)[0]
+            body = prefix + b" date <normalized>*"
+        elif is_kicad_drill and _DRILL_CREATED_BY_RE.fullmatch(body):
+            prefix = body.rsplit(b" date ", 1)[0]
+            body = prefix + b" date <normalized>"
+        elif is_kicad_drill and _DRILL_CREATION_DATE_RE.fullmatch(body):
+            body = b"; #@! TF.CreationDate,<normalized>"
+        normalized_lines.append(body + ending)
+    return b"".join(normalized_lines)
+
+
+def _normalized_snapshot_entries(root: Path) -> list[dict[str, str | int]]:
+    entries: list[dict[str, str | int]] = []
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        if path.name == _REFERENCE_MANIFEST_FILE:
+            continue
+        if path.is_symlink():
+            raise ValueError("reference manufacturing snapshot must not contain symlinks")
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root).as_posix()
+        normalized = _normalize_kicad_timestamp_bytes(relative, path.read_bytes())
+        entries.append(
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(normalized).hexdigest(),
+                "size_bytes": len(normalized),
+            }
+        )
+    return entries
+
+
+def _write_snapshot_manifest(
+    root: Path, generation: ReferenceSnapshotGeneration
+) -> dict[str, object]:
+    entries = _snapshot_file_entries(root)
+    payload: dict[str, object] = {
+        "schema_version": "pcb-reference-manufacturing-snapshot.v1",
+        "generation": generation,
+        "artifact_manifest_digest": _manifest_digest(entries),
+        "files": entries,
+    }
+    (root / _REFERENCE_MANIFEST_FILE).write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    return payload
+
+
+def _require_snapshot_export_success(label: str, result: str) -> None:
+    lowered = result.casefold()
+    if "failed:" in lowered or "no files were produced" in lowered:
+        raise ValueError(f"{label} export failed: {result}")
+
+
+def generate_reference_manufacturing_snapshot(generation: ReferenceSnapshotGeneration) -> str:
+    """Generate one fresh BOM + Gerber/drill snapshot with a stable byte manifest."""
+    root = _reference_snapshot_root(generation)
+    if root.is_symlink():
+        raise ValueError("reference manufacturing snapshot root must not be a symlink")
+    if root.exists() and any(root.iterdir()):
+        raise ValueError("reference manufacturing snapshot already contains artifacts")
+    root.mkdir(parents=True, exist_ok=True)
+    services = _snapshot_export_services(root)
+    _require_snapshot_export_success("Gerber", services.gerber.export("Gerbers"))
+    _require_snapshot_export_success("Drill", services.drill.export("Gerbers"))
+    _require_snapshot_export_success("BOM", services.bom.export("csv"))
+
+    generated_bom = root / "bom.csv"
+    canonical_bom = root / "BOM.csv"
+    if generated_bom.is_file() and not canonical_bom.exists():
+        generated_bom.replace(canonical_bom)
+    gerbers = root / "Gerbers"
+    has_gerber = gerbers.is_dir() and any(
+        path.is_file() and path.stat().st_size > 0 and path.suffix.casefold() != ".gbrjob"
+        for path in gerbers.glob("*.g*")
+    )
+    has_drill = gerbers.is_dir() and any(
+        path.is_file() and path.stat().st_size > 0
+        for pattern in ("*.drl", "*.xnc")
+        for path in gerbers.glob(pattern)
+    )
+    if (
+        not canonical_bom.is_file()
+        or canonical_bom.stat().st_size == 0
+        or not has_gerber
+        or not has_drill
+    ):
+        raise ValueError("reference manufacturing snapshot is missing BOM, Gerber, or drill output")
+    return json.dumps(_write_snapshot_manifest(root, generation), sort_keys=True)
+
+
+def _validated_snapshot_manifest(generation: ReferenceSnapshotGeneration) -> dict[str, object]:
+    root = _reference_snapshot_root(generation)
+    if root.is_symlink():
+        raise ValueError("reference manufacturing snapshot root must not be a symlink")
+    manifest_path = root / _REFERENCE_MANIFEST_FILE
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise ValueError("reference manufacturing snapshot manifest is missing")
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("reference manufacturing snapshot manifest is invalid") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("reference manufacturing snapshot manifest is invalid")
+    actual_entries = _snapshot_file_entries(root)
+    actual_digest = _manifest_digest(actual_entries)
+    if (
+        payload.get("schema_version") != "pcb-reference-manufacturing-snapshot.v1"
+        or payload.get("generation") != generation
+        or payload.get("files") != actual_entries
+        or payload.get("artifact_manifest_digest") != actual_digest
+    ):
+        raise ValueError("reference manufacturing manifest no longer matches snapshot bytes")
+    return payload
+
+
+def compare_reference_manufacturing_snapshots() -> str:
+    """Revalidate and compare two manufacturing generations without mutating artifacts."""
+    first = _validated_snapshot_manifest("generation-1")
+    second = _validated_snapshot_manifest("generation-2")
+    first_root = _reference_snapshot_root("generation-1")
+    second_root = _reference_snapshot_root("generation-2")
+    first_normalized = _normalized_snapshot_entries(first_root)
+    second_normalized = _normalized_snapshot_entries(second_root)
+    normalized_digests = [
+        _manifest_digest(first_normalized),
+        _manifest_digest(second_normalized),
+    ]
+
+    if first["files"] == second["files"]:
+        comparison = "byte_identical"
+    elif first_normalized == second_normalized:
+        comparison = "normalized_equivalent"
+    else:
+        comparison = "divergent"
+
+    payload: dict[str, object] = {
+        "schema_version": "pcb-reference-manufacturing-comparison.v1",
+        "comparison": comparison,
+        "artifact_manifest_digests": [
+            first["artifact_manifest_digest"],
+            second["artifact_manifest_digest"],
+        ],
+        "normalized_artifact_manifest_digests": normalized_digests,
+    }
+    if comparison == "normalized_equivalent":
+        payload["normalization_rules_version"] = REFERENCE_MANUFACTURING_NORMALIZATION_RULES_VERSION
+    parent = get_config().ensure_output_dir(_REFERENCE_SNAPSHOT_PARENT)
+    (parent / _REFERENCE_COMPARISON_FILE).write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    return json.dumps(payload, sort_keys=True)
+
+
+def _register_reference_manufacturing_tools(server: KiCadFastMCP) -> None:
+    @server.tool(name="reference_generate_manufacturing_snapshot")
+    def reference_generate_manufacturing_snapshot(
+        generation: ReferenceSnapshotGeneration,
+    ) -> str:
+        """Generate one of two fixed fresh manufacturing snapshots for benchmark evidence."""
+        return generate_reference_manufacturing_snapshot(generation)
+
+    @server.tool(name="reference_compare_manufacturing_snapshots")
+    def reference_compare_manufacturing_snapshots() -> str:
+        """Compare the two fixed manufacturing snapshot manifests after byte revalidation."""
+        return compare_reference_manufacturing_snapshots()
+
+
+def build_reference_manufacturing_server(*, defer_registration: bool = True) -> KiCadFastMCP:
+    """Build a manufacturing-mode server narrowed to the reviewed benchmark surface."""
+    server = cast(KiCadFastMCP, build_server("full", defer_registration=defer_registration))
+    _register_reference_manufacturing_tools(server)
+    exact = set(REFERENCE_MANUFACTURING_TOOL_NAMES)
+    server.allowed_tool_names = exact
+    server.execution_tool_names = exact
+    return server
+
+
+def main() -> None:
+    """Run the benchmark-only reference manufacturing server over stdio."""
+    with contextlib.redirect_stdout(sys.stderr):
+        reset_config()
+        cfg = get_config()
+        if cfg.transport != "stdio":
+            raise SystemExit("reference manufacturing benchmark server requires stdio transport")
+        if cfg.operating_mode != "manufacturing":
+            raise SystemExit("reference manufacturing benchmark server requires manufacturing mode")
+        server = build_reference_manufacturing_server(defer_registration=True)
+    _ensure_thread_aware_stdout()
+    server.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kicad_mcp/evals/reference_mcp_server.py
+++ b/src/kicad_mcp/evals/reference_mcp_server.py
@@ -247,6 +247,48 @@ def _require_snapshot_export_success(label: str, result: str) -> None:
         raise ValueError(f"{label} export failed: {result}")
 
 
+def _canonicalize_snapshot_bom(root: Path) -> Path:
+    """Require one BOM artifact and normalize its on-disk spelling to ``BOM.csv``."""
+    canonical_name = "BOM.csv"
+    candidates = [
+        path
+        for path in root.iterdir()
+        if path.name.casefold() == canonical_name.casefold() and path.is_file()
+    ]
+    canonical = root / canonical_name
+    if not candidates:
+        return canonical
+
+    exact = next((path for path in candidates if path.name == canonical_name), None)
+    if exact is not None:
+        for alias in candidates:
+            if alias == exact:
+                continue
+            if not alias.samefile(exact):
+                raise ValueError(
+                    "reference manufacturing snapshot contains ambiguous BOM artifacts"
+                )
+            alias.unlink()
+        return exact
+
+    if len(candidates) != 1:
+        raise ValueError("reference manufacturing snapshot contains ambiguous BOM artifacts")
+    source = candidates[0]
+    temporary = root / ".reference-bom-case-normalize.tmp"
+    if temporary.exists() or temporary.is_symlink():
+        raise ValueError(
+            "reference manufacturing snapshot contains reserved temporary BOM artifact"
+        )
+    source.replace(temporary)
+    try:
+        temporary.replace(canonical)
+    except OSError:
+        if temporary.exists() and not source.exists():
+            temporary.replace(source)
+        raise
+    return canonical
+
+
 def generate_reference_manufacturing_snapshot(generation: ReferenceSnapshotGeneration) -> str:
     """Generate one fresh BOM + Gerber/drill snapshot with a stable byte manifest."""
     root = _reference_snapshot_root(generation)
@@ -260,10 +302,7 @@ def generate_reference_manufacturing_snapshot(generation: ReferenceSnapshotGener
     _require_snapshot_export_success("Drill", services.drill.export("Gerbers"))
     _require_snapshot_export_success("BOM", services.bom.export("csv"))
 
-    generated_bom = root / "bom.csv"
-    canonical_bom = root / "BOM.csv"
-    if generated_bom.is_file() and not canonical_bom.exists():
-        generated_bom.replace(canonical_bom)
+    canonical_bom = _canonicalize_snapshot_bom(root)
     gerbers = root / "Gerbers"
     has_gerber = gerbers.is_dir() and any(
         path.is_file() and path.stat().st_size > 0 and path.suffix.casefold() != ".gbrjob"

--- a/src/kicad_mcp/server.py
+++ b/src/kicad_mcp/server.py
@@ -717,6 +717,7 @@ class KiCadFastMCP(FastMCP):
 
     allow_experimental_tools: bool = False
     allowed_tool_names: set[str] | None = None
+    execution_tool_names: set[str] | None = None
     filter_runtime_tools: bool = True
     operating_mode: OperatingMode = OperatingMode.READONLY
     _lazy_registration: Callable[[], None] | None = None
@@ -1019,6 +1020,15 @@ class KiCadFastMCP(FastMCP):
         with otel.tool_span(name) as span:
             try:
                 await self._ensure_registered_async()
+                execution_tool_names = getattr(self, "execution_tool_names", None)
+                if execution_tool_names is not None and name not in execution_tool_names:
+                    result = _structured_tool_error_from_message(
+                        f"Tool '{name}' is not available in this server execution surface.",
+                        tool_name=name,
+                    )
+                    status, error_code = _status_from_result(result)
+                    logger.warning("tool_denied_by_execution_surface", tool=name)
+                    return result
                 mode = getattr(self, "operating_mode", active_operating_mode())
                 if not is_tool_allowed_in_mode(name, mode):
                     result = _structured_tool_error_from_message(

--- a/tests/unit/test_reference_agent_runner.py
+++ b/tests/unit/test_reference_agent_runner.py
@@ -434,8 +434,10 @@ def test_reviewed_mcp_tools_follow_profile_and_mode_boundaries() -> None:
         "mcp__kicad__run_drc",
     } <= pcb
     assert "mcp__kicad__route_differential_pair" not in pcb
-    assert len(release) == 24
-    assert "mcp__kicad__export_manufacturing_package" in release
+    assert len(release) >= 18
+    assert "mcp__kicad__reference_generate_manufacturing_snapshot" in release
+    assert "mcp__kicad__reference_compare_manufacturing_snapshots" in release
+    assert "mcp__kicad__export_manufacturing_package" not in release
 
 
 def test_parse_claude_stream_rejects_tool_outside_reviewed_phase_surface() -> None:
@@ -619,6 +621,67 @@ def test_reference_agent_cli_threads_catalog_and_execution_boundaries(
     workspace = captured["workspace"]
     assert workspace.checkout_dir == tmp_path.resolve()
     assert workspace.agent_log_path == board / "attempts/attempt-001/agent-log.jsonl"
+
+
+def test_build_mcp_config_uses_benchmark_only_manufacturing_server(tmp_path) -> None:
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentPhase, build_mcp_config
+
+    workspace = _workspace(tmp_path, attempt_id="attempt-003")
+    config = build_mcp_config(
+        phase=ReferenceAgentPhase.for_name("manufacturing"),
+        workspace=workspace,
+        kicad_cli=tmp_path / "kicad-cli",
+    )
+    server = config["mcpServers"]["kicad"]
+    assert server["args"] == ["-m", "kicad_mcp.evals.reference_mcp_server"]
+    assert server["env"]["KICAD_MCP_OPERATING_MODE"] == "manufacturing"
+
+
+def test_reference_agent_cli_manufacturing_does_not_require_release_approval(
+    tmp_path, monkeypatch
+) -> None:
+    import importlib.util
+
+    from kicad_mcp.evals.reference_agent_runner import ReferenceAgentRunSummary
+
+    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
+    spec = importlib.util.spec_from_file_location("reference_agent_benchmark_manufacturing", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    board = tmp_path / "docs/evidence/reference-boards/stm32f072-usbc/v1"
+    board.mkdir(parents=True)
+    (board / "original-prompt.md").write_text(
+        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
+        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport twice.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "discover_reference_kicad_cli", lambda: tmp_path / "kicad-cli")
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs: object) -> ReferenceAgentRunSummary:
+        captured.update(kwargs)
+        return ReferenceAgentRunSummary(
+            events=(),
+            primary_model="claude-sonnet-5",
+            auxiliary_models=(),
+            provider="firstParty",
+            permission_denials=0,
+            terminal_reason="completed",
+            successful=True,
+        )
+
+    monkeypatch.setattr(module, "run_claude_session", fake_run)
+    assert (
+        module.main(
+            ["--board-id", "stm32f072-usbc", "--attempt-number", "3", "--phase", "manufacturing"]
+        )
+        == 0
+    )
+    assert "Reviewed manufacturing approval" not in captured["prompt"]
+    assert "mcp__kicad__reference_generate_manufacturing_snapshot" in captured["allowed_mcp_tools"]
+    assert "mcp__kicad__export_manufacturing_package" not in captured["allowed_mcp_tools"]
 
 
 def test_reference_agent_workspace_derives_reviewed_paths(tmp_path) -> None:
@@ -874,106 +937,6 @@ def test_reference_manufacturing_approval_event_is_sanitized(tmp_path) -> None:
     assert event.status == "completed"
     assert event.details["source_revision"] == source_revision
     assert event.details["project_state_digest"] == approval.project_state_digest
-
-
-def test_reference_agent_cli_manufacturing_fails_before_provider_without_human_approval(
-    tmp_path, monkeypatch
-) -> None:
-    import importlib.util
-
-    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
-    spec = importlib.util.spec_from_file_location("reference_agent_manufacturing_missing", script)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    board = tmp_path / "docs/evidence/reference-boards/stm32f072-usbc/v1"
-    board.mkdir(parents=True)
-    (board / "original-prompt.md").write_text(
-        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
-        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n",
-        encoding="utf-8",
-    )
-    project = tmp_path / ".dev-tools/reference-agent-runs/stm32f072-usbc/v1/attempt-003/project"
-    project.mkdir(parents=True)
-    (project / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
-    (project / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
-    monkeypatch.setattr(module, "ROOT", tmp_path)
-    monkeypatch.setattr(module, "discover_reference_source_revision", lambda _root: "f" * 40)
-    monkeypatch.setattr(module, "discover_reference_kicad_cli", lambda: tmp_path / "kicad-cli")
-
-    def fail_run(**_kwargs: object):
-        raise AssertionError("provider must not start before human manufacturing approval")
-
-    monkeypatch.setattr(module, "run_claude_session", fail_run)
-    with pytest.raises(ValueError, match="manufacturing approval evidence is missing"):
-        module.main(
-            ["--board-id", "stm32f072-usbc", "--attempt-number", "3", "--phase", "manufacturing"]
-        )
-
-
-def test_reference_agent_cli_manufacturing_consumes_bound_approval_and_logs_handoff(
-    tmp_path, monkeypatch
-) -> None:
-    import importlib.util
-
-    from kicad_mcp.evals.reference_agent_runner import (
-        ReferenceAgentRunSummary,
-        ReferenceAgentWorkspace,
-        compute_reference_project_state_digest,
-    )
-
-    script = Path(__file__).resolve().parents[2] / "scripts/run_reference_board_agent.py"
-    spec = importlib.util.spec_from_file_location("reference_agent_manufacturing_valid", script)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    board = tmp_path / "docs/evidence/reference-boards/stm32f072-usbc/v1"
-    board.mkdir(parents=True)
-    (board / "original-prompt.md").write_text(
-        "# Benchmark\nCommon.\n\n## Phase: schematic\nBuild.\n\n"
-        "## Phase: pcb\nLayout.\n\n## Phase: manufacturing\nExport.\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(module, "ROOT", tmp_path)
-    workspace = ReferenceAgentWorkspace.for_reviewed_attempt(
-        checkout_dir=tmp_path, board_id="stm32f072-usbc", attempt_number=3
-    )
-    workspace.project_dir.mkdir(parents=True)
-    (workspace.project_dir / "demo.kicad_sch").write_text("schematic\n", encoding="utf-8")
-    (workspace.project_dir / "demo.kicad_pcb").write_text("board\n", encoding="utf-8")
-    source_revision = "f" * 40
-    _write_reference_manufacturing_approval(
-        workspace,
-        source_revision=source_revision,
-        digest=compute_reference_project_state_digest(workspace),
-    )
-    monkeypatch.setattr(module, "discover_reference_source_revision", lambda _root: source_revision)
-    monkeypatch.setattr(module, "discover_reference_kicad_cli", lambda: tmp_path / "kicad-cli")
-    captured: dict[str, object] = {}
-
-    def fake_run(**kwargs: object) -> ReferenceAgentRunSummary:
-        captured.update(kwargs)
-        return ReferenceAgentRunSummary(
-            events=(),
-            primary_model="claude-sonnet-5",
-            auxiliary_models=(),
-            provider="firstParty",
-            permission_denials=0,
-            terminal_reason="completed",
-            successful=True,
-        )
-
-    monkeypatch.setattr(module, "run_claude_session", fake_run)
-    assert (
-        module.main(
-            ["--board-id", "stm32f072-usbc", "--attempt-number", "3", "--phase", "manufacturing"]
-        )
-        == 0
-    )
-    assert 'approval_evidence_path="reference-manufacturing-approval.json"' in captured["prompt"]
-    events = [json.loads(line) for line in workspace.agent_log_path.read_text().splitlines()]
-    assert events[0]["name"] == "human_manufacturing_approval"
-    assert events[0]["details"]["source_revision"] == source_revision
 
 
 def test_reference_source_revision_rejects_dirty_runtime_source_but_not_evidence(tmp_path) -> None:

--- a/tests/unit/test_reference_mcp_server.py
+++ b/tests/unit/test_reference_mcp_server.py
@@ -598,3 +598,59 @@ def test_reference_snapshot_rejects_reserved_bom_temp_artifact(
 
     with pytest.raises(ValueError, match="reserved temporary BOM artifact"):
         reference_server._canonicalize_snapshot_bom(root)
+
+
+def test_reference_snapshot_bom_canonicalizer_returns_missing_target(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.mkdir(parents=True, exist_ok=True)
+
+    canonical = reference_server._canonicalize_snapshot_bom(root)
+
+    assert canonical == root / "BOM.csv"
+    assert not canonical.exists()
+
+
+def test_reference_snapshot_rejects_multiple_noncanonical_bom_spellings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "bom.csv").write_text("one\n", encoding="utf-8")
+    (root / "BoM.csv").write_text("two\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="ambiguous BOM artifacts"):
+        reference_server._canonicalize_snapshot_bom(root)
+
+
+def test_reference_snapshot_bom_case_rename_rolls_back_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.mkdir(parents=True, exist_ok=True)
+    source = root / "bom.csv"
+    source.write_text("bom\n", encoding="utf-8")
+    original_replace = Path.replace
+
+    def fail_canonical_replace(path: Path, target: Path) -> Path:
+        if path.name == ".reference-bom-case-normalize.tmp" and target.name == "BOM.csv":
+            raise OSError("simulated case-only rename failure")
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_canonical_replace)
+
+    with pytest.raises(OSError, match="simulated case-only rename failure"):
+        reference_server._canonicalize_snapshot_bom(root)
+
+    assert source.read_text(encoding="utf-8") == "bom\n"
+    assert not (root / ".reference-bom-case-normalize.tmp").exists()

--- a/tests/unit/test_reference_mcp_server.py
+++ b/tests/unit/test_reference_mcp_server.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _reset_reference_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from kicad_mcp.config import reset_config
+
+    monkeypatch.setenv("KICAD_MCP_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("KICAD_MCP_OPERATING_MODE", "manufacturing")
+    monkeypatch.setenv("KICAD_MCP_FILTER_RUNTIME_TOOLS", "false")
+    reset_config()
+
+
+def test_reference_manufacturing_server_has_exact_non_release_surface(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from kicad_mcp.evals.reference_mcp_server import (
+        REFERENCE_MANUFACTURING_TOOL_NAMES,
+        build_reference_manufacturing_server,
+    )
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    server = build_reference_manufacturing_server(defer_registration=False)
+    names = {tool.name for tool in server.list_tools_sync()}
+
+    assert names == set(REFERENCE_MANUFACTURING_TOOL_NAMES)
+    assert "reference_generate_manufacturing_snapshot" in names
+    assert "reference_compare_manufacturing_snapshots" in names
+    assert "export_manufacturing_package" not in names
+    assert "export_gerber" not in names
+    assert "export_drill" not in names
+    assert "export_bom" not in names
+
+
+@pytest.mark.anyio
+async def test_execution_allowlist_rejects_hidden_direct_tool_call() -> None:
+    from kicad_mcp.operating_modes import OperatingMode
+    from kicad_mcp.server import KiCadFastMCP
+
+    server = KiCadFastMCP(name="reference-execution-boundary")
+    server.operating_mode = OperatingMode.MANUFACTURING
+    server.execution_tool_names = {"allowed_tool"}
+    hidden_called = False
+
+    @server.tool(name="allowed_tool")
+    def allowed_tool() -> str:
+        return "allowed"
+
+    @server.tool(name="hidden_tool")
+    def hidden_tool() -> str:
+        nonlocal hidden_called
+        hidden_called = True
+        return "hidden"
+
+    result = await server.call_tool("hidden_tool", {})
+
+    assert hidden_called is False
+    assert result.isError is True
+    assert "execution surface" in result.content[0].text
+
+
+def test_reference_snapshot_generation_is_fresh_and_manifested(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    class Gerber:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            calls.append(("gerber", output_subdir))
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "board-F_Cu.gbr").write_bytes(b"gerber\n")
+            return "ok"
+
+    class Drill:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            calls.append(("drill", output_subdir))
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "board.drl").write_bytes(b"drill\n")
+            return "ok"
+
+    class Bom:
+        def export(self, format: str = "csv") -> str:
+            calls.append(("bom", format))
+            root = reference_server._reference_snapshot_root("generation-1")
+            (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+            return "ok"
+
+    monkeypatch.setattr(
+        reference_server,
+        "_snapshot_export_services",
+        lambda _root: SimpleNamespace(gerber=Gerber(), drill=Drill(), bom=Bom()),
+    )
+
+    result = reference_server.generate_reference_manufacturing_snapshot("generation-1")
+    payload = json.loads(result)
+
+    assert calls == [("gerber", "Gerbers"), ("drill", "Gerbers"), ("bom", "csv")]
+    assert payload["generation"] == "generation-1"
+    assert payload["artifact_manifest_digest"].startswith("sha256:")
+    assert {item["path"] for item in payload["files"]} == {
+        "BOM.csv",
+        "Gerbers/board-F_Cu.gbr",
+        "Gerbers/board.drl",
+    }
+    manifest = reference_server._reference_snapshot_root("generation-1") / "artifact-manifest.json"
+    assert manifest.is_file()
+
+    with pytest.raises(ValueError, match="already contains artifacts"):
+        reference_server.generate_reference_manufacturing_snapshot("generation-1")
+
+
+def test_reference_snapshot_comparison_revalidates_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    for generation in ("generation-1", "generation-2"):
+        root = reference_server._reference_snapshot_root(generation)
+        (root / "Gerbers").mkdir(parents=True)
+        (root / "BOM.csv").write_bytes(b"same bom\n")
+        (root / "Gerbers/board-F_Cu.gbr").write_bytes(b"same gerber\n")
+        reference_server._write_snapshot_manifest(root, generation)
+
+    identical = json.loads(reference_server.compare_reference_manufacturing_snapshots())
+    assert identical["comparison"] == "byte_identical"
+    assert len(identical["artifact_manifest_digests"]) == 2
+
+    second = reference_server._reference_snapshot_root("generation-2") / "Gerbers/board-F_Cu.gbr"
+    second.write_bytes(b"changed\n")
+    with pytest.raises(ValueError, match="manifest no longer matches snapshot bytes"):
+        reference_server.compare_reference_manufacturing_snapshots()
+
+
+def test_reference_snapshot_comparison_normalizes_only_kicad_generation_timestamps(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    timestamped = {
+        "Gerbers/board-F_Cu.gtl": (
+            "%TF.GenerationSoftware,KiCad,Pcbnew,10.0.6*%\n"
+            "%TF.CreationDate,{iso}*%\n"
+            "G04 Created by KiCad (PCBNEW 10.0.6) date {plain}*\n"
+            "X100Y200D02*\n"
+        ),
+        "Gerbers/board.drl": (
+            "M48\n; DRILL file KiCad 10.0.6 date {drill}\n; #@! TF.CreationDate,{iso}\nT1C0.300\n"
+        ),
+        "Gerbers/board-job.gbrjob": (
+            '{{\n  "Header": {{\n    "CreationDate": "{iso}",\n'
+            '    "GenerationSoftware": {{"Vendor": "KiCad"}}\n  }},\n'
+            '  "GeneralSpecs": {{"ProjectId": "board"}}\n}}\n'
+        ),
+    }
+    values = (
+        ("generation-1", "2026-09-10T23:30:36+03:00", "2026-09-10 23:30:36", "2026-09-10T23:30:36"),
+        ("generation-2", "2026-09-10T23:30:37+03:00", "2026-09-10 23:30:37", "2026-09-10T23:30:37"),
+    )
+    for generation, iso, plain, drill in values:
+        root = reference_server._reference_snapshot_root(generation)
+        (root / "Gerbers").mkdir(parents=True)
+        (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+        for relative, template in timestamped.items():
+            path = root / relative
+            path.write_text(template.format(iso=iso, plain=plain, drill=drill), encoding="utf-8")
+        reference_server._write_snapshot_manifest(root, generation)
+
+    result = json.loads(reference_server.compare_reference_manufacturing_snapshots())
+
+    assert result["comparison"] == "normalized_equivalent"
+    assert result["normalization_rules_version"] == (
+        reference_server.REFERENCE_MANUFACTURING_NORMALIZATION_RULES_VERSION
+    )
+    assert result["artifact_manifest_digests"][0] != result["artifact_manifest_digests"][1]
+    assert (
+        result["normalized_artifact_manifest_digests"][0]
+        == (result["normalized_artifact_manifest_digests"][1])
+    )
+
+
+def test_reference_snapshot_comparison_does_not_normalize_manufacturing_content_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    for generation, coordinate in (
+        ("generation-1", "X100Y200D02*"),
+        ("generation-2", "X101Y200D02*"),
+    ):
+        root = reference_server._reference_snapshot_root(generation)
+        (root / "Gerbers").mkdir(parents=True)
+        (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+        (root / "Gerbers/board-F_Cu.gtl").write_text(
+            f"%TF.CreationDate,2026-09-10T23:30:36+03:00*%\n{coordinate}\n",
+            encoding="utf-8",
+        )
+        (root / "Gerbers/board.drl").write_text("M48\nT1C0.300\n", encoding="utf-8")
+        reference_server._write_snapshot_manifest(root, generation)
+
+    result = json.loads(reference_server.compare_reference_manufacturing_snapshots())
+
+    assert result["comparison"] == "divergent"
+    assert "normalization_rules_version" not in result
+
+
+def test_reference_timestamp_normalization_requires_kicad_provenance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    for generation, stamp in (
+        ("generation-1", "2026-09-10T23:30:36+03:00"),
+        ("generation-2", "2026-09-10T23:30:37+03:00"),
+    ):
+        root = reference_server._reference_snapshot_root(generation)
+        (root / "Gerbers").mkdir(parents=True)
+        (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+        (root / "Gerbers/board-F_Cu.gtl").write_text(
+            f"%TF.CreationDate,{stamp}*%\nX100Y200D02*\n",
+            encoding="utf-8",
+        )
+        (root / "Gerbers/board-job.gbrjob").write_text(
+            json.dumps(
+                {
+                    "Header": {
+                        "CreationDate": stamp,
+                        "GenerationSoftware": {"Vendor": "OtherEDA"},
+                    }
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        reference_server._write_snapshot_manifest(root, generation)
+
+    result = json.loads(reference_server.compare_reference_manufacturing_snapshots())
+
+    assert result["comparison"] == "divergent"
+    assert "normalization_rules_version" not in result
+
+
+def test_reference_snapshot_rejects_export_failure_even_with_partial_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+
+    class Gerber:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "board-F_Cu.gtl").write_text("partial\n", encoding="utf-8")
+            return "Gerber export failed: synthetic failure"
+
+    class Drill:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            (root / "board.drl").write_text("drill\n", encoding="utf-8")
+            return "ok"
+
+    class Bom:
+        def export(self, format: str = "csv") -> str:
+            root = reference_server._reference_snapshot_root("generation-1")
+            (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+            return "ok"
+
+    monkeypatch.setattr(
+        reference_server,
+        "_snapshot_export_services",
+        lambda _root: SimpleNamespace(gerber=Gerber(), drill=Drill(), bom=Bom()),
+    )
+
+    with pytest.raises(ValueError, match="Gerber export failed"):
+        reference_server.generate_reference_manufacturing_snapshot("generation-1")
+
+
+def test_reference_snapshot_rejects_empty_required_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+
+    class Gerber:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "board-F_Cu.gtl").write_bytes(b"")
+            return "ok"
+
+    class Drill:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            (root / "board.drl").write_text("drill\n", encoding="utf-8")
+            return "ok"
+
+    class Bom:
+        def export(self, format: str = "csv") -> str:
+            root = reference_server._reference_snapshot_root("generation-1")
+            (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+            return "ok"
+
+    monkeypatch.setattr(
+        reference_server,
+        "_snapshot_export_services",
+        lambda _root: SimpleNamespace(gerber=Gerber(), drill=Drill(), bom=Bom()),
+    )
+
+    with pytest.raises(ValueError, match="missing BOM, Gerber, or drill output"):
+        reference_server.generate_reference_manufacturing_snapshot("generation-1")
+
+
+def test_reference_snapshot_rejects_symlinked_generation_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    outside = tmp_path / "outside-generation"
+    outside.mkdir()
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.parent.mkdir(parents=True, exist_ok=True)
+    root.symlink_to(outside, target_is_directory=True)
+
+    def fail_services(_root: Path) -> SimpleNamespace:
+        raise AssertionError("export services must not start for a symlinked generation root")
+
+    monkeypatch.setattr(reference_server, "_snapshot_export_services", fail_services)
+
+    with pytest.raises(ValueError, match="snapshot root must not be a symlink"):
+        reference_server.generate_reference_manufacturing_snapshot("generation-1")
+    assert list(outside.iterdir()) == []
+
+
+def test_reference_gbrjob_normalization_preserves_non_timestamp_raw_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    first = b"""{
+  "Header": {
+    "GenerationSoftware": {"Vendor": "KiCad", "Application": "Pcbnew"},
+    "CreationDate": "2026-09-10T23:30:36+03:00"
+  },
+  "GeneralSpecs": {"ProjectId": "board"}
+}
+"""
+    second = (
+        b'{"GeneralSpecs":{"ProjectId":"board"},'
+        b'"Header":{"CreationDate":"2026-09-10T23:30:37+03:00",'
+        b'"GenerationSoftware":{"Application":"Pcbnew","Vendor":"KiCad"}}}\n'
+    )
+    for generation, payload in (("generation-1", first), ("generation-2", second)):
+        root = reference_server._reference_snapshot_root(generation)
+        (root / "Gerbers").mkdir(parents=True)
+        (root / "BOM.csv").write_bytes(b"reference,value\nU1,MCU\n")
+        (root / "Gerbers/board-job.gbrjob").write_bytes(payload)
+        reference_server._write_snapshot_manifest(root, generation)
+
+    result = json.loads(reference_server.compare_reference_manufacturing_snapshots())
+
+    assert result["comparison"] == "divergent"
+    assert "normalization_rules_version" not in result

--- a/tests/unit/test_reference_mcp_server.py
+++ b/tests/unit/test_reference_mcp_server.py
@@ -518,5 +518,83 @@ def test_reference_snapshot_accepts_lowercase_generated_bom(
 
     root = reference_server._reference_snapshot_root("generation-1")
     assert (root / "BOM.csv").is_file()
-    assert not (root / "bom.csv").exists()
+    names = {path.name for path in root.iterdir()}
+    assert "BOM.csv" in names
+    assert "bom.csv" not in names
     assert any(item["path"] == "BOM.csv" for item in payload["files"])
+
+
+def test_reference_snapshot_normalizes_same_file_bom_alias(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import os
+
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+
+    class Gerber:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "board-F_Cu.gbr").write_text("gerber\n", encoding="utf-8")
+            return "ok"
+
+    class Drill:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            (root / "board.drl").write_text("drill\n", encoding="utf-8")
+            return "ok"
+
+    class Bom:
+        def export(self, format: str = "csv") -> str:
+            root = reference_server._reference_snapshot_root("generation-1")
+            lowercase = root / "bom.csv"
+            lowercase.write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+            os.link(lowercase, root / "BOM.csv")
+            return "ok"
+
+    monkeypatch.setattr(
+        reference_server,
+        "_snapshot_export_services",
+        lambda _root: SimpleNamespace(gerber=Gerber(), drill=Drill(), bom=Bom()),
+    )
+
+    reference_server.generate_reference_manufacturing_snapshot("generation-1")
+
+    root = reference_server._reference_snapshot_root("generation-1")
+    assert (root / "BOM.csv").is_file()
+    names = {path.name for path in root.iterdir()}
+    assert "BOM.csv" in names
+    assert "bom.csv" not in names
+    assert ".reference-bom-case-normalize.tmp" not in names
+
+
+def test_reference_snapshot_rejects_distinct_bom_aliases(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "BOM.csv").write_text("canonical\n", encoding="utf-8")
+    (root / "bom.csv").write_text("different\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="ambiguous BOM artifacts"):
+        reference_server._canonicalize_snapshot_bom(root)
+
+
+def test_reference_snapshot_rejects_reserved_bom_temp_artifact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "bom.csv").write_text("bom\n", encoding="utf-8")
+    (root / ".reference-bom-case-normalize.tmp").write_text("reserved\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="reserved temporary BOM artifact"):
+        reference_server._canonicalize_snapshot_bom(root)

--- a/tests/unit/test_reference_mcp_server.py
+++ b/tests/unit/test_reference_mcp_server.py
@@ -377,3 +377,146 @@ def test_reference_gbrjob_normalization_preserves_non_timestamp_raw_bytes(
 
     assert result["comparison"] == "divergent"
     assert "normalization_rules_version" not in result
+
+
+def test_reference_snapshot_rejects_invalid_generation_and_subdir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="generation is invalid"):
+        reference_server._reference_snapshot_root("generation-3")  # type: ignore[arg-type]
+
+    root = tmp_path / "snapshot"
+    assert reference_server._snapshot_subdir(root, None) == root
+    assert reference_server._snapshot_subdir(root, "Gerbers") == root / "Gerbers"
+    with pytest.raises(ValueError, match="output subdirectory is invalid"):
+        reference_server._snapshot_subdir(root, "Elsewhere")
+
+
+def test_reference_snapshot_manifest_rejects_unsafe_and_stale_evidence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = reference_server._reference_snapshot_root("generation-1")
+    root.mkdir(parents=True)
+    with pytest.raises(ValueError, match="manifest is missing"):
+        reference_server._validated_snapshot_manifest("generation-1")
+
+    manifest = root / "artifact-manifest.json"
+    manifest.write_text("not-json\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="manifest is invalid"):
+        reference_server._validated_snapshot_manifest("generation-1")
+
+    manifest.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="manifest is invalid"):
+        reference_server._validated_snapshot_manifest("generation-1")
+
+    (root / "BOM.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "pcb-reference-manufacturing-snapshot.v1",
+                "generation": "generation-1",
+                "artifact_manifest_digest": "sha256:" + "0" * 64,
+                "files": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="no longer matches snapshot bytes"):
+        reference_server._validated_snapshot_manifest("generation-1")
+
+
+def test_reference_snapshot_entries_reject_symlinked_artifact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+    root = tmp_path / "snapshot"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    (root / "linked.txt").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="must not contain symlinks"):
+        reference_server._snapshot_file_entries(root)
+    with pytest.raises(ValueError, match="must not contain symlinks"):
+        reference_server._normalized_snapshot_entries(root)
+
+
+def test_reference_gbrjob_normalization_is_fail_closed_for_malformed_metadata() -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    malformed = b'{"Header":'
+    assert reference_server._normalize_kicad_timestamp_bytes("board.gbrjob", malformed) == malformed
+
+    wrong_shape = b"[]\n"
+    assert (
+        reference_server._normalize_kicad_timestamp_bytes("board.gbrjob", wrong_shape)
+        == wrong_shape
+    )
+
+    no_header = b'{"Other": {"CreationDate": "2026-09-11T00:00:00Z"}}\n'
+    assert reference_server._normalize_kicad_timestamp_bytes("board.gbrjob", no_header) == no_header
+
+    other_vendor = (
+        b'{"Header":{"CreationDate":"2026-09-11T00:00:00Z",'
+        b'"GenerationSoftware":{"Vendor":"OtherEDA"}}}\n'
+    )
+    assert (
+        reference_server._normalize_kicad_timestamp_bytes("board.gbrjob", other_vendor)
+        == other_vendor
+    )
+
+    duplicate = (
+        b'{"Header":{"CreationDate":"2026-09-11T00:00:00Z",'
+        b'"GenerationSoftware":{"Vendor":"KiCad"}},'
+        b'"Other":{"CreationDate":"2026-09-11T00:00:01Z"}}\n'
+    )
+    assert reference_server._normalize_kicad_timestamp_bytes("board.gbrjob", duplicate) == duplicate
+
+
+def test_reference_snapshot_accepts_lowercase_generated_bom(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import kicad_mcp.evals.reference_mcp_server as reference_server
+
+    _reset_reference_env(monkeypatch, tmp_path)
+
+    class Gerber:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "board-F_Cu.gbr").write_text("gerber\n", encoding="utf-8")
+            return "ok"
+
+    class Drill:
+        def export(self, output_subdir: str = "Gerbers") -> str:
+            root = reference_server._reference_snapshot_root("generation-1") / output_subdir
+            (root / "board.drl").write_text("drill\n", encoding="utf-8")
+            return "ok"
+
+    class Bom:
+        def export(self, format: str = "csv") -> str:
+            root = reference_server._reference_snapshot_root("generation-1")
+            (root / "bom.csv").write_text("reference,value\nU1,MCU\n", encoding="utf-8")
+            return "ok"
+
+    monkeypatch.setattr(
+        reference_server,
+        "_snapshot_export_services",
+        lambda _root: SimpleNamespace(gerber=Gerber(), drill=Drill(), bom=Bom()),
+    )
+
+    payload = json.loads(reference_server.generate_reference_manufacturing_snapshot("generation-1"))
+
+    root = reference_server._reference_snapshot_root("generation-1")
+    assert (root / "BOM.csv").is_file()
+    assert not (root / "bom.csv").exists()
+    assert any(item["path"] == "BOM.csv" for item in payload["files"])

--- a/tests/unit/test_reference_mcp_server.py
+++ b/tests/unit/test_reference_mcp_server.py
@@ -551,7 +551,10 @@ def test_reference_snapshot_normalizes_same_file_bom_alias(
             root = reference_server._reference_snapshot_root("generation-1")
             lowercase = root / "bom.csv"
             lowercase.write_text("reference,value\nU1,MCU\n", encoding="utf-8")
-            os.link(lowercase, root / "BOM.csv")
+            try:
+                os.link(lowercase, root / "BOM.csv")
+            except FileExistsError:
+                pytest.skip("case-insensitive filesystem cannot create a second BOM alias")
             return "ok"
 
     monkeypatch.setattr(
@@ -580,6 +583,9 @@ def test_reference_snapshot_rejects_distinct_bom_aliases(
     root.mkdir(parents=True, exist_ok=True)
     (root / "BOM.csv").write_text("canonical\n", encoding="utf-8")
     (root / "bom.csv").write_text("different\n", encoding="utf-8")
+    aliases = [path for path in root.iterdir() if path.name.casefold() == "bom.csv"]
+    if len(aliases) < 2:
+        pytest.skip("case-insensitive filesystem cannot represent distinct BOM aliases")
 
     with pytest.raises(ValueError, match="ambiguous BOM artifacts"):
         reference_server._canonicalize_snapshot_bom(root)
@@ -625,6 +631,9 @@ def test_reference_snapshot_rejects_multiple_noncanonical_bom_spellings(
     root.mkdir(parents=True, exist_ok=True)
     (root / "bom.csv").write_text("one\n", encoding="utf-8")
     (root / "BoM.csv").write_text("two\n", encoding="utf-8")
+    aliases = [path for path in root.iterdir() if path.name.casefold() == "bom.csv"]
+    if len(aliases) < 2:
+        pytest.skip("case-insensitive filesystem cannot represent multiple BOM spellings")
 
     with pytest.raises(ValueError, match="ambiguous BOM artifacts"):
         reference_server._canonicalize_snapshot_bom(root)


### PR DESCRIPTION
## Summary
- isolate reference-board manufacturing evidence behind an exact benchmark-only discovery/execution surface
- generate two fresh BOM/Gerber/drill snapshots and compare raw plus narrowly normalized KiCad timestamp manifests
- fail closed on export failures, empty/symlinked/stale evidence, hidden tool execution, and non-timestamp manufacturing differences
- keep production export_manufacturing_package human gate unchanged

## Verification
- reference/corpus/task/server focused regression suite: green
- Ruff + format + mypy + diff check: green
- real KiCad 10.0.6 smoke: normalized_equivalent with equal normalized manifests and unequal raw manifests
- independent Codex review: no actionable correctness defects

Progresses #730