### PR TITLE
evidence(evals): record STM32 provider failure

### DIFF
--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/attempt-manifest.json
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/attempt-manifest.json
@@ -9,6 +9,11 @@
       "attempt_id": "attempt-002",
       "directory": "attempts/attempt-002",
       "evidence_digest": "sha256:b737356ba06d17396acfb5c46341aa51d4803ac7b017f65b651acdceb916905e"
+    },
+    {
+      "attempt_id": "attempt-003",
+      "directory": "attempts/attempt-003",
+      "evidence_digest": "sha256:550897792dec23352775d078e2c86024afeb1751d47e0571b6c7c56585cc9e3e"
     }
   ],
   "benchmark_id": "stm32f072-usbc-reference-board",

--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/attempts/attempt-003/agent-log.jsonl
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/attempts/attempt-003/agent-log.jsonl
@@ -1,0 +1,2 @@
+{"schema_version":"pcb-reference-agent-log.v1","attempt_id":"attempt-003","sequence":1,"timestamp":"2026-09-11T10:51:30.639168Z","event_type":"workflow","name":"claude_session","status":"started","details":{}}
+{"schema_version":"pcb-reference-agent-log.v1","attempt_id":"attempt-003","sequence":2,"timestamp":"2026-09-11T10:51:34.048375Z","event_type":"workflow","name":"claude_session","status":"failed","details":{"exit_code":1}}

--- a/docs/evidence/reference-boards/stm32f072-usbc/v1/attempts/attempt-003/attempt.json
+++ b/docs/evidence/reference-boards/stm32f072-usbc/v1/attempts/attempt-003/attempt.json
@@ -1,0 +1,59 @@
+{
+  "agent": "claude-code-2.1.251",
+  "attempt_id": "attempt-003",
+  "benchmark_id": "stm32f072-usbc-reference-board",
+  "benchmark_version": "v1",
+  "classification": "provider_failure",
+  "failure_category": "provider",
+  "failure_reason_code": "provider_api_error",
+  "kicad_version": "10.0.6",
+  "manual_repair": false,
+  "manufacturing": {
+    "comparison": "not_run",
+    "generation_completed": false,
+    "regeneration_completed": false,
+    "required": true
+  },
+  "mcp_profile": "schematic_authoring",
+  "model": "claude-sonnet-5",
+  "mutations": [],
+  "operating_mode": "write",
+  "provider": "unknown",
+  "retry_count": 0,
+  "schema_version": "pcb-task-outcome.v1",
+  "source_revision": "0862cf532711d2eee00f7097daa40aa4d3d3dc97",
+  "stages": [
+    {
+      "outcome": "failed",
+      "stage": "requirements"
+    }
+  ],
+  "start_state": "clean",
+  "starting_state_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "task_class": "reference-board",
+  "task_contract_version": "v1",
+  "task_id": "clean-start-autonomous-build",
+  "timing": {
+    "ended_at": "2026-09-11T10:51:34.048375Z",
+    "started_at": "2026-09-11T10:51:30.639168Z"
+  },
+  "toolchain_contract": "dev-toolchain-v1:sha256:65d3c1702df9017631d9fb7787004de270964e332412e41fa3a73abd4238933c",
+  "validations": [
+    {
+      "disposition": "blocking",
+      "execution_attempted": false,
+      "execution_completed": false,
+      "kind": "erc",
+      "required": true,
+      "result_consumed": false
+    },
+    {
+      "disposition": "blocking",
+      "execution_attempted": false,
+      "execution_completed": false,
+      "kind": "drc",
+      "required": true,
+      "result_consumed": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- record STM32 reference-board attempt-003 as a provider/API failure
- preserve the sanitized agent session log and immutable attempt metadata
- update the canonical attempt manifest/evidence digest

## Verification
- MCP init reached `connected`, but the provider failed on the first model turn before any task tool execution
- independent Claude CLI health checks failed for both the pinned Sonnet model and CLI default model, confirming provider/API scope rather than MCP/runtime scope
- `python3 scripts/validate_reference_board_bundle.py --bundle docs/evidence/reference-boards/stm32f072-usbc/v1` => valid: 3 attempts, 0 success, 2 failed, 1 infrastructure-invalid
- `git diff --check`

Refs #730
